### PR TITLE
[FEATURE] Support Legacy Namespaces and throw Exception on unknown namespace use

### DIFF
--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -20,6 +20,11 @@ abstract class Patterns {
 	static public $SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG = '/xmlns:([a-z0-9\.]+)=("[^"]+"|\'[^\']+\')*/xi';
 
 	/**
+	 * @var string
+	 */
+	static public $NAMESPACE_DECLARATION = '/(?<!\\\\){namespace\s*(?P<identifier>[a-zA-Z\*]+[a-zA-Z0-9\.\*]*)\s*(=\s*(?P<phpNamespace>(?:[A-Za-z0-9\.]+|Tx)(?:\\\\\w+)+)\s*)?}/m';
+
+	/**
 	 * This regular expression splits the input string at all dynamic tags, AND
 	 * on all <![CDATA[...]]> sections.
 	 */

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -12,6 +12,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\UnknownNamespaceDetectionTemplateProcessor;
+use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
@@ -125,6 +127,7 @@ class TemplateParser {
 		}
 
 		$this->reset();
+		$this->registerNamespacesFromTemplateSource($templateString);
 		$templateString = $this->preProcessTemplateSource($templateString);
 
 		$splitTemplate = $this->splitTemplateAtDynamicTags($templateString);
@@ -138,7 +141,6 @@ class TemplateParser {
 	 * do what they need to do with the template source before it is parsed.
 	 *
 	 * @param string $templateSource
-	 * @param string $method
 	 * @return string
 	 */
 	protected function preProcessTemplateSource($templateSource) {
@@ -148,6 +150,43 @@ class TemplateParser {
 			$templateSource = $templateProcessor->preProcessSource($templateSource);
 		}
 		return $templateSource;
+	}
+
+	/**
+	 * Pre-process the template source before it is returned to the
+	 * TemplateParser or passed to the next TemplateProcessorInterface instance.
+	 *
+	 * @param string $templateSource
+	 * @return string
+	 */
+	protected function registerNamespacesFromTemplateSource($templateSource) {
+		preg_match_all(Patterns::$NAMESPACE_DECLARATION, $templateSource, $namespaces);
+		foreach ($namespaces['identifier'] as $key => $identifier) {
+			$namespace = $namespaces['phpNamespace'][$key];
+			if (strlen($namespace) === 0) {
+				$namespace = NULL;
+			}
+			$this->viewHelperResolver->registerNamespace($identifier, $namespace);
+		}
+
+		preg_match_all(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, $templateSource, $splitParts);
+		if (isset($splitParts[0])) {
+			foreach ($splitParts[0] as $viewHelper) {
+				preg_match_all(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, $viewHelper, $matches);
+				foreach ($matches['NamespaceIdentifier'] as $key => $namespace) {
+					if (!$this->viewHelperResolver->isNamespaceValidOrIgnored($namespace)) {
+						throw new UnknownNamespaceException('Unkown Namespace: ' . htmlspecialchars($matches[0][$key]));
+					}
+				}
+			}
+		}
+
+		preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER, $templateSource, $shorthandViewHelpers);
+		foreach ($shorthandViewHelpers['NamespaceIdentifier'] as $key => $namespace) {
+			if (!$this->viewHelperResolver->isNamespaceValidOrIgnored($namespace)) {
+				throw new UnknownNamespaceException('Unkown Namespace: ' . $shorthandViewHelpers[0][$key]);
+			}
+		}
 	}
 
 	/**

--- a/src/Core/Parser/UnknownNamespaceException.php
+++ b/src/Core/Parser/UnknownNamespaceException.php
@@ -1,0 +1,16 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * A generic Fluid Core exception.
+ *
+ * @api
+ */
+class UnknownNamespaceException extends \TYPO3Fluid\Fluid\Core\Parser\Exception {
+
+}

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -118,7 +118,40 @@ class ViewHelperResolver {
 	 * @return boolean TRUE if the given namespace is valid, otherwise FALSE
 	 */
 	public function isNamespaceValid($namespaceIdentifier, $methodIdentifier) {
-		return array_key_exists($namespaceIdentifier, $this->namespaces);
+		if (!array_key_exists($namespaceIdentifier, $this->namespaces)) {
+			return FALSE;
+		}
+
+		return $this->namespaces[$namespaceIdentifier] !== NULL;
+	}
+
+	/**
+	 * Validates the given namespaceIdentifier and returns FALSE
+	 * if the namespace is unknown and not ignored
+	 *
+	 * @param string $namespaceIdentifier
+	 * @return boolean TRUE if the given namespace is valid, otherwise FALSE
+	 */
+	public function isNamespaceValidOrIgnored($namespaceIdentifier) {
+		if ($this->isNamespaceValid($namespaceIdentifier, '') === TRUE) {
+			return TRUE;
+		}
+
+		if (array_key_exists($namespaceIdentifier, $this->namespaces)) {
+			return TRUE;
+		}
+
+		foreach (array_keys($this->namespaces) as $namespace) {
+			if (stristr($namespace, '*') === FALSE) {
+				continue;
+			}
+			$pattern = '/' . str_replace(array('.', '*'), array('\\.', '[a-zA-Z0-9\.]*'), $namespace) . '/';
+			if (preg_match($pattern, $namespaceIdentifier) === 1) {
+				return TRUE;
+			}
+		}
+
+		return FALSE;
 	}
 
 	/**

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -25,8 +25,10 @@ class ExamplesTest extends BaseTestCase {
 	 * @dataProvider getExampleScriptTestValues
 	 * @param string $script
 	 * @param array $expectedOutputs
+	 * @param string $expectedException
 	 */
-	public function testExampleScriptFileWithoutCache($script, array $expectedOutputs) {
+	public function testExampleScriptFileWithoutCache($script, array $expectedOutputs, $expectedException = NULL) {
+		$this->setExpectedException($expectedException);
 		$this->runExampleScriptTest($script, $expectedOutputs, FALSE);
 	}
 
@@ -34,8 +36,10 @@ class ExamplesTest extends BaseTestCase {
 	 * @dataProvider getExampleScriptTestValues
 	 * @param string $script
 	 * @param array $expectedOutputs
+	 * @param string $expectedException
 	 */
-	public function testExampleScriptFileWithCache($script, array $expectedOutputs) {
+	public function testExampleScriptFileWithCache($script, array $expectedOutputs, $expectedException = NULL) {
+		$this->setExpectedException($expectedException);
 		$cache = vfsStream::url('fakecache/');
 		$this->runExampleScriptTest($script, $expectedOutputs, $cache);
 		//$this->runExampleScriptTest($script, $expectedOutputs, $cache);
@@ -141,7 +145,8 @@ class ExamplesTest extends BaseTestCase {
 				array(
 					'Namespaces template',
 					'<invalid:vh>This tag will be shown</invalid:vh>'
-				)
+				),
+				'\TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException'
 			),
 			'example_namespaceresolving.php' => array(
 				'example_namespaceresolving.php',
@@ -149,7 +154,8 @@ class ExamplesTest extends BaseTestCase {
 					'NamespaceResolving template from Singles.',
 					'Argument passed to CustomViewHelper:',
 					'\'123\''
-				)
+				),
+				'\TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException'
 			),
 			'example_single.php' => array(
 				'example_single.php',

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -584,4 +584,38 @@ class TemplateParserTest extends UnitTestCase {
 
 		$templateParser->_call('textHandler', $mockState, 'string');
 	}
+
+	/**
+	 * @test
+	 */
+	public function testTemplateWithRegisteredNamespace() {
+		$resolver = new ViewHelperResolver();
+		$this->templateParser = new TemplateParser($resolver);
+		$this->templateParser->parse('<f:format.raw></f:format.raw>');
+		$this->templateParser->parse('{foo -> f:format.raw()}');
+		$this->templateParser->parse('{f:format.raw(value: foo)}');
+	}
+
+	/**
+	 * @test
+	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException
+	 */
+	public function testTemplateWithUnkownNamespace() {
+		$resolver = new ViewHelperResolver();
+		$this->templateParser = new TemplateParser($resolver);
+		$this->templateParser->parse('<foo:bar></foo:bar>');
+		$this->templateParser->parse('{foo -> foo:bar()}');
+		$this->templateParser->parse('{foo:bar(value: foo)}');
+	}
+
+	/**
+	 * @test
+	 */
+	public function testTemplateWithIgnoredNamespaces() {
+		$resolver = new ViewHelperResolver();
+		$this->templateParser = new TemplateParser($resolver);
+		$this->templateParser->parse('{namespace *} <foo:bar></foo:bar>');
+		$this->templateParser->parse('{namespace foo} {foo -> foo:bar()}');
+		$this->templateParser->parse('{namespace fo*} {foo:bar(value: foo)}');
+	}
 }


### PR DESCRIPTION
This commit adds back the "old" namespace syntax:

{namespace foo=Foo\Bar\ViewHelpers}

and it checks if you're using any viewHelpers in namespaces you didn't
register to reduce common problems where you move stuff in templates,
spelling errors and similar which result in not-rendered viewHelpers
or even exceptions because as a side effect arguments are cast to
string, but fail.

Additionally you can use the namespace syntax to ignore namespaces: 

{namespace \*}
{namespace xs*}  <!-- ignores namespaces starting with "xs" -->
{namespace foo}  <!-- ignores the namespace "foo" -->

fixes  #8