### PR TITLE
[BUGFIX] Support bin/fluid execution as dependency

### DIFF
--- a/bin/fluid
+++ b/bin/fluid
@@ -5,6 +5,8 @@ if (file_exists(__DIR__ . '/../autoload.php')) {
 	require_once __DIR__ . '/../autoload.php';
 } elseif (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 	require_once __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+	require_once __DIR__ . '/../../../autoload.php';
 }
 
 require_once __DIR__ . '/../examples/include/class_customvariableprovider.php';


### PR DESCRIPTION
If typo3fluid/fluid is installed as dependency the bin/fluid script fails with an error:

> PHP Fatal error:  Class 'TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider' not found in
> /var/www/vendor/typo3fluid/fluid/examples/include/class_customvariableprovider.php on line 19

Fix this by also looking for autoload.php in the vendor-dir this package is currently
installed to.