### PR TITLE
[BUGFIX] Ensure initial value for key in ForViewHelper is used

### DIFF
--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -134,7 +134,7 @@ class ForViewHelper extends AbstractViewHelper {
 		$output = '';
 		foreach ($arguments['each'] as $keyValue => $singleElement) {
 			$templateVariableContainer->add($arguments['as'], $singleElement);
-			if ($arguments['key'] !== '') {
+			if ($arguments['key'] !== NULL) {
 				$templateVariableContainer->add($arguments['key'], $keyValue);
 			}
 			if ($arguments['iteration'] !== NULL) {
@@ -148,7 +148,7 @@ class ForViewHelper extends AbstractViewHelper {
 			}
 			$output .= $renderChildrenClosure();
 			$templateVariableContainer->remove($arguments['as']);
-			if ($arguments['key'] !== '') {
+			if ($arguments['key'] !== NULL) {
 				$templateVariableContainer->remove($arguments['key']);
 			}
 			if ($arguments['iteration'] !== NULL) {

--- a/tests/Unit/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ForViewHelperTest.php
@@ -21,7 +21,7 @@ class ForViewHelperTest extends ViewHelperBaseTestcase {
 
 
 		$this->arguments['reverse'] = NULL;
-		$this->arguments['key'] = '';
+		$this->arguments['key'] = NULL;
 		$this->arguments['iteration'] = NULL;
 	}
 


### PR DESCRIPTION
By argument definition the default value for "key" in the ForViewHelper ist NULL instead of an empty string. The validation and the tests should care about that default value. Currently the key is set without any name in the $templateVariableContainer