### PR TITLE
[TASK] Convenience trimming backslash suffix from namespace

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -302,7 +302,7 @@ class ViewHelperResolver {
 		$namespaces = (array) $this->namespaces[$namespaceIdentifier];
 
 		do {
-			$name = array_pop($namespaces) . '\\' . $className;
+			$name = rtrim(array_pop($namespaces), '\\') . '\\' . $className;
 		} while (!class_exists($name) && count($namespaces));
 
 		return $name;

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -88,6 +88,16 @@ class ViewHelperResolverTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
+	public function testResolveViewHelperClassNameTrimsBackslashSuffixFromNamespace() {
+		$resolver = $this->getAccessibleMock(ViewHelperResolver::class, array('dummy'));
+		$resolver->_set('namespaces', array('f' => array('FluidTYPO3\\Fluid\\ViewHelpers\\')));
+		$result = $resolver->_call('resolveViewHelperName', 'f', 'render');
+		$this->assertEquals('FluidTYPO3\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
+	}
+
+	/**
+	 * @test
+	 */
 	public function testAddNamespaceWithString() {
 		$resolver = $this->getMock(ViewHelperResolver::class, array('dummy'));
 		$resolver->addNamespace('f', 'Foo\\Bar');


### PR DESCRIPTION
If a user was careless and added a ViewHelper namespace ending in a backslash, ViewHelper classes would fail to resolve but on some systems the class file would still load, causing a seemingly unrelated "Cannot redeclare class" error.

Trimming the namespace suffix before the lookup avoids this situation.