### PR TITLE
[BUGFIX] Avoid creating invalid class names for compiled template sources

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -526,7 +526,7 @@ class TemplatePaths {
 	public function getTemplateIdentifier($controller = 'Default', $action = 'Default') {
 		$format = $this->getFormat();
 		if ($this->templateSource !== NULL) {
-			return sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $format;
+			return 'source_' . sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $format;
 		}
 		$templatePathAndFilename = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);
 		$prefix = $controller . '_action_' . $action;

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -226,7 +226,7 @@ class TemplatePathsTest extends BaseTestCase {
 	public function testGetTemplateIdentifierReturnsSourceChecksumWithControllerAndActionAndFormat() {
 		$instance = new TemplatePaths();
 		$instance->setTemplateSource('foobar');
-		$this->assertEquals('8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
+		$this->assertEquals('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
 	}
 
 }


### PR DESCRIPTION
When passing a template source (not file reference) the resulting compiled class name was potentially invalid due to using sha1() as prefix. Adding a `source_` prefix avoids the problem.