### PR TITLE
[BUGFIX] Remove ``render()`` method from ``AbstractConditionViewHelper``

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -63,21 +63,6 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
-	 *
-	 * @param boolean $condition View helper condition
-	 * @return string the rendered string
-	 * @api
-	 */
-	public function render() {
-		if (static::evaluateCondition($this->arguments)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
-	}
-
-	/**
 	 * @param array $arguments
 	 * @param \Closure $renderChildrenClosure
 	 * @param RenderingContextInterface $renderingContext

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -66,7 +66,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function argumentsCanBeRegistered() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$name = 'This is a name';
 		$description = 'Example desc';
@@ -83,7 +83,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
 	 */
 	public function registeringTheSameArgumentNameAgainThrowsException() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$name = 'shortName';
 		$description = 'Example desc';
@@ -98,7 +98,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function overrideArgumentOverwritesExistingArgumentDefinition() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$name = 'argumentName';
 		$description = 'argument description';
@@ -118,7 +118,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
 	 */
 	public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$viewHelper->_call('overrideArgument', 'argumentName', 'string', 'description', TRUE);
 	}
@@ -127,7 +127,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function prepareArgumentsCallsInitializeArguments() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'initializeArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('initializeArguments'), array(), '', FALSE);
 
 		$viewHelper->expects($this->once())->method('initializeArguments');
 
@@ -138,7 +138,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function validateArgumentsCallsPrepareArguments() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array()));
 
@@ -149,7 +149,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function validateArgumentsAcceptsAllObjectsImplemtingArrayAccessAsAnArray() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setArguments(array('test' => new \ArrayObject));
 		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array('test' => new ArgumentDefinition('test', 'array', FALSE, 'documentation'))));
@@ -160,7 +160,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function validateArgumentsCallsTheRightValidators() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setArguments(array('test' => 'Value of argument'));
 
@@ -176,7 +176,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setArguments(array('test' => 'test'));
 
@@ -212,7 +212,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 		$renderingContext->setVariableProvider($templateVariableContainer);
 		$renderingContext->injectViewHelperVariableContainer($viewHelperVariableContainer);
 
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setRenderingContext($renderingContext);
 
@@ -224,7 +224,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function testRenderChildrenCallsRenderChildrenClosureIfSet() {
-		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('dummy'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 		$viewHelper->setRenderChildrenClosure(function() { return 'foobar'; });
 		$result = $viewHelper->renderChildren();
 		$this->assertEquals('foobar', $result);


### PR DESCRIPTION
This removes the render() method from the AbstractViewHelper
class in order to prevent PHP errors when a subclass overrides the
method with a different signature (i.e. including parameters).

Note:
This was lost when re-applying https://github.com/NamelessCoder/TYPO3.Fluid/pull/18
to this repository.
This change also adds the ``AbstractViewHelperTest`` changes that got
lost.