### PR TITLE
[FEATURE] Allow namespaces to be extended

### DIFF
--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -62,4 +62,33 @@ class ViewHelperResolverTest extends UnitTestCase {
 		$resolver->resolveViewHelperClassName('f', 'invalid');
 	}
 
+	/**
+	 * @test
+	 */
+	public function testResolveViewHelperClassNameSupportsMultipleNamespaces() {
+		$resolver = $this->getAccessibleMock('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\ViewHelperResolver', array('dummy'));
+		$resolver->_set('namespaces', array(
+			'f' => array(
+				'FluidTYPO3\\Fluid\\ViewHelpers',
+				'Foo\\Bar'
+			)
+		));
+		$result = $resolver->_call('resolveViewHelperName', 'f', 'render');
+		$this->assertEquals('FluidTYPO3\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
+	}
+
+	/**
+	 * @test
+	 */
+	public function testExtendNamespace() {
+		$resolver = $this->getMock('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\ViewHelperResolver', array('dummy'));
+		$resolver->extendNamespace('f', 'Foo\\Bar');
+		$this->assertAttributeEquals(array(
+			'f' => array(
+				'TYPO3Fluid\\Fluid\\ViewHelpers',
+				'Foo\\Bar'
+			)
+		), 'namespaces', $resolver);
+	}
+
 }


### PR DESCRIPTION
Allows:

```php
// given class My\Package\ViewHelpers\RenderViewHelper exists and REPLACES f:render
$view->getViewHelperResolver()->extendNamespace('f', 'My\\Package\\ViewHelpers');
$class = $view->getViewHelperResolver()->resolveViewHelperClassName('f', 'render');
// "My\\Package\\ViewHelpers\\RenderViewHelper"

// given class My\Package\OtherViewHelper exists, gets ADDED to "f:" namespace
$class = $view->getViewHelperResolver()->resolveViewHelperClassName('f', 'other');
// "My\\Package\\ViewHelpers\\OtherViewHelper"
```

And in templates allows all ViewHelpers from "My\Package\ViewHelpers" to be used as part of "f:".

The feature is achieved through allowing each registered PHP namespace string to become an array and the resolve class method to support both strings and arrays, walking the arrays backwards (for "overlay" style behavior) when it detects multiple PHP namespace targets.