### PR TITLE
[FEATURE] RenderingContext as implementation API

### DIFF
--- a/examples/example_conditions.php
+++ b/examples/example_conditions.php
@@ -23,7 +23,7 @@ $view->assign('ternaryFalse', 'The ternary expression is FALSE');
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Conditions.html');
+$paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Conditions.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.
 $output = $view->render();

--- a/examples/example_customresolving.php
+++ b/examples/example_customresolving.php
@@ -28,11 +28,11 @@ require_once __DIR__ . '/include/class_customviewhelper.php';
 // through the default namespace without that ViewHelper being in the
 // default package. The ViewHelper is added dynamically as `f:myLink`.
 // See CustomViewHelperResolver class for details.
-$view->setViewHelperResolver(new \TYPO3Fluid\Fluid\Tests\Example\CustomViewHelperResolver());
+$view->getRenderingContext()->setViewHelperResolver(new \TYPO3Fluid\Fluid\Tests\Example\CustomViewHelperResolver());
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CustomResolving.html');
+$paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CustomResolving.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.
 $output = $view->render();

--- a/examples/example_format.php
+++ b/examples/example_format.php
@@ -11,7 +11,7 @@ require __DIR__ . '/include/view_init.php';
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setFormat('json');
+$paths->setFormat('json');
 
 // Rendering the View: we use the $action argument for the render() method in
 // order to let the internal TemplatePaths object resolve our file paths while

--- a/examples/example_layoutless.php
+++ b/examples/example_layoutless.php
@@ -11,7 +11,7 @@ require __DIR__ . '/include/view_init.php';
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/LayoutLess.html');
+$paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/LayoutLess.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_variableprovider.php
+++ b/examples/example_variableprovider.php
@@ -19,7 +19,7 @@ $dynamic2 = 'DYN2'; // used as dynamic part when accessing other variables
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/VariableProvider.html');
+$paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/VariableProvider.html');
 
 // Assigning a custom VariableProvider which will return two variables:
 // $incrementer and $random; the former automatically increments every

