### PR TITLE
[BUGFIX] Fixes for namespace resolving

### DIFF
--- a/examples/Resources/Private/Singles/Namespaces.html
+++ b/examples/Resources/Private/Singles/Namespaces.html
@@ -9,19 +9,19 @@
 <alias:section name="Main">
     Namespaces template
 
-	This template aliases "f:" so it can be used as "alias:",
-	and defines an additional PHP namespace directly. As such
-	it shows examples for using the URL based convention or
-	a manual PHP namespace.
+    This template aliases "f:" so it can be used as "alias:",
+    and defines an additional PHP namespace directly. As such
+    it shows examples for using the URL based convention or
+    a manual PHP namespace.
 
-	In the top of the template two additional namespaces are
-	added, to be ignored (since they have no PHP namespace
-	associated with them). One is a direct exclusion, the
-	other is a wildcard which excludes by pattern.
+    In the top of the template two additional namespaces are
+    added, to be ignored (since they have no PHP namespace
+    associated with them). One is a direct exclusion, the
+    other is a wildcard which excludes by pattern.
 
     <invalid:vh>This tag will be shown</invalid:vh>
-	<wildcard:tag>This tag will also be shown</wildcard:tag>
-	<wildthing:tag>This tag will also be shown</wildthing:tag>
+    <wildcard:tag>This tag will also be shown</wildcard:tag>
+    <wildthing:tag>This tag will also be shown</wildthing:tag>
 </alias:section>
 
 </fluid>

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -296,7 +296,8 @@ class TemplateParser {
 	 * @throws Exception
 	 */
 	protected function initializeViewHelperAndAddItToStack(ParsingState $state, $namespaceIdentifier, $methodIdentifier, $argumentsObjectTree) {
-		if (!$this->renderingContext->getViewHelperResolver()->isNamespaceValid($namespaceIdentifier, $methodIdentifier)) {
+		$viewHelperResolver = $this->renderingContext->getViewHelperResolver();
+		if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
 			return NULL;
 		}
 		$currentViewHelperNode = new ViewHelperNode(
@@ -326,10 +327,9 @@ class TemplateParser {
 	 */
 	protected function closingViewHelperTagHandler(ParsingState $state, $namespaceIdentifier, $methodIdentifier) {
 		$viewHelperResolver = $this->renderingContext->getViewHelperResolver();
-		if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier, $methodIdentifier)) {
+		if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
 			return FALSE;
 		}
-
 		$lastStackElement = $state->popNodeFromStack();
 		if (!($lastStackElement instanceof ViewHelperNode)) {
 			throw new Exception('You closed a templating tag which you never opened!', 1224485838);

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -56,7 +56,7 @@ class ViewHelperResolverTest extends UnitTestCase {
 	 */
 	public function testIsNamespaceReturnsFalseIfNamespaceNotValid() {
 		$resolver = new ViewHelperResolver();
-		$result = $resolver->isNamespaceValid('test2', 'test');
+		$result = $resolver->isNamespaceValid('test2');
 		$this->assertFalse($result);
 	}
 


### PR DESCRIPTION
Before this change, ignoring a namespace with `{namespace ignoredname}` was not respected due to casting NULL to an array. And support restored for namespaces added as PHP namespace in xmlns notation, including without the "ViewHelpers" suffix which will now get appended automatically.

This change also removes a redundant argument on ViewHelperResolver and adds a specific method to check if namespace is ignored.