### PR TITLE
[TASK] Use var_export for basic DebugViewHelper

### DIFF
--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -70,10 +70,6 @@ class DebugViewHelper extends AbstractViewHelper {
 			return (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
 		}
 
-		ob_start();
-		var_dump($expressionToExamine);
-		$output = ob_get_contents();
-		ob_end_clean();
-		return $output;
+		return var_export($expressionToExamine, TRUE);
 	}
 }

--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -41,7 +41,7 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function getRenderTestValues() {
 		return array(
-			array('test', array('typeOnly' => FALSE), 'string(4) "test"' . PHP_EOL),
+			array('test', array('typeOnly' => FALSE), "'test'"),
 			array('test', array('typeOnly' => TRUE), 'string'),
 		);
 	}


### PR DESCRIPTION
Rather than depending on output buffering, var_export with "return" parameter can be used safely on all supported PHP versions. Prevents issues with debug instructions being output when var_dump is used on PHP7 with debug enabled.