--- a/examples/example_variables.php
+++ b/examples/example_variables.php
@@ -46,7 +46,7 @@ $view->assignMultiple(array(
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Variables.html');
+$paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Variables.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.
 $output = $view->render();

--- a/examples/include/view_init.php
+++ b/examples/include/view_init.php
@@ -5,8 +5,13 @@ $FLUID_CACHE_DIRECTORY = !isset($FLUID_CACHE_DIRECTORY) ? __DIR__ . '/../cache/'
 // Use Composer's autoloader to handle our class loading.
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+// Initializing the View: rendering in Fluid takes place through a View instance
+// which contains a RenderingContext that in turn contains things like definitions
+// of template paths, instances of variable containers and similar.
+$view = new \TYPO3Fluid\Fluid\View\TemplateView();
+
 // TemplatePaths object: a subclass can be used if custom resolving is wanted.
-$paths = new \TYPO3Fluid\Fluid\View\TemplatePaths();
+$paths = $view->getTemplatePaths();
 
 // Configuring paths: explicit setters used in this example. Paths can also
 // be passed as a ["templateRootPaths" => ["path1/", "path2/"]] constructor
@@ -26,17 +31,11 @@ $paths->setPartialRootPaths(array(
 	__DIR__ . '/../Resources/Private/Partials/'
 ));
 
-// Initializing the View: rendering in Fluid takes place through a View instance
-// which is given the TemplatePaths that resolve files and uses these as sources
-// for the rendering engine. As with TemplatePaths, custom implementations of
-// this View can be created to change the format from HTML to XML, assign some
-// default values, add additional ViewHelper namespaces, etc.
-$view = new \TYPO3Fluid\Fluid\View\TemplateView($paths);
-
 if ($FLUID_CACHE_DIRECTORY) {
 	// Configure View's caching to use ./examples/cache/ as caching directory.
 	$view->setCache(new \TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache($FLUID_CACHE_DIRECTORY));
 }
+
 
 /**
  * Tiny helper that outputs a plain string in a nice way,

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -56,28 +56,7 @@ class ParsingState implements ParsedTemplateInterface {
 	protected $compilable = TRUE;
 
 	/**
-	 * @var ViewHelperResolver
-	 */
-	protected $viewHelperResolver;
-
-	/**
-	 * @param ViewHelperResolver $viewHelperResolver
-	 * @return void
-	 */
-	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver) {
-		$this->viewHelperResolver = $viewHelperResolver;
-	}
-
-	/**
-	 * @return ViewHelperResolver
-	 */
-	public function getViewHelperResolver() {
-		return $this->viewHelperResolver;
-	}
-
-	/**
-	 * Injects a variable container. ViewHelpers implementing the PostParse
-	 * Facet can store information inside this variableContainer.
+	 * Injects a variable container to be used during parsing.
 	 *
 	 * @param VariableProviderInterface $variableContainer
 	 * @return void
@@ -87,7 +66,7 @@ class ParsingState implements ParsedTemplateInterface {
 	}
 
 	/**
-	 * Set root node of this parsing state
+	 * Set root node of this parsing state.
 	 *
 	 * @param NodeInterface $rootNode
 	 * @return void
@@ -181,7 +160,7 @@ class ParsingState implements ParsedTemplateInterface {
 	 * @throws View\Exception
 	 */
 	public function getLayoutName(RenderingContextInterface $renderingContext) {
-		return $renderingContext->getVariableProvider()->get('layoutName');
+		return $this->variableContainer->get('layoutName');
 	}
 
 	/**

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -39,11 +39,6 @@ class ViewHelperNode extends AbstractNode {
 	protected $argumentDefinitions = array();
 
 	/**
-	 * @var ViewHelperResolver
-	 */
-	protected $viewHelperResolver;
-
-	/**
 	 * @var string
 	 */
 	protected $pointerTemplateCode = NULL;
@@ -51,14 +46,14 @@ class ViewHelperNode extends AbstractNode {
 	/**
 	 * Constructor.
 	 *
-	 * @param ViewHelperResolver an instance or subclass of ViewHelperResolver
+	 * @param RenderingContextInterface $renderingContext a RenderingContext, provided by invoker
 	 * @param string $namespace the namespace identifier of the ViewHelper.
 	 * @param string $identifier the name of the ViewHelper to render, inside the namespace provided.
 	 * @param NodeInterface[] $arguments Arguments of view helper - each value is a RootNode.
 	 * @param ParsingState $state
 	 */
-	public function __construct(ViewHelperResolver $resolver, $namespace, $identifier, array $arguments, ParsingState $state) {
-		$this->viewHelperResolver = $resolver;
+	public function __construct(RenderingContextInterface $renderingContext, $namespace, $identifier, array $arguments, ParsingState $state) {
+		$resolver = $renderingContext->getViewHelperResolver();
 		$this->arguments = $arguments;
 		$this->viewHelperClassName = $resolver->resolveViewHelperClassName($namespace, $identifier);
 		$this->uninitializedViewHelper = $resolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
@@ -142,8 +137,7 @@ class ViewHelperNode extends AbstractNode {
 		// DO NOT CHANGE THIS ORDER. You *will* cause damage.
 		$viewHelper->setViewHelperNode($this);
 		$viewHelper->setChildNodes($this->getChildNodes());
-		return $renderingContext->getViewHelperResolver()->resolveViewHelperInvoker($this->getViewHelperClassName())
-			->invoke($viewHelper, $this->getArguments(), $renderingContext);
+		return $renderingContext->getViewHelperInvoker()->invoke($viewHelper, $this->arguments, $renderingContext);
 	}
 
 	/**

--- a/src/Core/Parser/TemplateProcessorInterface.php
+++ b/src/Core/Parser/TemplateProcessorInterface.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 
 /**
@@ -24,23 +25,10 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 interface TemplateProcessorInterface {
 
 	/**
-	 * Setter for passing the TemplateParser instance
-	 * that is currently processing the template.
-	 *
-	 * @param TemplateParser $templateParser
+	 * @param RenderingContextInterface $renderingContext
 	 * @return void
 	 */
-	public function setTemplateParser(TemplateParser $templateParser);
-
-	/**
-	 * Setter for passing the ViewHelperResolver instance
-	 * being used by the TemplateParser to resolve classes
-	 * and namespaces of ViewHelpers.
-	 *
-	 * @param ViewHelperResolver $viewHelperResolver
-	 * @return void
-	 */
-	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver);
+	public function setRenderingContext(RenderingContextInterface $renderingContext);
 
 	/**
 	 * Pre-process the template source before it is

--- a/src/Core/Rendering/RenderingContextInterface.php
+++ b/src/Core/Rendering/RenderingContextInterface.php
@@ -6,9 +6,16 @@ namespace TYPO3Fluid\Fluid\Core\Rendering;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\Configuration;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
+use TYPO3Fluid\Fluid\View\TemplatePaths;
 
 /**
  * Contract for the rendering context
@@ -26,7 +33,7 @@ interface RenderingContextInterface {
 	/**
 	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
 	 */
-	public function injectViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer);
+	public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer);
 
 	/**
 	 * Get the template variable container
@@ -41,6 +48,113 @@ interface RenderingContextInterface {
 	 * @return ViewHelperVariableContainer
 	 */
 	public function getViewHelperVariableContainer();
+
+	/**
+	 * @return ViewHelperResolver
+	 */
+	public function getViewHelperResolver();
+
+	/**
+	 * @param ViewHelperResolver $viewHelperResolver
+	 * @return void
+	 */
+	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver);
+
+	/**
+	 * @return ViewHelperInvoker
+	 */
+	public function getViewHelperInvoker();
+
+	/**
+	 * @param ViewHelperInvoker $viewHelperInvoker
+	 * @return void
+	 */
+	public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker);
+
+	/**
+	 * Inject the Template Parser
+	 *
+	 * @param TemplateParser $templateParser The template parser
+	 * @return void
+	 */
+	public function setTemplateParser(TemplateParser $templateParser);
+
+	/**
+	 * @return TemplateParser
+	 */
+	public function getTemplateParser();
+
+	/**
+	 * @param TemplateCompiler $templateCompiler
+	 * @return void
+	 */
+	public function setTemplateCompiler(TemplateCompiler $templateCompiler);
+
+	/**
+	 * @return TemplateCompiler
+	 */
+	public function getTemplateCompiler();
+
+	/**
+	 * @return TemplatePaths
+	 */
+	public function getTemplatePaths();
+
+	/**
+	 * @param TemplatePaths $templatePaths
+	 * @return void
+	 */
+	public function setTemplatePaths(TemplatePaths $templatePaths);
+
+	/**
+	 * Delegation: Set the cache used by this View's compiler
+	 *
+	 * @param FluidCacheInterface $cache
+	 * @return void
+	 */
+	public function setCache(FluidCacheInterface $cache);
+
+	/**
+	 * @return FluidCacheInterface
+	 */
+	public function getCache();
+
+	/**
+	 * @return boolean
+	 */
+	public function isCacheEnabled();
+
+	/**
+	 * Delegation: Set TemplateProcessor instances in the parser
+	 * through a public API.
+	 *
+	 * @param TemplateProcessorInterface[] $templateProcessors
+	 * @return void
+	 */
+	public function setTemplateProcessors(array $templateProcessors);
+
+	/**
+	 * @return TemplateProcessorInterface[]
+	 */
+	public function getTemplateProcessors();
+
+	/**
+	 * @return array
+	 */
+	public function getExpressionNodeTypes();
+
+	/**
+	 * @param array $expressionNodeTypes
+	 * @return void
+	 */
+	public function setExpressionNodeTypes(array $expressionNodeTypes);
+
+	/**
+	 * Build parser configuration
+	 *
+	 * @return Configuration
+	 */
+	public function buildParserConfiguration();
 
 	/**
 	 * @return string
@@ -63,16 +177,5 @@ interface RenderingContextInterface {
 	 * @return void
 	 */
 	public function setControllerAction($action);
-
-	/**
-	 * @return ViewHelperResolver
-	 */
-	public function getViewHelperResolver();
-
-	/**
-	 * @param ViewHelperResolver $viewHelperResolver
-	 * @return void
-	 */
-	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver);
 
 }

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -431,8 +431,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 */
 	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		$viewHelperClassName = get_called_class();
