### PR TITLE
[BUGFIX] Prevent warning with empty arrays

### DIFF
--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -203,7 +203,9 @@ class NodeConverter {
 			return array(
 				'initialization' => '',
 				'execution' => sprintf(
-					'%s[\'%s\']',
+					'isset(%s[\'%s\']) ? %s[\'%s\'] : NULL',
+					$providerReference,
+					str_replace('.', '\'][\'', $path),
 					$providerReference,
 					str_replace('.', '\'][\'', $path)
 				)

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -75,7 +75,7 @@ class NodeConverterTest extends UnitTestCase {
 			),
 			array(
 				new ObjectAccessorNode('foo.bar', array('array', 'array')),
-				'$renderingContext->getVariableProvider()[\'foo\'][\'bar\']'
+				'isset($renderingContext->getVariableProvider()[\'foo\'][\'bar\']) ? $renderingContext->getVariableProvider()[\'foo\'][\'bar\'] : NULL'
 			),
 			array(
 				new BooleanNode(new TextNode('TRUE')),


### PR DESCRIPTION
This wraps array access with an isset if to prevent warnings because of non existing keys in compiled templates