### PR TITLE
[TASK] Streamline names and behaviors in namespace registration

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -162,11 +162,7 @@ public function hasLayout() {
 return %s;
 }
 public function addCompiledNamespaces(\TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface \$renderingContext) {
-\$namespaces = %s;
-\$resolver = \$renderingContext->getViewHelperResolver();
-foreach (\$namespaces as \$namespace => \$phpNamespace) {
-\$resolver->registerNamespace(\$namespace, \$phpNamespace);
-}
+\$renderingContext->getViewHelperResolver()->addNamespaces(%s);
 }
 
 %s

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -100,7 +100,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface 
 				$viewHelperNamespace = $this->unquoteString($namespaceMatch[2]);
 				$phpNamespace = $viewHelperResolver->resolvePhpNamespaceFromFluidNamespace($viewHelperNamespace);
 				if (stristr($phpNamespace, '/') === FALSE) {
-					$viewHelperResolver->registerNamespace($namespaceMatch[1], $phpNamespace);
+					$viewHelperResolver->addNamespace($namespaceMatch[1], $phpNamespace);
 				}
 			}
 		}
@@ -111,7 +111,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface 
 			if (strlen($namespace) === 0) {
 				$namespace = NULL;
 			}
-			$viewHelperResolver->registerNamespace($identifier, $namespace);
+			$viewHelperResolver->addNamespace($identifier, $namespace);
 		}
 	}
 

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -18,20 +18,19 @@ class ViewHelperResolverTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function testRegisterNamespaceRecordsNamespace() {
+	public function testAddNamespaceWithStringRecordsNamespace() {
 		$resolver = new ViewHelperResolver();
-		$resolver->registerNamespace('t', 'test');
-		$this->assertAttributeContains('test', 'namespaces', $resolver);
+		$resolver->addNamespace('t', 'test');
+		$this->assertAttributeContains(array('test'), 'namespaces', $resolver);
 	}
 
 	/**
 	 * @test
 	 */
-	public function testRegisterNamespaceThrowsExceptionOnReRegistration() {
+	public function testAddNamespaceWithArrayRecordsNamespace() {
 		$resolver = new ViewHelperResolver();
-		$resolver->registerNamespace('t', 'test');
-		$this->setExpectedException(Exception::class);
-		$resolver->registerNamespace('t', 'test2');
+		$resolver->addNamespace('t', array('test'));
+		$this->assertAttributeContains(array('test'), 'namespaces', $resolver);
 	}
 
 	/**
@@ -39,8 +38,17 @@ class ViewHelperResolverTest extends UnitTestCase {
 	 */
 	public function testSetNamespacesSetsNamespaces() {
 		$resolver = new ViewHelperResolver();
+		$resolver->setNamespaces(array('t' => array('test')));
+		$this->assertAttributeEquals(array('t' => array('test')), 'namespaces', $resolver);
+	}
+
+	/**
+	 * @test
+	 */
+	public function testSetNamespacesSetsNamespacesAndConvertsStringNamespaceToArray() {
+		$resolver = new ViewHelperResolver();
 		$resolver->setNamespaces(array('t' => 'test'));
-		$this->assertAttributeEquals(array('t' => 'test'), 'namespaces', $resolver);
+		$this->assertAttributeEquals(array('t' => array('test')), 'namespaces', $resolver);
 	}
 
 	/**
@@ -80,9 +88,9 @@ class ViewHelperResolverTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function testExtendNamespace() {
+	public function testAddNamespace() {
 		$resolver = $this->getMock('TYPO3Fluid\\Fluid\\Core\\ViewHelper\\ViewHelperResolver', array('dummy'));
-		$resolver->extendNamespace('f', 'Foo\\Bar');
+		$resolver->addNamespace('f', 'Foo\\Bar');
 		$this->assertAttributeEquals(array(
 			'f' => array(
 				'TYPO3Fluid\\Fluid\\ViewHelpers',
@@ -93,23 +101,13 @@ class ViewHelperResolverTest extends UnitTestCase {
 
 	/**
 	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
 	 */
-	public function registerNamespaceThrowsExceptionIfOneAliasIsRegisteredWithDifferentPhpNamespaces() {
+	public function addNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace() {
 		$resolver = new ViewHelperResolver();
-		$resolver->registerNamespace('foo', 'Some\Namespace');
-		$resolver->registerNamespace('foo', 'Some\Other\Namespace');
-	}
-
-	/**
-	 * @test
-	 */
-	public function registerNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace() {
-		$resolver = new ViewHelperResolver();
-		$resolver->registerNamespace('foo', 'Some\Namespace');
-		$this->assertAttributeEquals(array('f' => 'TYPO3Fluid\Fluid\ViewHelpers', 'foo' => 'Some\Namespace'), 'namespaces', $resolver);
-		$resolver->registerNamespace('foo', 'Some\Namespace');
-		$this->assertAttributeEquals(array('f' => 'TYPO3Fluid\Fluid\ViewHelpers', 'foo' => 'Some\Namespace'), 'namespaces', $resolver);
+		$resolver->addNamespace('foo', 'Some\Namespace');
+		$this->assertAttributeEquals(array('f' => array('TYPO3Fluid\Fluid\ViewHelpers'), 'foo' => array('Some\Namespace')), 'namespaces', $resolver);
+		$resolver->addNamespace('foo', 'Some\Namespace');
+		$this->assertAttributeEquals(array('f' => array('TYPO3Fluid\Fluid\ViewHelpers'), 'foo' => array('Some\Namespace')), 'namespaces', $resolver);
 	}
 
 }


### PR DESCRIPTION
This change affects ViewHelperResolver and:

* Renames `registerNamespace` to `addNamespace` since it now truly does add, also when namespace exists.
* Removes the thrown exception "Namespace is already registered and should not be re-registered".
* Changes behavior to extend namespace when called multiple times with different PHP namespaces.
* Documents many public methods that were previously low on docs.
* Adds a shorthand addNamespaces method on ViewHelperResolver so that compiled templates can add all extracted namespaces with a single method call and avoid compiling a loop.