### PR TITLE
[TASK] Throw same Exception type as caught in Parser

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -288,7 +288,8 @@ abstract class AbstractTemplateView extends AbstractView {
 				$parsedTemplate = $this->templateParser->parse($templateSourceClosure($this, $this->templatePaths));
 			} catch (\RuntimeException $error) {
 				list ($line, $character, $templateCode) = $this->templateParser->getCurrentParsingPointers();
-				throw new Exception(
+				$exceptionClass = get_class($error);
+				throw new $exceptionClass(
 					sprintf(
 						'Fluid parse error in template %s, line %d at character %d. Error: %s (%d). Template code: %s',
 						$templateIdentifier,
@@ -297,7 +298,8 @@ abstract class AbstractTemplateView extends AbstractView {
 						$error->getMessage(),
 						$error->getCode(),
 						$templateCode
-					)
+					),
+					$error->getCode()
 				);
 			}
 			if ($parsedTemplate->isCompilable()) {


### PR DESCRIPTION
Exceptions converted by the Parser into pretty errors with template line, char and snippet are now thrown as the same type of Exception that was originally caught. This allows external users to check by class which type of Exception was thrown without having to read/parse the error message.