### PR TITLE
[FEATURE] Passing of tag content from f:render to partial/section

### DIFF
--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -83,6 +83,7 @@ class RenderViewHelper extends AbstractViewHelper {
 		$this->registerArgument('arguments', 'array', 'Array of variables to be transferred. Use {_all} for all variables', FALSE, array());
 		$this->registerArgument('optional', 'boolean', 'If TRUE, considers the *section* optional. Partial never is.', FALSE, FALSE);
 		$this->registerArgument('default', 'mixed', 'Value (usually string) to be displayed if the section or partial does not exist', FALSE, NULL);
+		$this->registerArgument('contentAs', 'string', 'If used, renders the child content and adds it as a template variable with this name for use in the partial/section', FALSE, NULL);
 	}
 
 	/**
@@ -96,6 +97,13 @@ class RenderViewHelper extends AbstractViewHelper {
 		$partial = $this->arguments['partial'];
 		$arguments = (array) $this->arguments['arguments'];
 		$optional = (boolean) $this->arguments['optional'];
+		$contentAs = $this->arguments['contentAs'];
+		$tagContent = $this->renderChildren();
+
+		if ($contentAs !== NULL) {
+			$arguments[$contentAs] = $tagContent;
+		}
+
 		$content = '';
 		if ($partial !== NULL) {
 			$content = $this->viewHelperVariableContainer->getView()->renderPartial($partial, $section, $arguments, $optional);
@@ -105,11 +113,8 @@ class RenderViewHelper extends AbstractViewHelper {
 		// Replace empty content with default value. If default is
 		// not set, NULL is returned and cast to a new, empty string
 		// outside of this ViewHelper.
-		if ('' === $content) {
-			$content = $this->arguments['default'];
-			if (NULL === $content) {
-				$content = $this->renderChildren();
-			}
+		if ($content === '') {
+			$content = isset($this->arguments['default']) ? $this->arguments['default'] : $tagContent;
 		}
 		return $content;
 	}


### PR DESCRIPTION
Allows a completely new approach to structuring Fluid template rendering, allowing partials and sections to be used as "wrappers" for an arbitrary piece of template code. Consider the following example:

```xml
<f:section name="MyWrap">
    <div>
        <!-- And LOTS more HTML, using variables if desired -->
        <!-- Tag content of f:render output: -->
        {contentVariable -> f:format.raw()}
    </div>
</f:section>

<f:render section="MyWrap" contentAs="contentVariable">
    This content will be wrapped. Any Fluid code can go here.
</f:render>
```

The result is that the tag content of `f:render` is assigned as the template variable `{contentVariable}` which can then be used in the template code that is in the section/partial. It's the same as passing a big chunk of Fluid to the `arguments` array as a variable there, and using it the same way - but it is a lot easier on the syntax.

The new structure approach is enabled because `f:render` can then be used recursively to wrap your template code in any number of wraps (imagine the `f:section` tags with content similar to above):

```xml
<f:render partial="OuterWrap" contentAs="contentVariable">
    <f:render partial="InnerWrap" contentAs="contentVariable">
        <f:render partial="ItemWrap" contentAs="contentVariable">
            <h2>My item, nicely wrapped</h2>
            <p>Nice.</p>
        </f:render>
   </f:render>
</f:render>
```

Which would render as follows:

1. Outermost wrap renders tag content and assigns as variable for second level
2. Second level wrap renders tag content and assigns as variable for innermost level
3. Innermost level renders the actual content you wish to wrap and assigns it as variable
4. The innermost "wrap" partial/section is rendered (because no more `f:render` children exist)
5. The second level "wrap" partial/section is rendered with the HTML from step 4 as content variable.
6. The outer level "wrap" partial/section is rendered with the HTML from step 5 as content variable.
7. The entire thing is output.