### PR TITLE
[BUGFIX] Caching identifier colission when using template source

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -527,6 +527,9 @@ class TemplatePaths {
 	 */
 	public function getTemplateIdentifier($controller = 'Default', $action = 'Default') {
 		$format = $this->getFormat();
+		if ($this->templateSource !== NULL) {
+			return sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $format;
+		}
 		$templatePathAndFilename = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);
 		$prefix = $controller . '_action_' . $action;
 		return $this->createIdentifierForFile($templatePathAndFilename, $prefix);

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -196,4 +196,13 @@ class TemplatePathsTest extends BaseTestCase {
 		$method->invokeArgs($instance, array(array('/not/', '/found/'), 'notfound.html'));
 	}
 
+	/**
+	 * @test
+	 */
+	public function testGetTemplateIdentifierReturnsSourceChecksumWithControllerAndActionAndFormat() {
+		$instance = new TemplatePaths();
+		$instance->setTemplateSource('foobar');
+		$this->assertEquals('8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
+	}
+
 }


### PR DESCRIPTION
When passing template resource as source code string to TemplatePaths the resulting template identifier would be non-unique and would falsely report TRUE for cached status and retrieve an unexpected parsed template.

Giving the template a unique identifier also when operated in source code mode solves this issue.