### PR TITLE
[BUGFIX] Make sure PreProcessors come before internal namespace extraction

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -153,8 +153,8 @@ class TemplateParser {
 		}
 
 		$this->reset();
-		$this->registerNamespacesFromTemplateSource($templateString);
 		$templateString = $this->preProcessTemplateSource($templateString);
+		$this->registerNamespacesFromTemplateSource($templateString);
 
 		$splitTemplate = $this->splitTemplateAtDynamicTags($templateString);
 		$parsingState = $this->buildObjectTree($splitTemplate, self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);


### PR DESCRIPTION
Prevents an issue where internal namespace extraction now fails when a namespace is not registered or would be registered only by a template pre-processor. Because template pre-processors were asked *after* the internal method, their registered namespaces were never recognised. TemplateParser would instead throw an error about an unknown namespace.