### PR TITLE
[BUGFIX] Invalid array object access

### DIFF
--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -170,8 +170,8 @@ class VariableExtractor {
 	 * @return mixed
 	 */
 	protected function extractWithAccessor($subject, $propertyName, $accessor) {
-		if (($accessor === self::ACCESSOR_ARRAY && is_array($subject) && (array_key_exists($propertyName, $subject))
-			|| (is_object($subject) && method_exists($subject, 'exists') && $subject->exists($propertyName)))
+		if ($accessor === self::ACCESSOR_ARRAY && is_array($subject) && array_key_exists($propertyName, $subject)
+			|| $subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)
 		) {
 			return $subject[$propertyName];
 		} elseif (is_object($subject)) {

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -89,7 +89,7 @@ class VariableExtractorTest extends UnitTestCase {
 	 * @dataProvider getExtractRedectAccessorTestValues
 	 */
 	public function testExtractRedetectsAccessorIfUnusableAccessorPassed($subject, $path, $accessor, $expected) {
-		$result = VariableExtractor::extract($subject, 'test', array($accessor));
+		$result = VariableExtractor::extract($subject, $path, array($accessor));
 		$this->assertEquals($expected, $result);
 	}
 
@@ -105,6 +105,7 @@ class VariableExtractorTest extends UnitTestCase {
 			array(array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_ASSERTER, 'test'),
 			array((object) array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_ARRAY, 'test'),
 			array((object) array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_ARRAY, 'test'),
+			array(new \ArrayObject(array('testProperty' => 'testValue')), 'testProperty', NULL, 'testValue'),
 		);
 	}
 


### PR DESCRIPTION
Accessing an object is bound to the existence of a method called
"exists()" which leads to an invalid array access on objects actually
implementing that method without the intention to be accessed as array.

Using the ArrayAccess interface using the method "offsetExists()"
offers a more specific approach on using an array accessor however.