### PR TITLE
[TASK] Compiling of switch statement

### DIFF
--- a/src/ViewHelpers/CaseViewHelper.php
+++ b/src/ViewHelpers/CaseViewHelper.php
@@ -6,6 +6,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -49,5 +51,17 @@ class CaseViewHelper extends AbstractViewHelper {
 			return $this->renderChildren();
 		}
 		return '';
+	}
+
+	/**
+	 * @param string $argumentsName
+	 * @param string $closureName
+	 * @param string $initializationPhpCode
+	 * @param ViewHelperNode $node
+	 * @param TemplateCompiler $compiler
+	 * @return string
+	 */
+	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
+		return '\'\'';
 	}
 }

--- a/src/ViewHelpers/DefaultCaseViewHelper.php
+++ b/src/ViewHelpers/DefaultCaseViewHelper.php
@@ -6,6 +6,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -33,5 +35,17 @@ class DefaultCaseViewHelper extends AbstractViewHelper {
 			throw new ViewHelper\Exception('The "default case" View helper can only be used within a switch View helper', 1368112037);
 		}
 		return $this->renderChildren();
+	}
+
+	/**
+	 * @param string $argumentsName
+	 * @param string $closureName
+	 * @param string $initializationPhpCode
+	 * @param ViewHelperNode $node
+	 * @param TemplateCompiler $compiler
+	 * @return string
+	 */
+	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
+		return '\'\'';
 	}
 }

--- a/src/ViewHelpers/SwitchViewHelper.php
+++ b/src/ViewHelpers/SwitchViewHelper.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -157,4 +158,42 @@ class SwitchViewHelper extends AbstractViewHelper {
 			$this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', TRUE);
 		}
 	}
+
+	/**
+	 * Compiles the node structure to a native switch
+	 * statement which evaluates closures for each
+	 * case comparison and renders child node closures
+	 * only when value matches.
+	 *
+	 * @param string $argumentsName
+	 * @param string $closureName
+	 * @param string $initializationPhpCode
+	 * @param ViewHelperNode $node
+	 * @param TemplateCompiler $compiler
+	 * @return string
+	 */
+	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
+		$phpCode = 'call_user_func(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+			'switch ($arguments[\'expression\']) {' . PHP_EOL;
+		$expressionEvaluationClosureName = $compiler->variableName('switchExpressionClosure');
+		foreach ($node->getChildNodes() as $childNode) {
+			if ($this->isDefaultCaseNode($childNode)) {
+				$childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
+				$phpCode .= sprintf('default: return call_user_func(%s);', $childrenClosure) . PHP_EOL;
+			} elseif ($this->isCaseNode($childNode)) {
+				$valueClosure = $compiler->wrapViewHelperNodeArgumentEvaluationInClosure($childNode, 'value');
+				$childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
+				$phpCode .= sprintf(
+					'case call_user_func(%s): return call_user_func(%s);',
+					$valueClosure,
+					$childrenClosure,
+					$compiler->getNodeConverter()->convert($childNode)
+				) . PHP_EOL;
+			}
+		}
+		$phpCode .= '}' . PHP_EOL;
+		$phpCode .= sprintf('}, array(%s))', $argumentsName);
+		return $phpCode;
+	}
+
 }

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -2,6 +2,7 @@
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;

--- a/tests/Functional/Cases/SwitchTest.php
+++ b/tests/Functional/Cases/SwitchTest.php
@@ -1,12 +1,23 @@
 <?php
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
+use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 
 /**
  * Class SwitchTest
  */
 class SwitchTest extends BaseFunctionalTestCase {
+
+	/**
+	 * If your test case requires a cache, override this
+	 * method and return an instance.
+	 *
+	 * @return FluidCacheInterface
+	 */
+	protected function getCache() {
+		return new SimpleFileCache(sys_get_temp_dir());
+	}
 
 	/**
 	 * @return array


### PR DESCRIPTION
This change introduces a custom compile() method for SwitchViewHelper which creates a native PHP switch() statement using various closures for evaluating the case matching and rendering the matched case.