### PR TITLE
[TASK] All parse-time errors are reported as ParserException

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -7,7 +7,7 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  */
 
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
 
 /**
  * Class ViewHelperResolver

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -29,7 +29,7 @@ class ViewHelperResolverTest extends UnitTestCase {
 	public function testRegisterNamespaceThrowsExceptionOnReRegistration() {
 		$resolver = new ViewHelperResolver();
 		$resolver->registerNamespace('t', 'test');
-		$this->setExpectedException('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\Exception');
+		$this->setExpectedException('TYPO3Fluid\\Fluid\\Core\\Parser\\Exception');
 		$resolver->registerNamespace('t', 'test2');
 	}
 
@@ -57,7 +57,7 @@ class ViewHelperResolverTest extends UnitTestCase {
 	public function testResolveViewHelperClassNameThrowsExceptionIfClassNotResolved() {
 		$resolver = $this->getMock('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\ViewHelperResolver', array('resolveViewHelperName'));
 		$resolver->expects($this->once())->method('resolveViewHelperName')->willReturn(FALSE);
-		$this->setExpectedException('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\Exception');
+		$this->setExpectedException('TYPO3Fluid\\Fluid\\Core\\Parser\\Exception');
 		$resolver->resolveViewHelperClassName('f', 'invalid');
 	}
 


### PR DESCRIPTION
Deviation: unresolvable ViewHelpers had been changed to throw ViewHelper Exception, not Parser Exception. Changed this and unit test expectations.

Close: #11