### PR TITLE
[FEATURE] Replace escaping by f:format.htmlspecialchars with EscapingNode

### DIFF
--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -8,6 +8,7 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionNodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
@@ -77,8 +78,20 @@ class NodeConverter {
 			$converted = $this->convertListOfSubNodes($node);
 		} elseif ($node instanceof BooleanNode) {
 			$converted = $this->convertBooleanNode($node);
+		} elseif ($node instanceof EscapingNode) {
+			$converted = $this->convertEscapingNode($node);
 		}
 		return $converted;
+	}
+
+	/**
+	 * @param EscapingNode $node
+	 * @return array
+	 */
+	protected function convertEscapingNode(EscapingNode $node) {
+		$configuration = $this->convert($node->getNode());
+		$configuration['execution'] = sprintf('htmlspecialchars(%s, ENT_QUOTES)', $configuration['execution']);
+		return $configuration;
 	}
 
 	/**

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -1,0 +1,61 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+
+/**
+ * Escaping Node - wraps all content that must be escaped before output.
+ */
+class EscapingNode extends AbstractNode {
+
+	/**
+	 * Node to be escaped
+	 *
+	 * @var NodeInterface
+	 */
+	protected $node;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param NodeInterface $node
+	 */
+	public function __construct(NodeInterface $node) {
+		$this->node = $node;
+	}
+
+	/**
+	 * Return the value associated to the syntax tree.
+	 *
+	 * @param RenderingContextInterface $renderingContext
+	 * @return number the value stored in this node/subtree.
+	 */
+	public function evaluate(RenderingContextInterface $renderingContext) {
+		return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES);
+	}
+
+	/**
+	 * @return NodeInterface
+	 */
+	public function getNode() {
+		return $this->node;
+	}
+
+	/**
+	 * NumericNode does not allow adding child nodes, so this will always throw an exception.
+	 *
+	 * @param NodeInterface $childNode The sub node to add
+	 * @throws Parser\Exception
+	 * @return void
+	 */
+	public function addChildNode(NodeInterface $childNode) {
+		$this->node = $childNode;
+	}
+}


### PR DESCRIPTION
Rather than use the f:format.htmlspecialchars ViewHelper via a ViewHelperNode, involving resolving and everything else implied by rendering a ViewHelper, a new node type - EscapingNode - is implemented. The node is added in the same way as the old escaping would do, but evaluates as and compiles to a single `htmlspecialchars` function call.