### PR TITLE
[BUGFIX] Spaceless ViewHelper builds render children closure

### DIFF
--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -40,7 +40,7 @@ class SpacelessViewHelper extends AbstractViewHelper {
 	 * @return string
 	 */
 	public function render() {
-		return static::renderStatic($this->arguments, $this->renderChildrenClosure, $this->renderingContext);
+		return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
 	}
 
 	/**


### PR DESCRIPTION
This change avoids using a possibly NULL value that should contain a rendering closure. Building the closure before using it avoids this problem.