### PR TITLE
[BUGFIX] Correct expected string unquoting behavior

### DIFF
--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -96,7 +96,7 @@ class BooleanNode extends AbstractNode {
 		} elseif (is_array($input)) {
 			$this->stack = $input;
 		} else {
-			$this->stack = array($input);
+			$this->stack = array(is_string($input) ? trim($input) : $input);
 		}
 	}
 
@@ -253,7 +253,7 @@ class BooleanNode extends AbstractNode {
 	 * @return string
 	 */
 	public static function trimQuotedString($string) {
-		$string = trim($string, self::TRIM_CHARACTERS);
+		$string = preg_match('/^[\'"].*[\'"]$/', $string) ? trim($string, $string{0}) : $string;
 		if (is_numeric($string)) {
 			// Rather than casting to integer or float we use PHP's type conversion via incrementing
 			$string += 0;
@@ -379,7 +379,7 @@ class BooleanNode extends AbstractNode {
 			return (boolean) ((float) $value > 0);
 		}
 		if (is_string($value)) {
-			$value = trim($value, self::TRIM_CHARACTERS . '()');
+			$value = self::trimQuotedString($value);
 			return (strtolower($value) !== 'false' && !empty($value));
 		}
 		if (is_array($value) || (is_object($value) && $value instanceof \Countable)) {

--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -49,6 +49,18 @@ class BasicConditionsTest extends BaseFunctionalTestCase {
 				array('yes'),
 				array('no')
 			),
+			'\'String containing word "false" in text\'' => array(
+				'<f:if condition="\'String containing word \"false\" in text\'" then="yes" else="no" />',
+				array(),
+				array('yes'),
+				array('no')
+			),
+			'\'  FALSE  \'' => array(
+				'<f:if condition="\'  FALSE  \'" then="yes" else="no" />',
+				array(),
+				array('yes'),
+				array('no')
+			),
 			'\'foo\' > 0' => array(
 				'<f:if condition="\'foo\' > 0" then="yes" else="no" />',
 				array(),

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -19,6 +19,18 @@ class VariableConditionsTest extends BaseFunctionalTestCase {
 				array('yes'),
 				array('no')
 			),
+			'"{test}" (test="\'  FALSE  \'")' => array(
+				'<f:if condition="{test}" then="yes" else="no" />',
+				array('test' => '\'  FALSE  \''),
+				array('yes'),
+				array('no')
+			),
+			'"{test}" (test="\'  0  \'")' => array(
+				'<f:if condition="{test}" then="yes" else="no" />',
+				array('test' => '\'  0  \''),
+				array('yes'),
+				array('no')
+			),
 			'"{test}" (test=0)' => array(
 				'<f:if condition="{test}" then="yes" else="no" />',
 				array('test' => 0),


### PR DESCRIPTION
Correctly preserves whitespace in quoted strings.

Close: #6