### PR TITLE
[FEATURE] Allow f:alias to create VariableProviders using "src" argument

### DIFF
--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -7,12 +7,12 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  */
 
 /**
- * Class JSONVariableProvider
+ * Class JsonVariableProvider
  *
  * VariableProvider capable of using JSON files
  * and streams as data source.
  */
-class JSONVariableProvider extends StandardVariableProvider implements VariableProviderInterface {
+class JsonVariableProvider extends StandardVariableProvider implements VariableProviderInterface {
 
 	/**
 	 * @var integer

--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -6,14 +6,22 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception as ViewHelperException;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Declares new variables which are aliases of other variables.
  * Takes a "map"-Parameter which is an associative array which defines the shorthand mapping.
  *
- * The variables are only declared inside the <f:alias>...</f:alias>-tag. After the
+ * The variables are only declared inside the ``<f:alias>...</f:alias>``-tag. After the
  * closing tag, all declared variables are removed again.
+ *
+ * External data like JSON can be consumed using the "src" and "as" arguments, optionally
+ * specifying the "type" manually. Both local and external (HTTP or other stream wrapper)
+ * accessible JSON sources can be used - "src" supports local files and URIs alike.
  *
  * = Examples =
  *
@@ -34,6 +42,15 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * depending on {foo.bar.baz}
  * </output>
  *
+ * <code title="VariableProvider with JSON">
+ * <f:alias src="/path/to/file.json" as="json">
+ *   {json.name} at {json.phone}
+ * </f:alias>
+ * <output>
+ *   // If "file.json" contains {"name": "John", "phone": "1-800-FLUID"}:
+ *   John at 1-800-FLUID
+ * </code>
+ *
  * Note: Using this view helper can be a sign of weak architecture. If you end up using it extensively
  * you might want to fine-tune your "view model" (the data you assign to the view).
  *
@@ -47,11 +64,33 @@ class AliasViewHelper extends AbstractViewHelper {
 	protected $escapeOutput = FALSE;
 
 	/**
+	 * @var array
+	 */
+	protected static $sources = array();
+
+	/**
 	 * @return void
 	 */
 	public function initializeArguments() {
 		parent::initializeArguments();
-		$this->registerArgument('map', 'array', 'Array that specifies which variables should be mapped to which alias', TRUE);
+		$this->registerArgument('map', 'array', 'Array that specifies which variables should be mapped to which alias');
+		$this->registerArgument('src', 'mixed', 'Source (file, URL, object, array - depends on "type") containing variables to insert. When used must be combined with "name" argument.');
+		$this->registerArgument('as', 'string', 'Name of template variable which will contain variables read from "src". Required when "src" is used.');
+		$this->registerArgument('type', 'string', 'Type of "src", currently only "json" is supported. Can be specified if the type cannot be detected based on file name of "src".');
+	}
+
+	/**
+	 * @thrpws ParserException
+	 */
+	public function validateArguments() {
+		parent::validateArguments();
+		if ((empty($this->arguments['map']) && empty($this->arguments['src'])) || (!empty($this->arguments['map']) && !empty($this->arguments['src']))) {
+			throw new ParserException('Either "map" or "src" argument must be specified (not both)');
+		} elseif (!empty($this->arguments['src']) && empty($this->arguments['as'])) {
+			throw new ParserException('Argument "src" must be used together with "as" argument');
+		} elseif (!empty($this->arguments['map']) && !empty($this->arguments['as'])) {
+			throw new ParserException('Argument "as" cannot be used together with argument "map" (works with "src" only)');
+		}
 	}
 
 	/**
@@ -61,14 +100,65 @@ class AliasViewHelper extends AbstractViewHelper {
 	 * @api
 	 */
 	public function render() {
-		$map = $this->arguments['map'];
+		return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
+	}
+
+	/**
+	 * @param array $map
+	 * @param callable $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return string
+	 */
+	protected static function renderUsingMap(array $map, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$provider = $renderingContext->getVariableProvider();
 		foreach ($map as $aliasName => $value) {
-			$this->templateVariableContainer->add($aliasName, $value);
+			$provider->add($aliasName, $value);
 		}
-		$output = $this->renderChildren();
+		$output = $renderChildrenClosure();
 		foreach ($map as $aliasName => $value) {
-			$this->templateVariableContainer->remove($aliasName);
+			$provider->remove($aliasName);
 		}
 		return $output;
 	}
+
+	/**
+	 * @param string $source
+	 * @param string|NULL $type
+	 * @return VariableProviderInterface
+	 */
+	protected static function createVariableProviderFromSource($source, $type) {
+		if (empty($type)) {
+			$type = strtolower(pathinfo($source, PATHINFO_EXTENSION));
+			if (empty($type)) {
+				throw new ViewHelperException('The type of source could not be detected - please provide it using the "type" argument');
+			}
+		}
+		$expectedVariableProviderClassName = sprintf('TYPO3Fluid\\Fluid\\Core\\Variables\\%sVariableProvider', ucfirst($type));
+		if (!class_exists($expectedVariableProviderClassName)) {
+			throw new ViewHelperException(sprintf('Induced variable provider class name "%s" does not exist', $expectedVariableProviderClassName));
+		}
+		if (!isset(static::$sources[$source])) {
+			/** @var VariableProviderInterface $provider */
+			static::$sources[$source] = new $expectedVariableProviderClassName();
+			static::$sources[$source]->setSource($source);
+		}
+		return static::$sources[$source];
+	}
+
+	/**
+	 * @param array $arguments
+	 * @param callable $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return string
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$map = array();
+		if (!empty($arguments['map'])) {
+			$map = $arguments['map'];
+		} elseif (!empty($arguments['src'])) {
+			$map = array($arguments['as'] => static::createVariableProviderFromSource($arguments['src'], $arguments['type'])->getAll());
+		}
+		return static::renderUsingMap($map, $renderChildrenClosure, $renderingContext);
+	}
+
 }

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -12,9 +12,9 @@ use TYPO3Fluid\Fluid\Core\Variables\JSONVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 /**
- * Testcase for JSONVariableProvider
+ * Testcase for JsonVariableProvider
  */
-class JSONVariableProviderTest extends UnitTestCase {
+class JsonVariableProviderTest extends UnitTestCase {
 
 	/**
 	 * @var vfsStreamFile
@@ -36,7 +36,7 @@ class JSONVariableProviderTest extends UnitTestCase {
 	 * @param array $expected
 	 */
 	public function testOperability($input, array $expected) {
-		$provider = new JSONVariableProvider();
+		$provider = new JsonVariableProvider();
 		$provider->setSource($input);
 		$this->assertEquals($input, $provider->getSource());
 		$this->assertEquals($expected, $provider->getAll());

--- a/tests/Unit/ViewHelpers/AliasViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/AliasViewHelperTest.php
@@ -6,7 +6,12 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\ViewHelpers\AliasViewHelper;
 
 /**
@@ -19,7 +24,10 @@ class AliasViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function testInitializeArgumentsRegistersExpectedArguments() {
 		$instance = $this->getMock(AliasViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('map', 'array', $this->anything(), TRUE);
+		$instance->expects($this->at(0))->method('registerArgument')->with('map', 'array', $this->anything());
+		$instance->expects($this->at(1))->method('registerArgument')->with('src', 'mixed', $this->anything());
+		$instance->expects($this->at(2))->method('registerArgument')->with('as', 'string', $this->anything());
+		$instance->expects($this->at(3))->method('registerArgument')->with('type', 'string', $this->anything());
 		$instance->initializeArguments();
 	}
 
@@ -28,17 +36,16 @@ class AliasViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function renderAddsSingleValueToTemplateVariableContainerAndRemovesItAfterRendering() {
 		$viewHelper = new AliasViewHelper();
-
+		$viewHelper->setRenderChildrenClosure(function() { return 'foo'; });
+		$arguments = array('map' => array('someAlias' => 'someValue'));
 		$mockViewHelperNode = $this->getMock(
 			ViewHelperNode::class,
-			array('evaluateChildNodes'),
-			array(), '', FALSE
+			array('evaluateChildNodes'), array(new RenderingContextFixture(), 'f', 'alias', $arguments, new ParsingState())
 		);
-		$mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
 
 		$this->injectDependenciesIntoViewHelper($viewHelper);
 		$viewHelper->setViewHelperNode($mockViewHelperNode);
-		$viewHelper->setArguments(array('map' => array('someAlias' => 'someValue')));
+		$viewHelper->setArguments($arguments);
 		$viewHelper->render();
 	}
 
@@ -47,37 +54,71 @@ class AliasViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function renderAddsMultipleValuesToTemplateVariableContainerAndRemovesThemAfterRendering() {
 		$viewHelper = new AliasViewHelper();
-
+		$arguments = array('map' => array('someAlias' => 'someValue', 'someOtherAlias' => 'someOtherValue'));
 		$mockViewHelperNode = $this->getMock(
 			ViewHelperNode::class,
-			array('evaluateChildNodes'),
-			array(), '', FALSE
+			array('evaluateChildNodes'), array(new RenderingContextFixture(), 'f', 'alias', $arguments, new ParsingState())
 		);
-		$mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
 
 		$this->injectDependenciesIntoViewHelper($viewHelper);
 		$viewHelper->setViewHelperNode($mockViewHelperNode);
-		$viewHelper->setArguments(array('map' => array('someAlias' => 'someValue', 'someOtherAlias' => 'someOtherValue')));
+		$viewHelper->setArguments($arguments);
 		$viewHelper->render();
 	}
 
 	/**
 	 * @test
 	 */
-	public function renderDoesNotTouchTemplateVariableContainerAndReturnsChildNodesIfMapIsEmpty() {
+	public function testCreatesVariableProvider() {
 		$viewHelper = new AliasViewHelper();
-
+		$arguments = array('map' => array(), 'src' => '{"foo": "bar"}', 'as' => 'baz', 'type' => 'json');
+		$context = new RenderingContextFixture();
+		$provider = $this->getMock(StandardVariableProvider::class, array('add', 'remove'));
+		$provider->expects($this->once())->method('add')->with('baz', $this->anything());
+		$provider->expects($this->once())->method('remove')->with('baz');
+		$context->setVariableProvider($provider);
 		$mockViewHelperNode = $this->getMock(
 			ViewHelperNode::class,
-			array('evaluateChildNodes'), array(), '',
-			FALSE
+			array('dummy'), array($context, 'f', 'alias', $arguments, new ParsingState())
 		);
-		$mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
+
+		$viewHelper->setRenderingContext($context);
+		$viewHelper->setViewHelperNode($mockViewHelperNode);
+		$viewHelper->setArguments($arguments);
+		$viewHelper->render();
+	}
+
+	/**
+	 * @param array $arguments
+	 * @test
+	 * @dataProvider getExceptionTestValues
+	 */
+	public function testThrowsExceptionOnInvalidArguments(array $arguments) {
+		$this->setExpectedException(ParserException::class);
+		$viewHelper = new AliasViewHelper();
+		$arguments = array('map' => array());
+		$mockViewHelperNode = $this->getMock(
+			ViewHelperNode::class,
+			array('evaluateChildNodes'), array(new RenderingContextFixture(), 'f', 'alias', $arguments, new ParsingState())
+		);
 
 		$this->injectDependenciesIntoViewHelper($viewHelper);
 		$viewHelper->setViewHelperNode($mockViewHelperNode);
 
-		$viewHelper->setArguments(array('map' => array()));
-		$this->assertEquals('foo', $viewHelper->render());
+		$viewHelper->setArguments($arguments);
+		$viewHelper->initializeArgumentsAndRender();
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getExceptionTestValues() {
+		return array(
+			array(array('map' => array(), 'src' => NULL, 'as' => NULL)),
+			array(array('map' => array('foo' => 'bar'), 'src' => 'foo', 'as' => NULL)),
+			array(array('map' => array('foo' => 'bar'), 'src' => 'foo', 'as' => 'baz')),
+			array(array('map' => array(), 'src' => 'foo', 'as' => NULL)),
+			array(array('map' => array(), 'src' => 'foo', 'as' => 'bar', 'type' => NULL)),
+		);
 	}
 }


### PR DESCRIPTION
This adds three new arguments to f:alias:

* `src` which can contain data which can be read by a VariableProvider
* `name` which can contain the name of a "container" variable in which values from the Provider will be placed
* `type` which allows manually defining the type

Currently, the one VariableProvider type which makes sense to use here is the `JsonVariableProvider`.

Examples:

```xml
<!-- given "file.json" contains {"name": "John", "phone": "1-800-FLUID"} -->
<f:alias src="/path/to/file.json" as="json">
  {json.name} at {json.phone}
  <!-- outputs: "John at 1-800-FLUID" -->
</f:alias>
```

The "src" argument can any stream wrapper compatible URI.

In addition the "JSONVariableProvider" has been renamed to "JsonVariableProvider" to be able to correctly assume the name of this and future VariableProviders to be supported.