### PR TITLE
[BUGFIX] Avoid reserved "sections" variable name

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -183,8 +183,8 @@ EOD;
 	 */
 	protected function generateSectionCodeFromParsingState(ParsingState $parsingState) {
 		$generatedRenderFunctions = '';
-		if ($parsingState->getVariableContainer()->exists('sections')) {
-			$sections = $parsingState->getVariableContainer()->get('sections'); // TODO: refactor to $parsedTemplate->getSections()
+		if ($parsingState->getVariableContainer()->exists('1457379500_sections')) {
+			$sections = $parsingState->getVariableContainer()->get('1457379500_sections'); // TODO: refactor to $parsedTemplate->getSections()
 			foreach ($sections as $sectionName => $sectionRootNode) {
 				$generatedRenderFunctions .= $this->generateCodeForSection(
 					$this->nodeConverter->convertListOfSubNodes($sectionRootNode),

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -237,7 +237,7 @@ abstract class AbstractTemplateView extends AbstractView {
 			$output = $parsedTemplate->$methodNameOfSection($renderingContext);
 			$this->stopRendering();
 		} else {
-			$sections = $parsedTemplate->getVariableContainer()->get('sections');
+			$sections = $parsedTemplate->getVariableContainer()->get('1457379500_sections');
 			if (!isset($sections[$sectionName])) {
 				if ($ignoreUnknown) {
 					return '';

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -85,9 +85,9 @@ class SectionViewHelper extends AbstractViewHelper {
 		/** @var $nameArgument TextNode */
 		$nameArgument = $arguments['name'];
 		$sectionName = $nameArgument->getText();
-		$sections = $variableContainer['sections'] ? $variableContainer['sections'] : array();
+		$sections = $variableContainer['1457379500_sections'] ? $variableContainer['1457379500_sections'] : array();
 		$sections[$sectionName] = $node;
-		$variableContainer['sections'] = $sections;
+		$variableContainer['1457379500_sections'] = $sections;
 	}
 
 	/**

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -94,7 +94,7 @@ class TemplateCompilerTest extends UnitTestCase {
 		$foo = new TextNode('foo');
 		$bar = new TextNode('bar');
 		$parsingState = new ParsingState();
-		$container = new StandardVariableProvider(array('sections' => array($foo, $bar)));
+		$container = new StandardVariableProvider(array('1457379500_sections' => array($foo, $bar)));
 		$parsingState->setVariableProvider($container);
 		$nodeConverter = $this->getMock(
 			NodeConverter::class,

--- a/tests/Unit/ViewHelpers/SectionViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SectionViewHelperTest.php
@@ -35,8 +35,8 @@ class SectionViewHelperTest extends UnitTestCase {
 
 		$section->postParseEvent($viewHelperNodeMock, $viewHelperArguments, $variableContainer);
 
-		$this->assertTrue($variableContainer->exists('sections'), 'Sections array was not created, albeit it should.');
-		$sections = $variableContainer->get('sections');
+		$this->assertTrue($variableContainer->exists('1457379500_sections'), 'Sections array was not created, albeit it should.');
+		$sections = $variableContainer->get('1457379500_sections');
 		$this->assertEquals($sections['sectionName'], $viewHelperNodeMock, 'ViewHelperNode for section was not stored.');
 	}
 


### PR DESCRIPTION
To prevent errors with "reserved" variable names, use a timestamp prefix for sections.

Related: https://review.typo3.org/#/c/46447/2