### PR TITLE
[BUGFIX] Ensure correct line endings in Unit Tests on Windows systems

### DIFF
--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -169,12 +169,12 @@ class ExamplesTest extends BaseTestCase {
 				'example_structures.php',
 				array(
 					'This section exists and is rendered: Valid section',
-					'Expects no output because section name is invalid: ' . PHP_EOL,
+					'Expects no output because section name is invalid: ' . "\n",
 					'Dynamic section name: Dynamically suffixed section',
 					'Bad dynamic section name, expects fallback: Just a section',
 					'Will render: Just a section',
 					'Will render, clause reversed: Just a section',
-					'Will not render: ' . PHP_EOL,
+					'Will not render: ' . "\n",
 					'This `f:else` was rendered',
 					'The value was "3"',
 					'The unmatched value case triggered',
@@ -186,7 +186,7 @@ class ExamplesTest extends BaseTestCase {
 				array(
 					'A string with numbers in it: 132',
 					'Ditto, with type name stored in variable: 132',
-					'A comma-separated value iterated as array:' . PHP_EOL . "\t- one" . PHP_EOL . "\t- two",
+					'A comma-separated value iterated as array:' . "\n\t- one\n\t- two",
 					'String variable name with dynamic1 part: String using $dynamic1.',
 					'String variable name with dynamic2 part: String using $dynamic2.',
 					'Array member in $array[$dynamic1]: Dynamic key in $array[$dynamic1]',

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture06-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture06-split.php
@@ -7,5 +7,5 @@ return array(
 	'{number}',
 	'</foo:format.number>',
 	'</foo:format.nl2br>',
-	PHP_EOL
+	"\n"
 );

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -69,23 +69,23 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase {
 		return array(
 			array(
 				array(),
-				'foobar-args[\'__thenClosure\'] = foobar-closure;' . PHP_EOL
+				'foobar-args[\'__thenClosure\'] = foobar-closure;' . chr(10)
 			),
 			array(
 				array(new ViewHelperNode($context, 'f', 'then', array(), $state)),
-				'foobar-args[\'__thenClosure\'] = closure;' . PHP_EOL
+				'foobar-args[\'__thenClosure\'] = closure;' . chr(10)
 			),
 			array(
 				array(new ViewHelperNode($context, 'f', 'else', array(), $state)),
-				'foobar-args[\'__elseClosures\'][] = closure;' . PHP_EOL
+				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
 			),
 			array(
 				array(
 					new ViewHelperNode($context, 'f', 'then', array(), $state),
 					new ViewHelperNode($context, 'f', 'else', array(), $state)
 				),
-				'foobar-args[\'__thenClosure\'] = closure;' . PHP_EOL .
-				'foobar-args[\'__elseClosures\'][] = closure;' . PHP_EOL
+				'foobar-args[\'__thenClosure\'] = closure;' . chr(10) .
+				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
 			),
 			array(
 				array(
@@ -93,10 +93,10 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase {
 					new ViewHelperNode($context, 'f', 'else', array('if' => new BooleanNode(new RootNode())), $state),
 					new ViewHelperNode($context, 'f', 'else', array(), $state)
 				),
-				'foobar-args[\'__thenClosure\'] = closure;' . PHP_EOL .
-				'foobar-args[\'__elseClosures\'][] = closure;' . PHP_EOL .
-				'foobar-args[\'__elseifClosures\'][] = arg-closure;' . PHP_EOL .
-				'foobar-args[\'__elseClosures\'][] = closure;' . PHP_EOL
+				'foobar-args[\'__thenClosure\'] = closure;' . chr(10) .
+				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10) .
+				'foobar-args[\'__elseifClosures\'][] = arg-closure;' . chr(10) .
+				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
 			),
 		);
 	}


### PR DESCRIPTION
This patch ensures correct line endings for Unit Test when running on Windows systems (and checked out as Unix files).