### PR TITLE
[BUGFIX] Match PHP behavior in deciding comparability of variables

### DIFF
--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -253,7 +253,12 @@ class BooleanNode extends AbstractNode {
 	 * @return string
 	 */
 	public static function trimQuotedString($string) {
-		return trim($string, self::TRIM_CHARACTERS);
+		$string = trim($string, self::TRIM_CHARACTERS);
+		if (is_numeric($string)) {
+			// Rather than casting to integer or float we use PHP's type conversion via incrementing
+			$string += 0;
+		}
+		return $string;
 	}
 
 	/**
@@ -351,12 +356,8 @@ class BooleanNode extends AbstractNode {
 	 * @return boolean TRUE if the operands can be compared using arithmetic operators, FALSE otherwise.
 	 */
 	static protected function isComparable($a, $b) {
-		$stringA = is_string($a);
-		$stringB = is_string($b);
 		return (
-			(is_null($a) || $stringA) && $stringB)
-			|| (($stringA || is_resource($a) || is_numeric($a)) && ($stringB || is_resource($b) || is_numeric($b)))
-			|| (is_bool($a) || is_null($a))
+			(is_null($a) || is_scalar($a) || is_resource($a)) && (is_null($b) || is_scalar($b) || is_resource($b)))
 			|| (is_object($a) && is_object($b))
 			|| (is_array($a) && is_array($b)
 		);

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -8,6 +8,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
@@ -512,6 +513,9 @@ class TemplateParser {
 	 */
 	protected function buildArgumentObjectTree($argumentString) {
 		if (strpos($argumentString, '{') === FALSE && strpos($argumentString, '<') === FALSE) {
+			if (is_numeric($argumentString)) {
+				return new NumericNode($argumentString);
+			}
 			return new TextNode($argumentString);
 		}
 		$splitArgument = $this->splitTemplateAtDynamicTags($argumentString);

--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -37,6 +37,24 @@ class BasicConditionsTest extends BaseFunctionalTestCase {
 				array('yes'),
 				array('no')
 			),
+			'\'foo\' == 0' => array(
+				'<f:if condition="\'foo\' == 0" then="yes" else="no" />',
+				array(),
+				array('yes'),
+				array('no')
+			),
+			'1.1 >= \'foo\'' => array(
+				'<f:if condition="1.1 >= \'foo\'" then="yes" else="no" />',
+				array(),
+				array('yes'),
+				array('no')
+			),
+			'\'foo\' > 0' => array(
+				'<f:if condition="\'foo\' > 0" then="yes" else="no" />',
+				array(),
+				array('no'),
+				array('yes')
+			),
 		);
 	}
 

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -43,11 +43,23 @@ class VariableConditionsTest extends BaseFunctionalTestCase {
 				array('yes'),
 				array('no')
 			),
-			'"{test1} === {test2}" (test1=1, test2="1")' => array(
+			'"{test1} === {test2}" (test1=abc, test2=abc)' => array(
 				'<f:if condition="{test1} === {test2}" then="yes" else="no" />',
-				array('test1' => 1, 'test2' => '1'),
+				array('test1' => 'abc', 'test2' => 'abc'),
+				array('yes'),
+				array('no')
+			),
+			'"{test1} === {test2}" (test1=1, test2=TRUE)' => array(
+				'<f:if condition="{test1} === {test2}" then="yes" else="no" />',
+				array('test1' => 1, 'test2' => TRUE),
 				array('no'),
 				array('yes')
+			),
+			'"{test1} == {test2}" (test1=1, test2=TRUE)' => array(
+				'<f:if condition="{test1} == {test2}" then="yes" else="no" />',
+				array('test1' => 1, 'test2' => TRUE),
+				array('yes'),
+				array('no')
 			),
 		);
 	}

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -84,10 +84,16 @@ class BooleanNodeTest extends UnitTestCase {
 			array('==', array('foobar'), array('baz'), FALSE),
 
 			array('>', 1, 0, TRUE),
-			array('>', 1, FALSE, FALSE),
+			array('>', 1, FALSE, TRUE),
 			array('>', FALSE, 0, FALSE),
 
 			array('<', 1, 0, FALSE),
+
+			// edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
+			array('==', 'foo', 0, TRUE),
+			array('>=', 1.1, 'foo', TRUE),
+			array('>', 'foo', 0, FALSE),
+
 		);
 	}
 
@@ -181,9 +187,9 @@ class BooleanNodeTest extends UnitTestCase {
 	 */
 	public function comparingUnequalIdentityReturnsFalse() {
 		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('5'));
+		$rootNode->addChildNode(new NumericNode('0'));
 		$rootNode->addChildNode(new TextNode('==='));
-		$rootNode->addChildNode(new NumericNode(5));
+		$rootNode->addChildNode(new BooleanNode(FALSE));
 
 		$booleanNode = new BooleanNode($rootNode);
 		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
@@ -492,10 +498,10 @@ class BooleanNodeTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function equalsReturnsFalseIfComparingStringWithZero() {
+	public function equalsReturnsTrueIfComparingStringWithZero() {
 		$rootNode = new RootNode();
 		$rootNode->addChildNode(new TextNode('\'stringA\' == 0'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
 	}
 
 	/**


### PR DESCRIPTION
This change:

* Uses PHP math workaround ($value + 0) to ensure numeric-ness of unqouted values.
* Changes the analysis of left/right sides to use is_scalar as basic decision; allowing scalar values to be compared readily with null and resource pointers.
* Changes test expectations that were previously off PHP standard.
* Adds new test cases for the PHP standard comparison expectations.

Close: #7