### PR TITLE
[FEATURE] BooleanNode accepts non-Nodes in constructor

### DIFF
--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -84,17 +84,19 @@ class BooleanNode extends AbstractNode {
 	protected $stack = array();
 
 	/**
-	 * @param NodeInterface $root
+	 * @param mixed $root NodeInterface, array (of nodes or expression parts) or a simple type that can be evaluated to boolean
 	 */
-	function __construct(NodeInterface $root) {
+	function __construct($input) {
 		// First, evaluate everything that is not an ObjectAccessorNode, ArrayNode
 		// or ViewHelperNode so we get all text, numbers, comparators and
 		// groupers from the text parts of the expression. All other nodes
 		// we leave intact for later processing
-		if ($root instanceof RootNode) {
-			$this->stack = $root->getChildNodes();
+		if ($input instanceof RootNode) {
+			$this->stack = $input->getChildNodes();
+		} elseif (is_array($input)) {
+			$this->stack = $input;
 		} else {
-			$this->stack = array($root);
+			$this->stack = array($input);
 		}
 	}
 

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -21,7 +21,7 @@ use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 /**
- * Testcase for ViewHelperNode's evaluateBooleanExpression()
+ * Testcase for BooleanNode
  */
 class BooleanNodeTest extends UnitTestCase {
 
@@ -614,5 +614,35 @@ class BooleanNodeTest extends UnitTestCase {
 		$this->assertFalse(BooleanNode::convertToBoolean(NULL));
 
 		$this->assertTrue(BooleanNode::convertToBoolean(new \stdClass()));
+	}
+
+	/**
+	 * @param mixed $input
+	 * @param boolean $expected
+	 * @test
+	 * @dataProvider getStandardInputTypes
+	 */
+	public function acceptsStandardTypesAsInput($input, $expected) {
+		$context = new RenderingContext();
+		$node = new BooleanNode($input);
+		$this->assertEquals($expected, $node->evaluate($context));
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getStandardInputTypes() {
+		return array(
+			array(0, FALSE),
+			array(1, TRUE),
+			array(FALSE, FALSE),
+			array(TRUE, TRUE),
+			array(NULL, FALSE),
+			array('', FALSE),
+			array('0', FALSE),
+			array('1', TRUE),
+			array(array(1), TRUE),
+			array(array(0), FALSE),
+		);
 	}
 }


### PR DESCRIPTION
Relaxing the required input type for the constructor of
BooleanNode allows simple values to be passed, avoiding
the need for additional wrapping of plain types in Nodes
before being able to evaluate them as booleans.