### PR TITLE
[TASK] Use ENT_QUOTES rather than ENT_COMPAT

### DIFF
--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -78,7 +78,7 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper {
 		if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
 			return $value;
 		}
-		$flags = $keepQuotes ? ENT_NOQUOTES : ENT_COMPAT;
+		$flags = $keepQuotes ? ENT_NOQUOTES : ENT_QUOTES;
 
 		return htmlspecialchars($value, $flags, $encoding, $doubleEncode);
 	}

--- a/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
@@ -70,15 +70,15 @@ class HtmlspecialcharsViewHelperTest extends ViewHelperBaseTestcase {
 			array(
 				'value' => 'Some special characters: &©"\'',
 				'options' => array(),
-				'expectedResult' => 'Some special characters: &amp;©&quot;\''
+				'expectedResult' => 'Some special characters: &amp;©&quot;&#039;'
 			),
 			// render respects "keepQuotes" argument
 			array(
-				'value' => 'Some special characters: &©"\'',
+				'value' => 'Some special characters: &©"',
 				'options' => array(
 					'keepQuotes' => TRUE,
 				),
-				'expectedResult' => 'Some special characters: &amp;©"\''
+				'expectedResult' => 'Some special characters: &amp;©"'
 			),
 			// render respects "encoding" argument
 			array(
@@ -86,7 +86,7 @@ class HtmlspecialcharsViewHelperTest extends ViewHelperBaseTestcase {
 				'options' => array(
 					'encoding' => 'ISO-8859-1',
 				),
-				'expectedResult' => 'Some special characters: &amp;&quot;\''
+				'expectedResult' => 'Some special characters: &amp;&quot;&#039;'
 			),
 			// render converts already converted entities by default
 			array(


### PR DESCRIPTION
Ensures escaping of single quotes. See: https://forge.typo3.org/issues/59540