### PR TITLE
[FEATURE] Chained VariableProvider

### DIFF
--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -1,0 +1,98 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Variables;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Class ChainedVariableProvider
+ *
+ * Allows chainging any number of prioritised VariableProviders
+ * to be consulted whenever a variable is requested. First
+ * VariableProvider to return a value "wins".
+ */
+class ChainedVariableProvider extends StandardVariableProvider implements VariableProviderInterface {
+
+	/**
+	 * @var VariableProviderInterface[]
+	 */
+	protected $variableProviders = array();
+
+	/**
+	 * @param VariableProviderInterface $variableProviders
+	 */
+	public function __construct(array $variableProviders = array()) {
+		$this->variableProviders = $variableProviders;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAll() {
+		$merged = array();
+		foreach (array_reverse($this->variableProviders) as $provider) {
+			$merged = array_replace_recursive($merged, $provider->getAll());
+		}
+		return array_merge($merged, $this->variables);
+	}
+
+	/**
+	 * @param string $identifier
+	 * @return mixed
+	 */
+	public function get($identifier) {
+		if (array_key_exists($identifier, $this->variables)) {
+			return $this->variables[$identifier];
+		}
+		foreach ($this->variableProviders as $provider) {
+			$value = $provider->get($identifier);
+			if ($value !== NULL) {
+				return $value;
+			}
+		}
+		return NULL;
+	}
+
+	/**
+	 * @param string $path
+	 * @param array $accessors
+	 * @return mixed|null
+	 */
+	public function getByPath($path, array $accessors = array()) {
+		$value = VariableExtractor::extract($this->variables, $path, $accessors);
+		if ($value !== NULL) {
+			return $value;
+		}
+		foreach ($this->variableProviders as $provider) {
+			$value = $provider->getByPath($path, $accessors);
+			if ($value !== NULL) {
+				return $value;
+			}
+		}
+		return NULL;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAllIdentifiers() {
+		$merged = parent::getAllIdentifiers();
+		foreach ($this->variableProviders as $provider) {
+			$merged = array_replace_recursive($merged, $provider->getAllIdentifiers());
+		}
+		return array_values(array_unique($merged));
+	}
+
+	/**
+	 * @param array $variables
+	 * @return ChainedVariableProvider
+	 */
+	public function getScopeCopy(array $variables) {
+		$clone = clone $this;
+		$clone->setSource($variables);
+		return $clone;
+	}
+
+}

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Variables\ChainedVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+
+/**
+ * Testcase for ChainedVariableContainer
+ */
+class ChainedVariableProviderTest extends UnitTestCase {
+
+	/**
+	 * @param array $local
+	 * @param VariableProviderInterface $chain
+	 * @param string $path
+	 * @param mixed $expected
+	 * @dataProvider getGetTestValues
+	 */
+	public function testGet(array $local, array $chain, $path, $expected) {
+		$chainedProvider = new ChainedVariableProvider($chain);
+		$chainedProvider->setSource($local);
+		$this->assertEquals($expected, $chainedProvider->get($path));
+	}
+
+	/**
+	 * @param array $local
+	 * @param VariableProviderInterface $chain
+	 * @param string $path
+	 * @param mixed $expected
+	 * @dataProvider getGetTestValues
+	 */
+	public function testGetByPath(array $local, array $chain, $path, $expected) {
+		$chainedProvider = new ChainedVariableProvider($chain);
+		$chainedProvider->setSource($local);
+		$this->assertEquals($expected, $chainedProvider->getByPath($path));
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getGetTestValues() {
+		$a = new StandardVariableProvider(array('a' => 'a'));
+		$b = new StandardVariableProvider(array('a' => 'b', 'b' => 'b'));
+
+		return array(
+			array(array('a' => 'local'), array($a, $b), 'a', 'local'),
+			array(array(), array($a, $b), 'a', 'a'),
+			array(array(), array($a, $b), 'b', 'b'),
+			array(array(), array($b, $a), 'a', 'b'),
+			array(array(), array($b, $a), 'b', 'b'),
+			array(array(), array($b, $a), 'notfound', NULL),
+		);
+	}
+
+	/**
+	 * @param array $local
+	 * @param VariableProviderInterface $chain
+	 * @param mixed $expected
+	 * @dataProvider getGetAllTestValues
+	 */
+	public function testGetAll(array $local, array $chain, $expected) {
+		$chainedProvider = new ChainedVariableProvider($chain);
+		$chainedProvider->setSource($local);
+		$this->assertEquals($expected, $chainedProvider->getAll());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getGetAllTestValues() {
+		$a = new StandardVariableProvider(array('a' => 'a'));
+		$b = new StandardVariableProvider(array('a' => 'b', 'b' => 'b'));
+
+		return array(
+			array(array('a' => 'local'), array($a, $b), array('a' => 'local', 'b' => 'b')),
+			array(array(), array($a, $b), array('a' => 'a', 'b' => 'b')),
+			array(array(), array($a, $b), array('a' => 'a', 'b' => 'b')),
+			array(array(), array($b, $a), array('a' => 'b', 'b' => 'b')),
+		);
+	}
+
+	/**
+	 * @param array $local
+	 * @param VariableProviderInterface $chain
+	 * @param mixed $expected
+	 * @dataProvider getGetAllIdentifiersTestValues
+	 */
+	public function testGetAllIdentifiers(array $local, array $chain, $expected) {
+		$chainedProvider = new ChainedVariableProvider($chain);
+		$chainedProvider->setSource($local);
+		$this->assertEquals($expected, $chainedProvider->getAllIdentifiers());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getGetAllIdentifiersTestValues() {
+		$a = new StandardVariableProvider(array('a' => 'a'));
+		$b = new StandardVariableProvider(array('a' => 'b', 'b' => 'b'));
+
+		return array(
+			array(array('a' => 'local'), array($a, $b), array('a', 'b')),
+			array(array(), array($a, $b), array('a', 'b')),
+			array(array(), array($a, $b), array('a', 'b')),
+			array(array(), array($b, $a), array('a', 'b')),
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function testGetScopeCopy() {
+		$chain = array(new StandardVariableProvider(), new StandardVariableProvider());
+		$chainedProvider = new ChainedVariableProvider($chain);
+		$copy = $chainedProvider->getScopeCopy(array());
+		$this->assertAttributeSame($chain, 'variableProviders', $copy);
+	}
+}


### PR DESCRIPTION
Allows any number of VariableProviders to be chained in another VariableProvider, making the container consult each chained VariableProvider until a value is found. Different types of VariableProviders can be combined, e.g. a standard array-based instance combined with a VariableProvider that reads a JSON file.