### PR TITLE
[TASK] Remove never-reached code from AbstractConditionViewHelper

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -121,9 +121,6 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper {
 		if ($this->hasArgument('then')) {
 			return $this->arguments['then'];
 		}
-		if ($this->hasArgument('__thenClosure')) {
-			return $this->arguments['__thenClosure']();
-		}
 
 		$elseViewHelperEncountered = FALSE;
 		foreach ($this->childNodes as $childNode) {
@@ -157,10 +154,6 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper {
 
 		if ($this->hasArgument('else')) {
 			return $this->arguments['else'];
-		}
-		if ($this->hasArgument('__elseClosures')) {
-			$elseIfClosures = isset($this->arguments['__elseifClosures']) ? $this->arguments['__elseifClosures'] : array();
-			return static::evaluateElseClosures($this->arguments['__elseClosures'], $elseIfClosures, $this->renderingContext);
 		}
 
 		/** @var ViewHelperNode|NULL $elseNode */

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -315,6 +315,20 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase {
 				),
 				'second-else'
 			),
+			'else if closures none match' => array(
+				array(
+					'condition' => FALSE,
+					'__elseClosures' => array(
+						function() { return 'first-else'; },
+						function() { return 'second-else'; }
+					),
+					'__elseifClosures' => array(
+						function() { return FALSE; },
+						function() { return FALSE; }
+					)
+				),
+				''
+			),
 		);
 	}
 }


### PR DESCRIPTION
Removed code deals with static rendering but was called during non-static rendering. The code would never be reached - and the same evaluation is already being done correctly in the static rendering method.