### PR TITLE
[BUGFIX] No-action template must not have priority over action template

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -261,14 +261,13 @@ class TemplatePaths {
 		$identifier = $controller . '/' . $action . '.' . $format;
 		if (!array_key_exists($identifier, self::$resolvedFiles['templates'])) {
 			foreach ($this->getTemplateRootPaths() as $templateRootPath) {
-				$candidate = $templateRootPath . $identifier;
-				$candidate = $this->ensureAbsolutePath($candidate);
+				$candidate = $this->ensureAbsolutePath($templateRootPath . $action . '.' . $format);
 				if (file_exists($candidate)) {
 					return self::$resolvedFiles['templates'][$identifier] = $candidate;
 				}
 			}
 			foreach ($this->getTemplateRootPaths() as $templateRootPath) {
-				$candidate = $this->ensureAbsolutePath($templateRootPath . $action . '.' . $format);
+				$candidate = $this->ensureAbsolutePath($templateRootPath . $identifier);
 				if (file_exists($candidate)) {
 					return self::$resolvedFiles['templates'][$identifier] = $candidate;
 				}
@@ -550,10 +549,11 @@ class TemplatePaths {
 	 * @throws InvalidTemplateResourceException
 	 */
 	public function getTemplateSource($controller = 'Default', $action = 'Default') {
-		if (is_resource($this->templateSource)) {
-			return $this->templateSource = stream_get_contents($this->templateSource);
-		} elseif (is_string($this->templateSource)) {
+		if (is_string($this->templateSource)) {
 			return $this->templateSource;
+		} elseif (is_resource($this->templateSource)) {
+			rewind($this->templateSource);
+			return $this->templateSource = stream_get_contents($this->templateSource);
 		}
 		$format = $this->getFormat();
 		$templateReference = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -18,6 +18,30 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 class TemplatePathsTest extends BaseTestCase {
 
 	/**
+	 * @param string|array $input
+	 * @param string|array $expected
+	 * @test
+	 * @dataProvider getSanitizePathTestValues
+	 */
+	public function testSanitizePath($input, $expected) {
+		$instance = new TemplatePaths();
+		$method = new \ReflectionMethod($instance, 'sanitizePath');
+		$method->setAccessible(TRUE);
+		$output = $method->invokeArgs($instance, array($input));
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getSanitizePathTestValues() {
+		return array(
+			array(__FILE__, __FILE__),
+			array(array(__FILE__, __DIR__), array(__FILE__, __DIR__ . '/'))
+		);
+	}
+
+	/**
 	 * @test
 	 */
 	public function setsLayoutPathAndFilename() {
@@ -147,6 +171,18 @@ class TemplatePathsTest extends BaseTestCase {
 		$instance = new TemplatePaths();
 		$this->setExpectedException(InvalidTemplateResourceException::class);
 		$instance->getTemplateSource();
+	}
+
+	/**
+	 * @test
+	 */
+	public function testGetTemplateSourceReadsStreamWrappers() {
+		$fixture = __DIR__ . '/Fixtures/LayoutFixture.html';
+		$instance = new TemplatePaths();
+		$stream = fopen($fixture, 'r');
+		$instance->setTemplateSource($stream);
+		$this->assertEquals(stream_get_contents($stream), $instance->getTemplateSource());
+		fclose($stream);
 	}
 
 	/**


### PR DESCRIPTION
This change fixes an issue where if one of multiple template root paths contained a no-action template (named by controllername sitting directly in template root path) would take priority over an action template, if the no-action template sat in a template file which had priority over the other but the priority path did not contain an action template.

Example:

Path A contains MyController.html
Path B contains MyController/MyAction.html

If Path A was checked before Path B then MyController.html would be returned where the expected return is MyController/MyAction.html.

Also fixes a side issue exposed by the bug fix, where stream wrappers would not be rewound before being read, causing empty template source on subsequent reads.