### PR TITLE
[FEATURE] Support Legacy Namespaces and throw Exception on unknown namespace use

### DIFF
--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -20,6 +20,11 @@ abstract class Patterns {
 	static public $SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG = '/xmlns:([a-z0-9\.]+)=("[^"]+"|\'[^\']+\')*/xi';
 
 	/**
+	 * @var string
+	 */
+	static public $NAMESPACE_DECLARATION = '/(?<!\\\\){namespace\s*(?P<identifier>[a-zA-Z\*]+[a-zA-Z0-9\.\*]*)\s*(=\s*(?P<phpNamespace>(?:[A-Za-z0-9\.]+|Tx)(?:\\\\\w+)+)\s*)?}/m';
+
+	/**
 	 * This regular expression splits the input string at all dynamic tags, AND
 	 * on all <![CDATA[...]]> sections.
 	 */

--- a/src/Core/Parser/UnknownNamespaceException.php
+++ b/src/Core/Parser/UnknownNamespaceException.php
@@ -1,0 +1,16 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * A generic Fluid Core exception.
+ *
+ * @api
+ */
+class UnknownNamespaceException extends \TYPO3Fluid\Fluid\Core\Parser\Exception {
+
+}

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -118,7 +118,40 @@ class ViewHelperResolver {
 	 * @return boolean TRUE if the given namespace is valid, otherwise FALSE
 	 */
 	public function isNamespaceValid($namespaceIdentifier, $methodIdentifier) {
-		return array_key_exists($namespaceIdentifier, $this->namespaces);
+		if (!array_key_exists($namespaceIdentifier, $this->namespaces)) {
+			return FALSE;
+		}
+
+		return $this->namespaces[$namespaceIdentifier] !== NULL;
+	}
+
+	/**
+	 * Validates the given namespaceIdentifier and returns FALSE
+	 * if the namespace is unknown and not ignored
+	 *
+	 * @param string $namespaceIdentifier
+	 * @return boolean TRUE if the given namespace is valid, otherwise FALSE
+	 */
+	public function isNamespaceValidOrIgnored($namespaceIdentifier) {
+		if ($this->isNamespaceValid($namespaceIdentifier, '') === TRUE) {
+			return TRUE;
+		}
+
+		if (array_key_exists($namespaceIdentifier, $this->namespaces)) {
+			return TRUE;
+		}
+
+		foreach (array_keys($this->namespaces) as $namespace) {
+			if (stristr($namespace, '*') === FALSE) {
+				continue;
+			}
+			$pattern = '/' . str_replace(array('.', '*'), array('\\.', '[a-zA-Z0-9\.]*'), $namespace) . '/';
+			if (preg_match($pattern, $namespaceIdentifier) === 1) {
+				return TRUE;
+			}
+		}
+
+		return FALSE;
 	}
 
 	/**

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -25,8 +25,12 @@ class ExamplesTest extends BaseTestCase {
 	 * @dataProvider getExampleScriptTestValues
 	 * @param string $script
 	 * @param array $expectedOutputs
+	 * @param string $expectedException
 	 */
-	public function testExampleScriptFileWithoutCache($script, array $expectedOutputs) {
+	public function testExampleScriptFileWithoutCache($script, array $expectedOutputs, $expectedException = NULL) {
+		if ($expectedException !== NULL) {
+			$this->setExpectedException($expectedException);
+		}
 		$this->runExampleScriptTest($script, $expectedOutputs, FALSE);
 	}
 
@@ -34,11 +38,14 @@ class ExamplesTest extends BaseTestCase {
 	 * @dataProvider getExampleScriptTestValues
 	 * @param string $script
 	 * @param array $expectedOutputs
+	 * @param string $expectedException
 	 */
-	public function testExampleScriptFileWithCache($script, array $expectedOutputs) {
+	public function testExampleScriptFileWithCache($script, array $expectedOutputs, $expectedException = NULL) {
+		if ($expectedException !== NULL) {
+			$this->setExpectedException($expectedException);
+		}
 		$cache = vfsStream::url('fakecache/');
 		$this->runExampleScriptTest($script, $expectedOutputs, $cache);
-		//$this->runExampleScriptTest($script, $expectedOutputs, $cache);
 	}
 
 	/**
@@ -141,7 +148,8 @@ class ExamplesTest extends BaseTestCase {
 				array(
 					'Namespaces template',
 					'<invalid:vh>This tag will be shown</invalid:vh>'
-				)
+				),
+				'\TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException'
 			),
 			'example_namespaceresolving.php' => array(
 				'example_namespaceresolving.php',
@@ -149,7 +157,8 @@ class ExamplesTest extends BaseTestCase {
 					'NamespaceResolving template from Singles.',
 					'Argument passed to CustomViewHelper:',
 					'\'123\''
-				)
+				),
+				'\TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException'
 			),
 			'example_single.php' => array(
 				'example_single.php',

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -584,4 +584,70 @@ class TemplateParserTest extends UnitTestCase {
 
 		$templateParser->_call('textHandler', $mockState, 'string');
 	}
+
+	/**
+	 * @dataProvider getExampleScriptTestValues
+	 * @param string $templateCode
+	 * @param array $expectsIgnored
+	 * @param string $expectedException
+	 */
+	public function testNamespaceParsing($templateCode, $expectsIgnored = array(), $expectedException = NULL) {
+
+		$resolver = new ViewHelperResolver();
+		$this->templateParser = new TemplateParser($resolver);
+
+		if ($expectedException !== NULL) {
+			$this->setExpectedException($expectedException);
+		}
+		$this->templateParser->parse($templateCode);
+		foreach ($expectsIgnored as $namespace) {
+			$this->assertTrue($resolver->isNamespaceValidOrIgnored($namespace));
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getExampleScriptTestValues() {
+		return array(
+			array(
+				'<f:format.raw></f:format.raw>'
+			),
+			array(
+				'{foo -> f:format.raw()}'
+			),
+			array(
+				'{f:format.raw(value: foo)}'
+			),
+
+			array(
+				'<foo:bar></foo:bar>',
+				array(),
+				'\TYPO3Fluid\Fluid\Core\Parser\Exception'
+			),
+			array(
+				'{foo -> foo:bar()}',
+				array(),
+				'\TYPO3Fluid\Fluid\Core\Parser\Exception'
+			),
+			array(
+				'{foo:bar(value: foo)}',
+				array(),
+				'\TYPO3Fluid\Fluid\Core\Parser\Exception'
+			),
+
+			array(
+				'{namespace *} <foo:bar></foo:bar>',
+				array('foo')
+			),
+			array(
+				'{namespace foo} {foo -> foo:bar()}',
+				array('foo')
+			),
+			array(
+				'{namespace fo*} {foo:bar(value: foo)}',
+				array('foo')
+			),
+		);
+	}
 }


### PR DESCRIPTION
This commit adds back the "old" namespace syntax:

{namespace foo=Foo\Bar\ViewHelpers}

and it checks if you're using any viewHelpers in namespaces you didn't
register to reduce common problems where you move stuff in templates,
spelling errors and similar which result in not-rendered viewHelpers
or even exceptions because as a side effect arguments are cast to
string, but fail.

fixes  #8