### PR TITLE
[BUGFIX] Avoid double HTML encoding on chained view helpers

### DIFF
--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -38,7 +38,7 @@ class EscapingNode extends AbstractNode {
 	 * @return number the value stored in this node/subtree.
 	 */
 	public function evaluate(RenderingContextInterface $renderingContext) {
-		return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES);
+		return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES, 'UTF-8', false);
 	}
 
 	/**

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -41,4 +41,19 @@ class EscapingNodeTest extends UnitTestCase {
 		$this->assertEquals($node->evaluate($renderingContext), htmlspecialchars($string2, ENT_QUOTES));
 	}
 
+	/**
+	 * @test
+	 */
+	public function nestedEscapeNodesAreOnlyEscapedOnce()
+	{
+		$string = '<strong>escape me & don\'t do "that" twice</strong>';
+		$node = new EscapingNode(new EscapingNode(new TextNode($string)));
+		$renderingContext = new RenderingContextFixture();
+
+		$this->assertEquals(
+			'&lt;strong&gt;escape me &amp; don&#039;t do &quot;that&quot; twice&lt;/strong&gt;',
+			$node->evaluate($renderingContext)
+		);
+	}
+
 }


### PR DESCRIPTION
If view helpers are chained, already encoded HTML entities will
be encoded again and again. To circumvent that, the handing in
the escaping interceptor is adjusted to avoid double encoding.

Related: https://forge.typo3.org/issues/75133
Releases: master