### PR TITLE
[BUGFIX] Compiled condition never reaches "else" if passed as argument

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -84,6 +84,8 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper {
 		} elseif (!empty($arguments['__elseClosures'])) {
 			$elseIfClosures = isset($arguments['__elseifClosures']) ? $arguments['__elseifClosures'] : array();
 			return static::evaluateElseClosures($arguments['__elseClosures'], $elseIfClosures, $renderingContext);
+		} elseif (array_key_exists('else', $arguments)) {
+			return $arguments['else'];
 		}
 		return '';
 	}


### PR DESCRIPTION
When rendering a template with a piece of template code like:

```xml
{f:if(condition: variable, then: 'yes', else: 'no')}
<f:if condition="{variable}" then="yes" else="no" />
```

Would never execute the "else" statement once the ViewHelper was compiled regardless of input arguments. Used with child nodes the compiled result works perfectly.

Problem is in renderStatic which does not consider "else" passed directly in arguments. The condition is extended to also consider this way of passing the argument.