### PR TITLE
[TASK] Improve performance of rendering logic

### DIFF
--- a/src/Core/Compiler/StopCompilingException.php
+++ b/src/Core/Compiler/StopCompilingException.php
@@ -1,0 +1,16 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Compiler;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Exception thrown to stop the template compiling process
+ *
+ * @api
+ */
+class StopCompilingException extends \TYPO3Fluid\Fluid\Core\Exception {
+
+}

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -26,11 +26,6 @@ class TemplateCompiler {
 	const SHOULD_GENERATE_VIEWHELPER_INVOCATION = '##should_gen_viewhelper##';
 
 	/**
-	 * @var boolean
-	 */
-	protected $disabled = FALSE;
-
-	/**
 	 * @var array
 	 */
 	protected $syntaxTreeInstanceCache = array();
@@ -86,14 +81,14 @@ class TemplateCompiler {
 	 * @return void
 	 */
 	public function disable() {
-		$this->disabled = TRUE;
+		throw new StopCompilingException('Compiling stopped');
 	}
 
 	/**
 	 * @return boolean
 	 */
 	public function isDisabled() {
-		return $this->disabled || !$this->renderingContext->isCacheEnabled();
+		return !$this->renderingContext->isCacheEnabled();
 	}
 
 	/**
@@ -101,7 +96,10 @@ class TemplateCompiler {
 	 * @return boolean
 	 */
 	public function has($identifier) {
-		if (!$this->renderingContext->isCacheEnabled() || $this->disabled) {
+		if (isset($this->syntaxTreeInstanceCache[$identifier])) {
+			return TRUE;
+		}
+		if (!$this->renderingContext->isCacheEnabled()) {
 			return FALSE;
 		}
 		$identifier = $this->sanitizeIdentifier($identifier);

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -67,31 +67,13 @@ class ViewHelperInvoker {
 			}
 		}
 
-		$this->abortIfRequiredArgumentsAreMissing($expectedViewHelperArguments, $evaluatedArguments);
-
-		$viewHelper->setRenderingContext($renderingContext);
-		$viewHelper->setArguments($evaluatedArguments);
-		$viewHelper->handleAdditionalArguments($undeclaredArguments);
 		if ($renderChildrenClosure) {
 			$viewHelper->setRenderChildrenClosure($renderChildrenClosure);
 		}
+		$viewHelper->setRenderingContext($renderingContext);
+		$viewHelper->setArguments($evaluatedArguments);
+		$viewHelper->handleAdditionalArguments($undeclaredArguments);
 		return $viewHelper->initializeArgumentsAndRender();
-	}
-
-	/**
-	 * Throw an exception if required arguments are missing
-	 *
-	 * @param ArgumentDefinition[] $expectedArguments Array of all expected arguments
-	 * @param NodeInterface[] $actualArguments Actual arguments
-	 * @throws Exception
-	 */
-	protected function abortIfRequiredArgumentsAreMissing($expectedArguments, $actualArguments) {
-		$actualArgumentNames = array_keys($actualArguments);
-		foreach ($expectedArguments as $expectedArgument) {
-			if ($expectedArgument->isRequired() && !in_array($expectedArgument->getName(), $actualArgumentNames)) {
-				throw new Exception('Required argument "' . $expectedArgument->getName() . '" was not supplied.', 1237823699);
-			}
-		}
 	}
 
 }

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\NodeConverter;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
@@ -129,8 +130,8 @@ class TemplateCompilerTest extends UnitTestCase {
 	 */
 	public function testSupportsDisablingCompiler() {
 		$instance = new TemplateCompiler();
+		$this->setExpectedException(StopCompilingException::class);
 		$instance->disable();
-		$this->assertTrue($instance->isDisabled());
 	}
 
 	/**
@@ -147,9 +148,9 @@ class TemplateCompilerTest extends UnitTestCase {
 	public function testStoreWhenDisabledFlushesCache() {
 		$renderingContext = new RenderingContextFixture();
 		$state = new ParsingState();
-		$instance = new TemplateCompiler();
-		$instance->setRenderingContext($renderingContext);
-		$instance->disable();
+		$instance = $this->getAccessibleMock(TemplateCompiler::class);
+		$instance->_set('renderingContext', $renderingContext);
+		$instance->_set('disabled', TRUE);
 		$instance->store('fakeidentifier', $state);
 	}
 

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -50,9 +50,9 @@ class ViewHelperNodeTest extends UnitTestCase {
 	public function setUp() {
 		$this->renderingContext = new RenderingContextFixture();
 		$this->mockViewHelperResolver = $this->getMock(ViewHelperResolver::class, array('resolveViewHelperClassName', 'createViewHelperInstanceFromClassName', 'getArgumentDefinitionsForViewHelper'));
-		$this->mockViewHelperResolver->expects($this->once())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
-		$this->mockViewHelperResolver->expects($this->once())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
-		$this->mockViewHelperResolver->expects($this->once())->method('getArgumentDefinitionsForViewHelper')->willReturn(array(
+		$this->mockViewHelperResolver->expects($this->any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
+		$this->mockViewHelperResolver->expects($this->any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
+		$this->mockViewHelperResolver->expects($this->any())->method('getArgumentDefinitionsForViewHelper')->willReturn(array(
 			'foo' => new ArgumentDefinition('foo', 'string', 'Dummy required argument', TRUE)
 		));
 		$this->renderingContext->setViewHelperResolver($this->mockViewHelperResolver);
@@ -87,6 +87,40 @@ class ViewHelperNodeTest extends UnitTestCase {
 	public function testThrowsExceptionOnMissingRequiredArgument() {
 		$this->setExpectedException(ParserException::class);
 		new ViewHelperNode($this->renderingContext, 'f', 'vh', array('notfoo' => FALSE), new ParsingState());
+	}
+
+	/**
+	 * @test
+	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
+	 */
+	public function abortIfRequiredArgumentsAreMissingThrowsException() {
+		$expected = array(
+			new ArgumentDefinition('firstArgument', 'string', '', FALSE),
+			new ArgumentDefinition('secondArgument', 'string', '', TRUE)
+		);
+
+		$templateParser = $this->getAccessibleMock(ViewHelperNode::class, array('dummy'), array(), '', FALSE);
+
+		$templateParser->_call('abortIfRequiredArgumentsAreMissing', $expected, array());
+	}
+
+	/**
+	 * @test
+	 */
+	public function abortIfRequiredArgumentsAreMissingDoesNotThrowExceptionIfRequiredArgumentExists() {
+		$expectedArguments = array(
+			new ArgumentDefinition('name1', 'string', 'desc', FALSE),
+			new ArgumentDefinition('name2', 'string', 'desc', TRUE)
+		);
+		$actualArguments = array(
+			'name2' => 'bla'
+		);
+
+		$mockTemplateParser = $this->getAccessibleMock(ViewHelperNode::class, array('dummy'), array(), '', FALSE);
+
+		$mockTemplateParser->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
+		// dummy assertion to avoid "did not perform any assertions" error
+		$this->assertTrue(TRUE);
 	}
 
 }

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -28,38 +28,4 @@ class ViewHelperInvokerTest extends UnitTestCase {
 		$this->assertEquals(1, $result);
 	}
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
-	 */
-	public function abortIfRequiredArgumentsAreMissingThrowsException() {
-		$expected = array(
-			new ArgumentDefinition('firstArgument', 'string', '', FALSE),
-			new ArgumentDefinition('secondArgument', 'string', '', TRUE)
-		);
-
-		$templateParser = $this->getAccessibleMock(ViewHelperInvoker::class, array('dummy'), array(), '', FALSE);
-
-		$templateParser->_call('abortIfRequiredArgumentsAreMissing', $expected, array());
-	}
-
-	/**
-	 * @test
-	 */
-	public function abortIfRequiredArgumentsAreMissingDoesNotThrowExceptionIfRequiredArgumentExists() {
-		$expectedArguments = array(
-			new ArgumentDefinition('name1', 'string', 'desc', FALSE),
-			new ArgumentDefinition('name2', 'string', 'desc', TRUE)
-		);
-		$actualArguments = array(
-			'name2' => 'bla'
-		);
-
-		$mockTemplateParser = $this->getAccessibleMock(ViewHelperInvoker::class, array('dummy'), array(), '', FALSE);
-
-		$mockTemplateParser->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
-		// dummy assertion to avoid "did not perform any assertions" error
-		$this->assertTrue(TRUE);
-	}
-
 }