-		return $renderingContext->getViewHelperResolver()->resolveViewHelperInvoker($viewHelperClassName)
-			->invoke($viewHelperClassName, $arguments, $renderingContext, $renderChildrenClosure);
+		return $renderingContext->getViewHelperInvoker()->invoke($viewHelperClassName, $arguments, $renderingContext, $renderChildrenClosure);
 	}
 
 	/**

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -31,18 +31,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 class ViewHelperInvoker {
 
 	/**
-	 * @var ViewHelperResolver
-	 */
-	protected $viewHelperResolver;
-
-	/**
-	 * @param ViewHelperResolver $viewHelperResolver
-	 */
-	public function __construct(ViewHelperResolver $viewHelperResolver) {
-		$this->viewHelperResolver = $viewHelperResolver;
-	}
-
-	/**
 	 * Invoke the ViewHelper described by the ViewHelperNode, the properties
 	 * of which will already have been filled by the ViewHelperResolver.
 	 *
@@ -53,12 +41,13 @@ class ViewHelperInvoker {
 	 * @return mixed
 	 */
 	public function invoke($viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, \Closure $renderChildrenClosure = NULL) {
+		$viewHelperResolver = $renderingContext->getViewHelperResolver();
 		if ($viewHelperClassNameOrInstance instanceof ViewHelperInterface) {
 			$viewHelper = $viewHelperClassNameOrInstance;
 		} else {
-			$viewHelper = $this->viewHelperResolver->createViewHelperInstanceFromClassName($viewHelperClassNameOrInstance);
+			$viewHelper = $viewHelperResolver->createViewHelperInstanceFromClassName($viewHelperClassNameOrInstance);
 		}
-		$expectedViewHelperArguments = $renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper($viewHelper);
+		$expectedViewHelperArguments = $viewHelperResolver->getArgumentDefinitionsForViewHelper($viewHelper);
 
 		// Rendering process
 		$evaluatedArguments = array();

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -36,26 +36,6 @@ class ViewHelperResolver {
 	);
 
 	/**
-	 * List of class names implementing ExpressionNodeInterface
-	 * which will be consulted when an expression does not match
-	 * any built-in parser expression types.
-	 *
-	 * @var string
-	 */
-	protected $expressionNodeTypes = array(
-		CastingExpressionNode::class,
-		MathExpressionNode::class,
-		TernaryExpressionNode::class,
-	);
-
-	/**
-	 * @return string
-	 */
-	public function getExpressionNodeTypes() {
-		return $this->expressionNodeTypes;
-	}
-
-	/**
 	 * @return array
 	 */
 	public function getNamespaces() {
@@ -175,26 +155,6 @@ class ViewHelperResolver {
 		}
 
 		return FALSE;
-	}
-
-	/**
-	 * Resolve an Invoker that will call the ViewHelper given as
-	 * argument to render it correctly.
-	 *
-	 * If any ViewHelper requires special execution to render
-	 * correctly, this is the method to override in a custom
-	 * ViewHelperResolver to return a different ViewHelperInvoker
-	 * for that class and others like it.
-	 *
-	 * Our default implementation returns the simplest possible
-	 * Invoker that only supports the default implementations of
-	 * ViewHelper arguments and render methods.
-	 *
-	 * @param string $viewHelperClassName
-	 * @return ViewHelperInvoker
-	 */
-	public function resolveViewHelperInvoker($viewHelperClassName) {
-		return new ViewHelperInvoker($this);
 	}
 
 	/**

--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -6,7 +6,7 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  * See LICENSE.txt that was shipped with this package.
  */
 
-use TYPO3Fluid\Fluid\View\AbstractTemplateView;
+use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
  * A key/value store that can be used by ViewHelpers to communicate between each other.
@@ -24,7 +24,7 @@ class ViewHelperVariableContainer {
 	protected $objects = array();
 
 	/**
-	 * @var AbstractTemplateView
+	 * @var ViewInterface
 	 */
 	protected $view;
 
@@ -104,10 +104,10 @@ class ViewHelperVariableContainer {
 	/**
 	 * Set the view to pass it to ViewHelpers.
 	 *
-	 * @param AbstractTemplateView $view View to set
+	 * @param ViewInterface $view View to set
 	 * @return void
 	 */
-	public function setView(AbstractTemplateView $view) {
+	public function setView(ViewInterface $view) {
 		$this->view = $view;
 	}
 
@@ -116,7 +116,7 @@ class ViewHelperVariableContainer {
 	 *
 	 * !!! This is NOT a public API and might still change!!!
 	 *
-	 * @return AbstractTemplateView The View
+	 * @return ViewInterface The View
 	 */
 	public function getView() {
 		return $this->view;

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -27,63 +27,17 @@ abstract class BaseFunctionalTestCase extends UnitTestCase {
 	}
 
 	/**
-	 * If your test case requires a custom VariableProvider
-	 * implementation, return the instance from this method.
-	 *
-	 * @return VariableProviderInterface
-	 */
-	protected function getVariableProvider() {
-		return new StandardVariableProvider();
-	}
-
-	/**
-	 * If your test case requires a custom RenderingContext,
-	 * return the instance from this method.
-	 *
-	 * @return RenderingContext
-	 */
-	protected function getRenderingContext() {
-		return new RenderingContext();
-	}
-
-	/**
-	 * If your test case requires a custom ViewHelperResolver,
-	 * return the instance from this method.
-	 *
-	 * @return ViewHelperResolver
-	 */
-	protected function getViewHelperResolver() {
-		return new ViewHelperResolver();
-	}
-
-	/**
-	 * If your test case requires a custom TemplatePaths
-	 * implementation, return the instance from this method.
-	 *
-	 * @return TemplatePaths
-	 */
-	protected function getTemplatePaths() {
-		return new TemplatePaths();
-	}
-
-	/**
 	 * If your test case requires a custom View instance
 	 * return the instance from this method.
 	 *
 	 * @return ViewInterface
 	 */
 	protected function getView($withCache = FALSE) {
-		$paths = $this->getTemplatePaths();
-		$context = $this->getRenderingContext();
-		$resolver = $this->getViewHelperResolver();
-		if (!$withCache) {
-			$view = new TemplateView($paths, $context);
-		} else {
-			$cache = $this->getCache();
-			$view = new TemplateView($paths, $context, $cache);
+		$view = new TemplateView();
+		$cache = $this->getCache();
+		if ($cache && $withCache) {
+			$view->getRenderingContext()->setCache($cache);
 		}
-
-		$view->setViewHelperResolver($resolver);
 		return $view;
 	}
 
@@ -139,10 +93,10 @@ abstract class BaseFunctionalTestCase extends UnitTestCase {
 	 */
 	public function testTemplateCodeFixture($source, array $variables, array $expected, array $notExpected, $withCache = FALSE) {
 		$view = $this->getView(FALSE);
-		$view->getTemplatePaths()->setTemplateSource($source);
+		$view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
 		$view->assignMultiple($variables);
 		$output = $view->render();
-		$this->assertNotEquals($view->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
+		$this->assertNotEquals($view->getRenderingContext()->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
 		if (empty($expected) && empty($notExpected)) {
 			$this->fail('Test performs no assertions!');
 		}

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -11,7 +11,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class AbstractCompiledTemplateTest
@@ -23,7 +25,7 @@ class AbstractCompiledTemplateTest extends UnitTestCase {
 	 */
 	public function testParentGetVariableContainerMethodReturnsStandardVariableProvider() {
 		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->getVariableContainer(new RenderingContext());
+		$result = $instance->getVariableContainer();
 		$this->assertInstanceOf(StandardVariableProvider::class, $result);
 	}
 
@@ -32,7 +34,7 @@ class AbstractCompiledTemplateTest extends UnitTestCase {
 	 */
 	public function testParentRenderMethodReturnsEmptyString() {
 		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->render(new RenderingContext());
+		$result = $instance->render(new RenderingContextFixture());
 		$this->assertEquals('', $result);
 	}
 
@@ -41,7 +43,7 @@ class AbstractCompiledTemplateTest extends UnitTestCase {
 	 */
 	public function testParentGetLayoutNameMethodReturnsEmptyString() {
 		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->getLayoutName(new RenderingContext());
+		$result = $instance->getLayoutName(new RenderingContextFixture());
 		$this->assertEquals('', $result);
 	}
 
@@ -65,7 +67,7 @@ class AbstractCompiledTemplateTest extends UnitTestCase {
 			array('createViewHelperInstanceFromClassName')
 		);
 		$resolver->expects($this->once())->method('createViewHelperInstanceFromClassName')->willReturn($viewHelper);
-		$renderingContext = new RenderingContext();
+		$renderingContext = new RenderingContextFixture();
 		$renderingContext->setViewHelperResolver($resolver);
 		$result = $instance->getViewHelper(1, $renderingContext, TestViewHelper::class);
 		$this->assertSame($viewHelper, $result);
@@ -94,7 +96,7 @@ class AbstractCompiledTemplateTest extends UnitTestCase {
 	 */
 	public function testAddCompiledNamespacesDoesNothing() {
 		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$context = new RenderingContext();
+		$context = new RenderingContextFixture();
 		$before = $context->getViewHelperResolver()->getNamespaces();
 		$instance->addCompiledNamespaces($context);
 		$after = $context->getViewHelperResolver()->getNamespaces();

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -19,6 +19,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 /**
@@ -42,7 +43,8 @@ class NodeConverterTest extends UnitTestCase {
 	 * @param string $expected
 	 */
 	public function testConvert(NodeInterface $node, $expected) {
-		$instance = new NodeConverter(new TemplateCompiler());
+		$compiler = new TemplateCompiler();
+		$instance = $compiler->getNodeConverter();
 		$method = new \ReflectionMethod($instance, 'convert');
 		$method->setAccessible(TRUE);
 		$result = $method->invokeArgs($instance, array($node));
@@ -95,7 +97,7 @@ class NodeConverterTest extends UnitTestCase {
 			),
 			array(
 				new ViewHelperNode(
-					new ViewHelperResolver(),
+					new RenderingContextFixture(),
 					'f',
 					'render',
 					array('section' => new TextNode('test'), 'partial' => 'test'),

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -10,7 +10,10 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for ParsingState
@@ -55,7 +58,7 @@ class ParsingStateTest extends UnitTestCase {
 	 * @test
 	 */
 	public function renderCallsTheRightMethodsOnTheRootNode() {
-		$renderingContext = $this->getMock(RenderingContextInterface::class);
+		$renderingContext = new RenderingContextFixture();
 		$rootNode = $this->getMock(RootNode::class);
 		$rootNode->expects($this->once())->method('evaluate')->with($renderingContext)->will($this->returnValue('T3DD09 Rock!'));
 		$this->parsingState->setRootNode($rootNode);
@@ -67,9 +70,8 @@ class ParsingStateTest extends UnitTestCase {
 	 * @test
 	 */
 	public function testGetLayoutName() {
-		$context = new RenderingContext();
-		$context->getVariableProvider()->add('layoutName', 'test');
-		$result = $this->parsingState->getLayoutName($context);
+		$this->parsingState->setVariableProvider(new StandardVariableProvider(array('layoutName' => 'test')));
+		$result = $this->parsingState->getLayoutName(new RenderingContextFixture());
 		$this->assertEquals('test', $result);
 	}
 

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -17,8 +17,11 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for BooleanNode
@@ -39,7 +42,7 @@ class BooleanNodeTest extends UnitTestCase {
 	 * Setup fixture
 	 */
 	public function setUp() {
-		$this->renderingContext = $this->getMock(RenderingContextInterface::class);
+		$this->renderingContext = new RenderingContextFixture();
 	}
 
 	/**
@@ -377,7 +380,8 @@ class BooleanNodeTest extends UnitTestCase {
 	 * @return RenderingContext
 	 */
 	protected function getDummyRenderingContextWithVariables(array $variables) {
-		$context = new RenderingContext();
+		$context = $this->renderingContext;
+		$context->setVariableProvider(new StandardVariableProvider($variables));
 		$context->getVariableProvider()->setSource($variables);
 		return $context;
 	}
@@ -629,9 +633,8 @@ class BooleanNodeTest extends UnitTestCase {
 	 * @dataProvider getStandardInputTypes
 	 */
 	public function acceptsStandardTypesAsInput($input, $expected) {
-		$context = new RenderingContext();
 		$node = new BooleanNode($input);
-		$this->assertEquals($expected, $node->evaluate($context));
+		$this->assertEquals($expected, $node->evaluate($this->renderingContext));
 	}
 
 	/**

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -12,6 +12,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToArray;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class CastingExpressionNodeTest
@@ -27,7 +28,8 @@ class CastingExpressionNodeTest extends UnitTestCase {
 			array('dummy'),
 			array('{test as string}', array('test as string'))
 		);
-		$context = new RenderingContext();
+		$view = new TemplateView();
+		$context = new RenderingContext($view);
 		$context->setVariableProvider(new StandardVariableProvider(array('test' => 10)));
 		$result = $subject->evaluate($context);
 		$this->assertSame('10', $result);
@@ -37,7 +39,8 @@ class CastingExpressionNodeTest extends UnitTestCase {
 	 * @test
 	 */
 	public function testEvaluateInvalidExpressionThrowsException() {
-		$renderingContext = new RenderingContext();
+		$view = new TemplateView();
+		$renderingContext = new RenderingContext($view);
 		$renderingContext->setVariableProvider(new StandardVariableProvider());
 		$this->setExpectedException(Exception::class);
 		$result = CastingExpressionNode::evaluateExpression($renderingContext, 'suchaninvalidexpression as 1', array());
@@ -50,7 +53,8 @@ class CastingExpressionNodeTest extends UnitTestCase {
 	 * @param mixed $expected
 	 */
 	public function testEvaluateExpression($expression, array $variables, $expected) {
-		$renderingContext = new RenderingContext();
+		$view = new TemplateView();
+		$renderingContext = new RenderingContext($view);
 		$renderingContext->setVariableProvider(new StandardVariableProvider($variables));
 		$result = CastingExpressionNode::evaluateExpression($renderingContext, $expression, array());
 		$this->assertEquals($expected, $result);

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class MathExpressionNodeTest
@@ -23,7 +24,8 @@ class MathExpressionNodeTest extends UnitTestCase {
 	 * @param mixed $expected
 	 */
 	public function testEvaluateExpression($expression, array $variables, $expected) {
-		$renderingContext = new RenderingContext();
+		$view = new TemplateView();
+		$renderingContext = new RenderingContext($view);
 		$renderingContext->setVariableProvider(new StandardVariableProvider($variables));
 		$result = MathExpressionNode::evaluateExpression($renderingContext, $expression, array());
 		$this->assertEquals($expected, $result);

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class TernaryExpressionNodeTest
@@ -23,7 +24,8 @@ class TernaryExpressionNodeTest extends UnitTestCase {
 	 * @param mixed $expected
 	 */
 	public function testEvaluateExpression($expression, array $variables, $expected) {
-		$renderingContext = new RenderingContext();
+		$view = new TemplateView();
+		$renderingContext = new RenderingContext($view);
 		$renderingContext->setVariableProvider(new StandardVariableProvider($variables));
 		$result = TernaryExpressionNode::evaluateExpression($renderingContext, $expression, array());
 		$this->assertEquals($expected, $result);

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -8,7 +8,9 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for NumericNode
@@ -17,12 +19,21 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 class NumericNodeTest extends UnitTestCase {
 
 	/**
+	 * @var RenderingContext
+	 */
+	protected $renderingContext;
+
+	public function setUp() {
+		$this->renderingContext = new RenderingContextFixture();
+	}
+
+	/**
 	 * @test
 	 */
 	public function renderReturnsProperIntegerGivenInConstructor() {
 		$string = '1';
 		$node = new NumericNode($string);
-		$this->assertEquals($node->evaluate($this->getMock(RenderingContext::class)), 1, 'The rendered value of a numeric node does not match the string given in the constructor.');
+		$this->assertEquals($node->evaluate($this->renderingContext), 1, 'The rendered value of a numeric node does not match the string given in the constructor.');
 	}
 
 	/**
@@ -31,7 +42,7 @@ class NumericNodeTest extends UnitTestCase {
 	public function renderReturnsProperFloatGivenInConstructor() {
 		$string = '1.1';
 		$node = new NumericNode($string);
-		$this->assertEquals($node->evaluate($this->getMock(RenderingContext::class)), 1.1, 'The rendered value of a numeric node does not match the string given in the constructor.');
+		$this->assertEquals($node->evaluate($this->renderingContext), 1.1, 'The rendered value of a numeric node does not match the string given in the constructor.');
 	}
 
 	/**

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for RootNode
@@ -20,9 +21,10 @@ class RootNodeTest extends UnitTestCase {
 	 * @test
 	 */
 	public function testEvaluateCallsEvaluateChildNodes() {
+		$view = new TemplateView();
 		$subject = $this->getMock(RootNode::class, array('evaluateChildNodes'));
 		$subject->expects($this->once())->method('evaluateChildNodes');
-		$subject->evaluate(new RenderingContext());
+		$subject->evaluate(new RenderingContext($view));
 	}
 
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -7,7 +7,9 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
  */
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for TextNode
@@ -20,7 +22,9 @@ class TextNodeTest extends UnitTestCase {
 	public function renderReturnsSameStringAsGivenInConstructor() {
 		$string = 'I can work quite effectively in a train!';
 		$node = new TextNode($string);
-		$this->assertEquals($node->evaluate($this->getMock('TYPO3Fluid\Fluid\Core\Rendering\RenderingContext')), $string, 'The rendered string of a text node is not the same as the string given in the constructor.');
+		$view = new TemplateView();
+		$renderingContext = new RenderingContext($view);
+		$this->assertEquals($node->evaluate($renderingContext), $string, 'The rendered string of a text node is not the same as the string given in the constructor.');
 	}
 
 	/**

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -16,6 +16,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\Fixtures\ChildNodeAccessFacetViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for \TYPO3Fluid\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode
@@ -41,7 +42,8 @@ class ViewHelperNodeTest extends UnitTestCase {
 	 * Setup fixture
 	 */
 	public function setUp() {
-		$this->renderingContext = new RenderingContext();
+		$view = new TemplateView();
+		$this->renderingContext = new RenderingContext($view);
 
 		$this->templateVariableContainer = $this->getMockBuilder(StandardVariableProvider::class)
 			->disableOriginalConstructor()->getMock();
@@ -57,12 +59,11 @@ class ViewHelperNodeTest extends UnitTestCase {
 	public function constructorSetsViewHelperAndArguments() {
 		$viewHelper = $this->getMock(AbstractViewHelper::class);
 		$arguments = array('then' => 'test');
-		$resolver = new ViewHelperResolver();
 		/** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $viewHelperNode */
 		$viewHelperNode = $this->getAccessibleMock(
 			ViewHelperNode::class,
 			array('dummy'),
-			array($resolver, 'f', 'if', $arguments, new ParsingState())
+			array($this->renderingContext, 'f', 'if', $arguments, new ParsingState())
 		);
 
 		$this->assertEquals($arguments, $viewHelperNode->_get('arguments'));
@@ -73,13 +74,12 @@ class ViewHelperNodeTest extends UnitTestCase {
 	 */
 	public function testEvaluateCallsInvoker() {
 		$resolver = $this->getMock(ViewHelperResolver::class, array('resolveViewHelperInvoker'));
-		$invoker = $this->getMock(ViewHelperInvoker::class, array('invoke'), array($resolver));
-		$resolver->expects($this->once())->method('resolveViewHelperInvoker')->willReturn($invoker);
+		$invoker = $this->getMock(ViewHelperInvoker::class, array('invoke'));
 		$invoker->expects($this->once())->method('invoke')->willReturn('test');
-		$node = new ViewHelperNode($resolver, 'f', 'count', array(), new ParsingState());
-		$context = new RenderingContext();
-		$context->setViewHelperResolver($resolver);
-		$result = $node->evaluate($context);
+		$this->renderingContext->setViewHelperResolver($resolver);
+		$this->renderingContext->setViewHelperInvoker($invoker);
+		$node = new ViewHelperNode($this->renderingContext, 'f', 'count', array(), new ParsingState());
+		$result = $node->evaluate($this->renderingContext);
 		$this->assertEquals('test', $result);
 	}
 

--- a/tests/Unit/Core/Rendering/RenderingContextFixture.php
+++ b/tests/Unit/Core/Rendering/RenderingContextFixture.php
@@ -1,132 +1,107 @@
 <?php
-namespace TYPO3Fluid\Fluid\Core\Rendering;
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
 
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
 
-use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\CastingExpressionNode;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode;
+use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
-use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
-use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
-use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
- * The rendering context that contains useful information during rendering time of a Fluid template
+ * Class RenderingContextFixture
  */
-class RenderingContext implements RenderingContextInterface {
+class RenderingContextFixture implements RenderingContextInterface {
 
 	/**
-	 * Template Variable Container. Contains all variables available through object accessors in the template
-	 *
 	 * @var VariableProviderInterface
 	 */
-	protected $variableProvider;
+	public $variableProvider;
 
 	/**
-	 * ViewHelper Variable Container
-	 *
 	 * @var ViewHelperVariableContainer
 	 */
-	protected $viewHelperVariableContainer;
+	public $viewHelperVariableContainer;
 
 	/**
 	 * @var ViewHelperResolver
 	 */
-	protected $viewHelperResolver;
+	public $viewHelperResolver;
 
 	/**
 	 * @var ViewHelperInvoker
 	 */
-	protected $viewHelperInvoker;
-
-	/**
-	 * @var TemplatePaths
-	 */
-	protected $templatePaths;
-
-	/**
-	 * @var string
-	 */
-	protected $controllerName;
-
-	/**
-	 * @var string
-	 */
-	protected $controllerAction;
-
-	/**
-	 * @var ViewInterface
-	 */
-	protected $view;
+	public $viewHelperInvoker;
 
 	/**
 	 * @var TemplateParser
 	 */
-	protected $templateParser;
+	public $templateParser;
 
 	/**
 	 * @var TemplateCompiler
 	 */
-	protected $templateCompiler;
+	public $templateCompiler;
+
+	/**
+	 * @var TemplatePaths
+	 */
+	public $templatePaths;
 
 	/**
 	 * @var FluidCacheInterface
 	 */
-	protected $cache;
+	public $cache;
 
 	/**
 	 * @var TemplateProcessorInterface[]
 	 */
-	protected $templateProcessors = array();
+	public $templateProcessors = array();
 
 	/**
-	 * List of class names implementing ExpressionNodeInterface
-	 * which will be consulted when an expression does not match
-	 * any built-in parser expression types.
-	 *
+	 * @var array
+	 */
+	public $expressionNodeTypes = array();
+
+	/**
 	 * @var string
 	 */
-	protected $expressionNodeTypes = array(
-		CastingExpressionNode::class,
-		MathExpressionNode::class,
-		TernaryExpressionNode::class,
-	);
+	public $controllerName = 'Default';
+
+	/**
+	 * @var string
+	 */
+	public $controllerAction = 'Default';
+
+	/**
+	 * @var boolean
+	 */
+	public $cacheDisabled = FALSE;
 
 	/**
 	 * Constructor
-	 *
-	 * Constructing a RenderingContext should result in an object containing instances
-	 * in all properties of the object. Subclassing RenderingContext allows changing the
-	 * types of instances that are created.
-	 *
-	 * Setters are used to fill the object instances. Some setters will call the
-	 * setRenderingContext() method (convention name) to provide the instance that is
-	 * created with an instance of the "parent" RenderingContext.
 	 */
-	public function __construct(ViewInterface $view) {
-		$this->view = $view;
-		$this->setTemplateParser(new TemplateParser());
-		$this->setTemplateCompiler(new TemplateCompiler());
-		$this->setTemplatePaths(new TemplatePaths());
-		$this->setTemplateProcessors(array(new NamespaceDetectionTemplateProcessor()));
-		$this->setViewHelperResolver(new ViewHelperResolver());
-		$this->setViewHelperInvoker(new ViewHelperInvoker());
-		$this->setViewHelperVariableContainer(new ViewHelperVariableContainer());
-		$this->setVariableProvider(new StandardVariableProvider());
+	public function __construct() {
+		$mockBuilder = new \PHPUnit_Framework_MockObject_Generator();
+		$this->variableProvider = $mockBuilder->getMock(VariableProviderInterface::class);
+		$this->viewHelperVariableContainer = $mockBuilder->getMock(ViewHelperVariableContainer::class, array('dummy'));
+		$this->viewHelperResolver = $mockBuilder->getMock(ViewHelperResolver::class, array('dummy'));
+		$this->viewHelperInvoker = $mockBuilder->getMock(ViewHelperInvoker::class, array('dummy'));
+		$this->templateParser = $mockBuilder->getMock(TemplateParser::class, array('dummy'));
+		$this->templateCompiler = $mockBuilder->getMock(TemplateCompiler::class, array('dummy'));
+		$this->templatePaths = $mockBuilder->getMock(TemplatePaths::class, array('dummy'));
+		$this->cache = $mockBuilder->getMock(FluidCacheInterface::class);
 	}
 
 	/**
@@ -140,12 +115,28 @@ class RenderingContext implements RenderingContextInterface {
 	}
 
 	/**
+	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
+	 */
+	public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer) {
+		$this->viewHelperVariableContainer = $viewHelperVariableContainer;
+	}
+
+	/**
 	 * Get the template variable container
 	 *
 	 * @return VariableProviderInterface The Template Variable Container
 	 */
 	public function getVariableProvider() {
 		return $this->variableProvider;
+	}
+
+	/**
+	 * Get the ViewHelperVariableContainer
+	 *
+	 * @return ViewHelperVariableContainer
+	 */
+	public function getViewHelperVariableContainer() {
+		return $this->viewHelperVariableContainer;
 	}
 
 	/**
@@ -179,40 +170,6 @@ class RenderingContext implements RenderingContextInterface {
 	}
 
 	/**
-	 * @return TemplatePaths
-	 */
-	public function getTemplatePaths() {
-		return $this->templatePaths;
-	}
-
-	/**
-	 * @param TemplatePaths $templatePaths
-	 * @return void
-	 */
-	public function setTemplatePaths(TemplatePaths $templatePaths) {
-		$this->templatePaths = $templatePaths;
-	}
-
-	/**
-	 * Set the ViewHelperVariableContainer
-	 *
-	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
-	 * @return void
-	 */
-	public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer) {
-		$this->viewHelperVariableContainer = $viewHelperVariableContainer;
-	}
-
-	/**
-	 * Get the ViewHelperVariableContainer
-	 *
-	 * @return ViewHelperVariableContainer
-	 */
-	public function getViewHelperVariableContainer() {
-		return $this->viewHelperVariableContainer;
-	}
-
-	/**
 	 * Inject the Template Parser
 	 *
 	 * @param TemplateParser $templateParser The template parser
@@ -220,7 +177,6 @@ class RenderingContext implements RenderingContextInterface {
 	 */
 	public function setTemplateParser(TemplateParser $templateParser) {
 		$this->templateParser = $templateParser;
-		$this->templateParser->setRenderingContext($this);
 	}
 
 	/**
@@ -236,7 +192,6 @@ class RenderingContext implements RenderingContextInterface {
 	 */
 	public function setTemplateCompiler(TemplateCompiler $templateCompiler) {
 		$this->templateCompiler = $templateCompiler;
-		$this->templateCompiler->setRenderingContext($this);
 	}
 
 	/**
@@ -244,6 +199,21 @@ class RenderingContext implements RenderingContextInterface {
 	 */
 	public function getTemplateCompiler() {
 		return $this->templateCompiler;
+	}
+
+	/**
+	 * @return TemplatePaths
+	 */
+	public function getTemplatePaths() {
+		return $this->templatePaths;
+	}
+
+	/**
+	 * @param TemplatePaths $templatePaths
+	 * @return void
+	 */
+	public function setTemplatePaths(TemplatePaths $templatePaths) {
+		$this->templatePaths = $templatePaths;
 	}
 
 	/**
@@ -267,7 +237,7 @@ class RenderingContext implements RenderingContextInterface {
 	 * @return boolean
 	 */
 	public function isCacheEnabled() {
-		return $this->cache instanceof FluidCacheInterface;
+		return !$this->cacheDisabled;
 	}
 
 	/**
@@ -279,9 +249,6 @@ class RenderingContext implements RenderingContextInterface {
 	 */
 	public function setTemplateProcessors(array $templateProcessors) {
 		$this->templateProcessors = $templateProcessors;
-		foreach ($this->templateProcessors as $templateProcessor) {
-			$templateProcessor->setRenderingContext($this);
-		}
 	}
 
 	/**
@@ -292,7 +259,7 @@ class RenderingContext implements RenderingContextInterface {
 	}
 
 	/**
-	 * @return string
+	 * @return array
 	 */
 	public function getExpressionNodeTypes() {
 		return $this->expressionNodeTypes;
@@ -312,10 +279,7 @@ class RenderingContext implements RenderingContextInterface {
 	 * @return Configuration
 	 */
 	public function buildParserConfiguration() {
-		$parserConfiguration = new Configuration();
-		$escapeInterceptor = new Escape();
-		$parserConfiguration->addEscapingInterceptor($escapeInterceptor);
-		return $parserConfiguration;
+		return new Configuration();
 	}
 
 	/**
@@ -330,7 +294,7 @@ class RenderingContext implements RenderingContextInterface {
 	 * @return void
 	 */
 	public function setControllerName($controllerName) {
-		$this->controllerName = $controllerName;
+		$this->controllerName;
 	}
 
 	/**

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -12,6 +12,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for ParsingState
@@ -25,7 +26,7 @@ class RenderingContextTest extends UnitTestCase {
 	protected $renderingContext;
 
 	public function setUp() {
-		$this->renderingContext = new RenderingContext();
+		$this->renderingContext = new RenderingContextFixture();
 	}
 
 	/**
@@ -34,7 +35,8 @@ class RenderingContextTest extends UnitTestCase {
 	 * @dataProvider getPropertyNameTestValues
 	 */
 	public function testGetter($property, $value) {
-		$subject = $this->getAccessibleMock(RenderingContext::class, array('dummy'));
+		$view = new TemplateView();
+		$subject = $this->getAccessibleMock(RenderingContext::class, array('dummy'), array($view));
 		$subject->_set($property, $value);
 		$getter = 'get' . ucfirst($property);
 		$this->assertSame($value, $subject->$getter());
@@ -46,7 +48,8 @@ class RenderingContextTest extends UnitTestCase {
 	 * @dataProvider getPropertyNameTestValues
 	 */
 	public function testSetter($property, $value) {
-		$subject = new RenderingContext();
+		$view = new TemplateView();
+		$subject = new RenderingContext($view);
 		$setter = 'set' . ucfirst($property);
 		$subject->$setter($value);
 		$this->assertAttributeSame($value, $property, $subject);
@@ -78,7 +81,8 @@ class RenderingContextTest extends UnitTestCase {
 	 */
 	public function viewHelperVariableContainerCanBeReadCorrectly() {
 		$viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
-		$this->renderingContext->injectViewHelperVariableContainer($viewHelperVariableContainer);
+		$this->renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
 		$this->assertSame($viewHelperVariableContainer, $this->renderingContext->getViewHelperVariableContainer());
 	}
+
 }

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -22,7 +22,7 @@ class StandardVariableProviderTest extends UnitTestCase {
 	/**
 	 */
 	public function setUp() {
-		$this->variableProvider = new StandardVariableProvider();
+		$this->variableProvider = $this->getMock(StandardVariableProvider::class, array('dummy'));
 	}
 
 	/**

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -18,6 +18,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for AbstractViewHelper
@@ -208,9 +209,10 @@ class AbstractViewHelperTest extends UnitTestCase {
 		$templateVariableContainer = $this->getMock(StandardVariableProvider::class);
 		$viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
 
-		$renderingContext = new RenderingContext();
+		$view = new TemplateView();
+		$renderingContext = new RenderingContext($view);
 		$renderingContext->setVariableProvider($templateVariableContainer);
-		$renderingContext->injectViewHelperVariableContainer($viewHelperVariableContainer);
+		$renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
 
 		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('prepareArguments'), array(), '', FALSE);
 
@@ -315,8 +317,10 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function testCompileReturnsAndAssignsExpectedPhpCode() {
+		$view = new TemplateView();
+		$context = new RenderingContext($view);
 		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('dummy'), array(), '', FALSE);
-		$node = new ViewHelperNode(new ViewHelperResolver(), 'f', 'comment', array(), new ParsingState());
+		$node = new ViewHelperNode($context, 'f', 'comment', array(), new ParsingState());
 		$init = '';
 		$compiler = new TemplateCompiler();
 		$result = $viewHelper->compile('foobar', 'baz', $init, $node, $compiler);

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -11,6 +11,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\CountViewHelper;
 
 /**
@@ -19,9 +20,10 @@ use TYPO3Fluid\Fluid\ViewHelpers\CountViewHelper;
 class ViewHelperInvokerTest extends UnitTestCase {
 
 	public function testInvokeViewHelper() {
+		$view = new TemplateView();
 		$resolver = new ViewHelperResolver();
 		$invoker = new ViewHelperInvoker($resolver);
-		$renderingContext = new RenderingContext();
+		$renderingContext = new RenderingContext($view);
 		$result = $invoker->invoke(CountViewHelper::class, array('subject' => array('foo')), $renderingContext);
 		$this->assertEquals(1, $result);
 	}

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -91,4 +91,25 @@ class ViewHelperResolverTest extends UnitTestCase {
 		), 'namespaces', $resolver);
 	}
 
+	/**
+	 * @test
+	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
+	 */
+	public function registerNamespaceThrowsExceptionIfOneAliasIsRegisteredWithDifferentPhpNamespaces() {
+		$resolver = new ViewHelperResolver();
+		$resolver->registerNamespace('foo', 'Some\Namespace');
+		$resolver->registerNamespace('foo', 'Some\Other\Namespace');
+	}
+
+	/**
+	 * @test
+	 */
+	public function registerNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace() {
+		$resolver = new ViewHelperResolver();
+		$resolver->registerNamespace('foo', 'Some\Namespace');
+		$this->assertAttributeEquals(array('f' => 'TYPO3Fluid\Fluid\ViewHelpers', 'foo' => 'Some\Namespace'), 'namespaces', $resolver);
+		$resolver->registerNamespace('foo', 'Some\Namespace');
+		$this->assertAttributeEquals(array('f' => 'TYPO3Fluid\Fluid\ViewHelpers', 'foo' => 'Some\Namespace'), 'namespaces', $resolver);
+	}
+
 }

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -91,7 +91,7 @@ class ViewHelperVariableContainerTest extends UnitTestCase {
 	 * @test
 	 */
 	public function viewCanBeReadOutAgain() {
-		$view = $this->getMockForAbstractClass(AbstractTemplateView::class, array(new TemplatePaths()));
+		$view = $this->getMockForAbstractClass(AbstractTemplateView::class);
 		$this->viewHelperVariableContainer->setView($view);
 		$this->assertSame($view, $this->viewHelperVariableContainer->getView());
 	}

--- a/tests/Unit/ViewHelpers/Format/CdataViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/CdataViewHelperTest.php
@@ -7,6 +7,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Format;
  */
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use TYPO3Fluid\Fluid\ViewHelpers\Format\CdataViewHelper;
 
@@ -25,7 +26,7 @@ class CdataViewHelperTest extends ViewHelperBaseTestcase {
 		$instance = new CdataViewHelper();
 		$instance->initializeArguments();
 		$instance->setArguments($arguments);
-		$instance->setRenderingContext(new RenderingContext());
+		$instance->setRenderingContext(new RenderingContextFixture());
 		$instance->setRenderChildrenClosure(function() use ($tagContent) { return $tagContent; });
 		$this->assertEquals($expected, $instance->render());
 	}

--- a/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
@@ -12,6 +12,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\ViewHelpers\LayoutViewHelper;
 
 /**
@@ -46,7 +47,7 @@ class LayoutViewHelperTest extends ViewHelperBaseTestcase {
 	public function testPostParseEvent(array $arguments, $expectedLayoutName) {
 		$instance = new LayoutViewHelper();
 		$variableContainer = new StandardVariableProvider();
-		$node = new ViewHelperNode(new ViewHelperResolver(), 'f', 'layout', $arguments, new ParsingState());
+		$node = new ViewHelperNode(new RenderingContextFixture(), 'f', 'layout', $arguments, new ParsingState());
 		$result = LayoutViewHelper::postParseEvent($node, $arguments, $variableContainer);
 		$this->assertNull($result);
 		$this->assertEquals($expectedLayoutName, $variableContainer->get('layoutName'));

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -8,6 +8,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper;
@@ -31,15 +32,14 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase {
 	 * @return void
 	 */
 	public function setUp() {
+		parent::setUp();
 		$this->subject = $this->getMock(RenderViewHelper::class, array('renderChildren'));
-		$renderingContext = new RenderingContext();
-		$paths = $this->getMock(TemplatePaths::class, array('sanitizePath'));
-		$paths->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
-		$viewHelperVariableContainer = new ViewHelperVariableContainer();
-		$this->view = $this->getMock(TemplateView::class, array('renderPartial', 'renderSection'), array($paths, $renderingContext));
-		$viewHelperVariableContainer->setView($this->view);
-		$renderingContext->injectViewHelperVariableContainer($viewHelperVariableContainer);
-		$this->subject->setRenderingContext($renderingContext);
+		$this->view = $this->getMock(TemplateView::class, array('renderPartial', 'renderSection'));
+		$this->view->setRenderingContext($this->renderingContext);
+		$container = new ViewHelperVariableContainer();
+		$container->setView($this->view);
+		$this->renderingContext->setViewHelperVariableContainer($container);
+		$this->subject->setRenderingContext($this->renderingContext);
 	}
 
 	/**

--- a/tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -13,7 +13,9 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Base test class for testing view helpers
@@ -61,9 +63,9 @@ abstract class ViewHelperBaseTestcase extends UnitTestCase {
 	public function setUp() {
 		$this->viewHelperVariableContainer = new ViewHelperVariableContainer();
 		$this->templateVariableContainer = new StandardVariableProvider();
-		$this->renderingContext = new RenderingContext();
+		$this->renderingContext = new RenderingContextFixture();
 		$this->renderingContext->setVariableProvider($this->templateVariableContainer);
-		$this->renderingContext->injectViewHelperVariableContainer($this->viewHelperVariableContainer);
+		$this->renderingContext->setViewHelperVariableContainer($this->viewHelperVariableContainer);
 	}
 
 	/**


### PR DESCRIPTION
#### Status: done
This change:

* Wraps all essential context-like classes into RenderingContext
* Removes those same context-like classes from various instances which now receive a RenderingContext

Using the RenderingContext is ideal since it is available both during parsing and once templates are compiled, and can be replaced at any time without invalidating compiled templates.

The change breaks code which depends on the following usages:

* getViewHelperInvoker() on ViewHelperResolver (moved to RenderingContext)
* getExpressionNodeTypes on ViewHelperResolver (moved to RenderingContext)
* resolveViewHelperInvoker() by ViewHelper class name (moved to RenderingContext, no class name gets passed)
* explicit calls to injectViewHelperVariableContainer on RenderingContext (renamed to setViewHelperVariableContainer for consistency in interface)