### PR TITLE
[BUGFIX] Correct handling of disabled compiler in relation to cache

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -93,7 +93,7 @@ class TemplateCompiler {
 	 * @return boolean
 	 */
 	public function isDisabled() {
-		return $this->disabled;
+		return $this->disabled || !$this->renderingContext->isCacheEnabled();
 	}
 
 	/**
@@ -129,7 +129,11 @@ class TemplateCompiler {
 	 * @return void
 	 */
 	public function store($identifier, ParsingState $parsingState) {
-		if (!$this->renderingContext->isCacheEnabled() || $this->disabled) {
+		if ($this->isDisabled()) {
+			if ($this->renderingContext->isCacheEnabled()) {
+				// Compiler is disabled but cache is enabled. Flush cache to make sure.
+				$this->renderingContext->getCache()->flush($identifier);
+			}
 			$parsingState->setCompilable(FALSE);
 			return;
 		}


### PR DESCRIPTION
This change makes sure that when caching is disabled, the template compiler will flush the cache for any existing entries (allowing for example dynamically flushing cache by custom TTL from a ViewHelper's compile method). Until this change, a previously cached template could never be excluded from compiling, which resulted in bad behavior when combined with the fact that the template caching could possibly already have begun at the time when a ViewHelper disables the compiler.