--- a/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
@@ -110,8 +110,8 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase {
 		$matchingCaseViewHelper->setRenderChildrenClosure(function() { return 'foo-childcontent'; });
 		$breakingMatchingCaseNode = $this->getAccessibleMock(ViewHelperNode::class, array('getViewHelperClassName', 'getUninitializedViewHelper'), array(), '', FALSE);
 		$breakingMatchingCaseNode->_set('arguments', array('value' => 'foo'));
+		$breakingMatchingCaseNode->_set('uninitializedViewHelper', $matchingCaseViewHelper);
 		$breakingMatchingCaseNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
-		$breakingMatchingCaseNode->method('getUninitializedViewHelper')->willReturn($matchingCaseViewHelper);
 		$defaultCaseNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', FALSE);
 		$defaultCaseNode->method('getViewHelperClassName')->willReturn(DefaultCaseViewHelper::class);
 		$defaultCaseNode->expects($this->never())->method('evaluate');


### PR DESCRIPTION
This change:

* Implements a StopCompilingException to allow earlier return during compiling when disabling compiler from a ViewHelper. Sets compilable state to FALSE in ParsingState.
* Implements L1 caching of ParsedTemplate (ParsingState) in TemplateParser; preventing re-parsing of uncompilable templates and storing already instantiated compiled templates.
* Refactors some argument validation to ViewHelperNode in order to prevent multiple executions (will execute once per node and not execute once compiled).

The change improves performance in two key areas:

* During template parsing and compiling performance is improved when rendering templates that use loops or multiple calls to render the same partial/section.
* During rendering of compiled templates performance is improved due to avoiding calling some relatively expensive (frequent but not individually costly) methods.

The change improved performance of a ~50 nodes 2500 iterations template by approximately 40%; the more iterations and nodes the template contains the larger the improvement is.

References: #64