### PR TITLE
[BUGFIX] Set default value for argument "value" to NULL

### DIFF
--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -54,7 +54,7 @@ class PrintfViewHelper extends AbstractViewHelper {
 	public function initializeArguments() {
 		parent::initializeArguments();
 		$this->registerArgument('arguments', 'array', 'The arguments for vsprintf', FALSE, array());
-		$this->registerArgument('value', 'string', 'String to format', FALSE, FALSE);
+		$this->registerArgument('value', 'string', 'String to format', FALSE, NULL);
 	}
 
 	/**


### PR DESCRIPTION
To enable the rendering of the children the default value of the argument "value" must be NULL instead of FALSE.