### PR TITLE
[BUGFIX] Assign RenderingContext during parsing

### DIFF
--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -57,6 +57,8 @@ class ViewHelperNode extends AbstractNode {
 		$this->viewHelperClassName = $resolver->resolveViewHelperClassName($namespace, $identifier);
 		$this->uninitializedViewHelper = $resolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
 		$this->uninitializedViewHelper->setViewHelperNode($this);
+		// Note: RenderingContext required here though replaced later. See https://github.com/TYPO3Fluid/Fluid/pull/93
+		$this->uninitializedViewHelper->setRenderingContext($renderingContext);
 		$this->argumentDefinitions = $resolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
 		$this->rewriteBooleanNodesInArgumentsObjectTree($this->argumentDefinitions, $this->arguments);
 		$this->validateArguments($this->argumentDefinitions, $this->arguments);


### PR DESCRIPTION
Some third party ViewHelpers may depend on the presence of a rendering context while parsing - although it technically is an incorrect expectation to have the context available at this point, making it available allows third parties to access various secondary aspects of the rendering context.

Specifically, the lack of this parse-time rendering context setting affects Widgets used in TYPO3 CMS when the template is uncompilable.

Followup for https://github.com/TYPO3Fluid/Fluid/pull/77 which removed this line as it was evidently redundant. Line restored now along with a comment linking to this pull request.