### PR TITLE
[BUGFIX] Shallow copy RenderingContext before each ViewHelper

### DIFF
--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -56,7 +56,6 @@ class ViewHelperNode extends AbstractNode {
 		$this->arguments = $arguments;
 		$this->viewHelperClassName = $resolver->resolveViewHelperClassName($namespace, $identifier);
 		$this->uninitializedViewHelper = $resolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
-		$this->uninitializedViewHelper->setRenderingContext($renderingContext);
 		$this->uninitializedViewHelper->setViewHelperNode($this);
 		$this->argumentDefinitions = $resolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
 		$this->rewriteBooleanNodesInArgumentsObjectTree($this->argumentDefinitions, $this->arguments);

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -275,7 +275,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 * @return \Closure
 	 */
 	protected function buildRenderChildrenClosure() {
-		$self = $this;
+		$self = clone $this;
 		return function() use ($self) {
 			return $self->renderChildren();
 		};

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -102,7 +102,7 @@ abstract class BaseFunctionalTestCase extends UnitTestCase {
 		$view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
 		$view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
 		$view->assignMultiple($variables);
-		$output = $view->render();
+		$output = trim($view->render());
 		$this->assertNotEquals($view->getRenderingContext()->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
 		if (empty($expected) && empty($notExpected)) {
 			$this->fail('Test performs no assertions!');

--- a/tests/Functional/Cases/Rendering/RecursiveSectionRenderingTest.php
+++ b/tests/Functional/Cases/Rendering/RecursiveSectionRenderingTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Escaping;
+
+use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
+
+/**
+ * Class RecursiveSectionRendering
+ */
+class RecursiveSectionRenderingTest extends BaseFunctionalTestCase {
+
+	/**
+	 * Variables array constructed to expect exactly three
+	 * recursive renderings followed by a single rendering.
+	 *
+	 * @var array
+	 */
+	protected $variables = array(
+		'settings' => array(
+			'test' => '<strong>Bla</strong>'
+		),
+		'items' => array(
+			array(
+				'id' => 1,
+				'items' => array(
+					array(
+						'id' => 2,
+						'items' => array(
+							array(
+								'id' => 3,
+								'items' => array()
+							)
+						)
+					)
+				)
+			),
+			array(
+				'id' => 4
+			)
+		)
+	);
+
+	/**
+	 * @return array
+	 */
+	public function getTemplateCodeFixturesAndExpectations() {
+		return array(
+			'Recursive section rendering clones variable storage and restores after loop ends' => array(
+				file_get_contents(__DIR__ . '/../../Fixtures/Templates/RecursiveSectionRendering.html'),
+				$this->variables,
+				array('Item: 1.', 'Item: 2.', 'Item: 3.', 'Item: 4.'),
+				array(),
+			),
+		);
+	}
+
+}

--- a/tests/Functional/Fixtures/Templates/RecursiveSectionRendering.html
+++ b/tests/Functional/Fixtures/Templates/RecursiveSectionRendering.html
@@ -1,0 +1,12 @@
+<f:section name="Items">
+	<f:spaceless>
+		<f:for each="{items}" as="item">
+			Item: {item.id}.
+			<f:if condition="{item.items}">
+				<f:render section="Items" arguments="{items: item.items}" />
+			</f:if>
+		</f:for>
+	</f:spaceless>
+</f:section>
+
+<f:render section="Items" arguments="{items: items}" />


### PR DESCRIPTION
Fixes an issue where recursively calling a ViewHelper caused the RenderingContext reference to become incorrect after ViewHelper renders a nested instance of itself. Expressed for example by recursively rendering a section with a loop - after exiting the loop and returning to the parent section variables would have unexpected values because the RenderingContext was replaced.

Cloning (shallow copying) the ViewHelper instance before creating the render children closure solves this issue.