### PR TITLE
[TASK] Refactor ExpressionNode and interface to move compiling to each node

### DIFF
--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -320,21 +320,7 @@ class NodeConverter {
 	 * @see convert()
 	 */
 	protected function convertExpressionNode(ExpressionNodeInterface $node) {
-		$handlerClass = get_class($node);
-		$expressionVariable = $this->variableName('string');
-		$matchesVariable = $this->variableName('array');
-		$initializationPhpCode = sprintf('// Rendering %s node' . chr(10), $handlerClass);
-		$initializationPhpCode .= sprintf('%s = \'%s\';' , $expressionVariable, $node->getExpression()) . chr(10);
-		$initializationPhpCode .= sprintf('%s = %s;' , $matchesVariable, var_export($node->getMatches(), TRUE)) . chr(10);
-		return array(
-			'initialization' => $initializationPhpCode,
-			'execution' => sprintf(
-				'\%s::evaluateExpression($renderingContext, %s, %s)',
-				$handlerClass,
-				$expressionVariable,
-				$matchesVariable
-			)
-		);
+		return $node->compile($this->templateCompiler);
 	}
 
 	/**

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -34,6 +35,22 @@ interface ExpressionNodeInterface extends NodeInterface {
 	 * @return mixed
 	 */
 	public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches);
+
+	/**
+	 * Compiles the ExpressionNode, returning an array with
+	 * exactly two keys which contain strings:
+	 *
+	 * - "initialization" which contains variable initializations
+	 * - "execution" which contains the execution (that uses the variables)
+	 *
+	 * The expression and matches can be read from the local
+	 * instance - and the RenderingContext and other APIs
+	 * can be accessed via the TemplateCompiler.
+	 *
+	 * @param TemplateCompiler $templateCompiler
+	 * @return string
+	 */
+	public function compile(TemplateCompiler $templateCompiler);
 
 	/**
 	 * Getter for returning the expression before parsing.


### PR DESCRIPTION
This allows each node to compile itself differently as optimised PHP calls. A default implementation is provided which utilises the existing `evaluateExpression()` method to evaluate the node. The change is not breaking.