### PR TITLE
[TASK] Improve TemplateParser logic

### DIFF
--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -373,6 +373,20 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 * @return void
 	 */
 	public function handleAdditionalArguments(array $arguments) {
+	}
+
+	/**
+	 * Default implementation of validating additional, undeclared arguments.
+	 * In this implementation the behavior is to consistently throw an error
+	 * about NOT supporting any additional arguments. This method MUST be
+	 * overridden by any ViewHelper that desires this support and this inherited
+	 * method must not be called, obviously.
+	 *
+	 * @throws Exception
+	 * @param array $arguments
+	 * @return void
+	 */
+	public function validateAdditionalArguments(array $arguments) {
 		if (!empty($arguments)) {
 			throw new Exception(
 				sprintf(

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -91,6 +91,16 @@ interface ViewHelperInterface {
 	 */
 	public function handleAdditionalArguments(array $arguments);
 
+	/**
+	 * Method which can be implemented in any ViewHelper if that ViewHelper desires
+	 * the ability to allow additional, undeclared, dynamic etc. arguments for the
+	 * node in the template. Do not implement this unless you need it!
+	 *
+	 * @param array $arguments
+	 * @return void
+	 */
+	public function validateAdditionalArguments(array $arguments);
+
 //	/**
 //	 * Render method you need to implement for your custom view helper.
 //	 * Note: This method is commented out in order to avoid conflicts with different method signatures in the implementation

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -284,24 +284,7 @@ abstract class AbstractTemplateView extends AbstractView {
 		if ($this->templateCompiler->has($templateIdentifier)) {
 			$parsedTemplate = $this->templateCompiler->get($templateIdentifier);
 		} else {
-			try {
-				$parsedTemplate = $this->templateParser->parse($templateSourceClosure($this, $this->templatePaths));
-			} catch (\RuntimeException $error) {
-				list ($line, $character, $templateCode) = $this->templateParser->getCurrentParsingPointers();
-				$exceptionClass = get_class($error);
-				throw new $exceptionClass(
-					sprintf(
-						'Fluid parse error in template %s, line %d at character %d. Error: %s (%d). Template code: %s',
-						$templateIdentifier,
-						$line,
-						$character,
-						$error->getMessage(),
-						$error->getCode(),
-						$templateCode
-					),
-					$error->getCode()
-				);
-			}
+			$parsedTemplate = $this->templateParser->parse($templateSourceClosure($this, $this->templatePaths), $templateIdentifier);
 			if ($parsedTemplate->isCompilable()) {
 				$this->templateCompiler->store($templateIdentifier, $parsedTemplate);
 			}

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -267,6 +267,12 @@ class TemplatePaths {
 					return self::$resolvedFiles['templates'][$identifier] = $candidate;
 				}
 			}
+			foreach ($this->getTemplateRootPaths() as $templateRootPath) {
+				$candidate = $this->ensureAbsolutePath($templateRootPath . $action . '.' . $format);
+				if (file_exists($candidate)) {
+					return self::$resolvedFiles['templates'][$identifier] = $candidate;
+				}
+			}
 		}
 		return isset(self::$resolvedFiles['templates'][$identifier]) ? self::$resolvedFiles['templates'][$identifier] : NULL;
 	}

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -73,7 +73,7 @@ class ForViewHelper extends AbstractViewHelper {
 		parent::initializeArguments();
 		$this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', TRUE);
 		$this->registerArgument('as', 'string', 'The name of the iteration variable', TRUE);
-		$this->registerArgument('key', 'string', 'Variable to assign array key to', TRUE);
+		$this->registerArgument('key', 'string', 'Variable to assign array key to', FALSE);
 		$this->registerArgument('reverse', 'boolean', 'If TRUE, iterates in reverse', FALSE, FALSE);
 		$this->registerArgument('iteration', 'string', 'Name of iteration variable to assign', FALSE, NULL);
 	}

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -7,6 +7,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
  */
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\Fixtures\ChildNodeAccessFacetViewHelper;
@@ -56,7 +57,7 @@ class ViewHelperNodeTest extends UnitTestCase {
 	 */
 	public function constructorSetsViewHelperAndArguments() {
 		$viewHelper = $this->getMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper');
-		$arguments = array('foo' => 'bar');
+		$arguments = array('then' => 'test');
 		$resolver = new ViewHelperResolver();
 		/** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $viewHelperNode */
 		$viewHelperNode = $this->getAccessibleMock(

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -33,7 +33,7 @@ class TemplateParserTest extends UnitTestCase {
 		$method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
 		$method->setAccessible(TRUE);
 		$result = $method->invokeArgs($templateParser, array(new ParsingState(), 'f', 'render', array()));
-		$this->assertFalse($result);
+		$this->assertNull($result);
 	}
 
 	/**
@@ -176,7 +176,7 @@ class TemplateParserTest extends UnitTestCase {
 		$templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')
 			->with($mockState, 'namespaceIdentifier', 'methodIdentifier', array('parsedArguments'));
 
-		$templateParser->_call('openingViewHelperTagHandler', $mockState, 'namespaceIdentifier', 'methodIdentifier', array('arguments'), FALSE);
+		$templateParser->_call('openingViewHelperTagHandler', $mockState, 'namespaceIdentifier', 'methodIdentifier', array('arguments'), FALSE, '');
 	}
 
 	/**
@@ -191,9 +191,10 @@ class TemplateParserTest extends UnitTestCase {
 			'TYPO3Fluid\Fluid\Core\Parser\TemplateParser',
 			array('parseArguments', 'initializeViewHelperAndAddItToStack')
 		);
-		$templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')->will($this->returnValue(TRUE));
+		$node = $this->getMock('TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode', array('dummy'), array(), '', FALSE);
+		$templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')->will($this->returnValue($node));
 
-		$templateParser->_call('openingViewHelperTagHandler', $mockState, '', '', array(), TRUE);
+		$templateParser->_call('openingViewHelperTagHandler', $mockState, '', '', array(), TRUE, '');
 	}
 
 	/**

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -118,14 +118,14 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function testHandleAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments() {
+	public function testValidateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments() {
 		$viewHelper = $this->getAccessibleMock(
 			'TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper',
 			array('dummy'),
 			array(), '', FALSE
 		);
 		$this->setExpectedException('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\Exception');
-		$viewHelper->handleAdditionalArguments(array('foo' => 'bar'));
+		$viewHelper->validateAdditionalArguments(array('foo' => 'bar'));
 	}
 
 	/**

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -301,14 +301,14 @@ class AbstractViewHelperTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function testHandleAdditionalArgumentsThrowsExceptionIfNotEmpty() {
+	public function testValidateAdditionalArgumentsThrowsExceptionIfNotEmpty() {
 		$viewHelper = $this->getAccessibleMock(
 			'TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper',
 			array('dummy'),
 			array(), '', FALSE
 		);
 		$this->setExpectedException('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\Exception');
-		$viewHelper->handleAdditionalArguments(array('foo' => 'bar'));
+		$viewHelper->validateAdditionalArguments(array('foo' => 'bar'));
 	}
 
 	/**
@@ -316,7 +316,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 */
 	public function testCompileReturnsAndAssignsExpectedPhpCode() {
 		$viewHelper = $this->getAccessibleMock('TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper', array('dummy'), array(), '', FALSE);
-		$node = new ViewHelperNode(new ViewHelperResolver(), 'f', 'section', array(), new ParsingState());
+		$node = new ViewHelperNode(new ViewHelperResolver(), 'f', 'comment', array(), new ParsingState());
 		$init = '';
 		$compiler = new TemplateCompiler();
 		$result = $viewHelper->compile('foobar', 'baz', $init, $node, $compiler);


### PR DESCRIPTION
This change:

* Improves handling of errors with template examples
* Moves such template code errors to TemplateParser entirely
* Implements validation of required arguments (by presence alone) in ViewHelperNode constructor, causing it to fail on bad syntax
* Introduces a secondary validateAdditionalArguments method that allows validating the presences of additional, unregistered arguments at parse time
* Cleans up the way ViewHelperNode is handled in TemplateParser
* Makes sure the TemplatePaths checks for global (not controller specific) templates after controller specific ones