### PR TITLE
Revert "[BUGFIX] Avoid double HTML encoding on chained view helpers"

### DIFF
--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -38,7 +38,7 @@ class EscapingNode extends AbstractNode {
 	 * @return number the value stored in this node/subtree.
 	 */
 	public function evaluate(RenderingContextInterface $renderingContext) {
-		return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES, 'UTF-8', false);
+		return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES);
 	}
 
 	/**

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -41,19 +41,4 @@ class EscapingNodeTest extends UnitTestCase {
 		$this->assertEquals($node->evaluate($renderingContext), htmlspecialchars($string2, ENT_QUOTES));
 	}
 
-	/**
-	 * @test
-	 */
-	public function nestedEscapeNodesAreOnlyEscapedOnce()
-	{
-		$string = '<strong>escape me & don\'t do "that" twice</strong>';
-		$node = new EscapingNode(new EscapingNode(new TextNode($string)));
-		$renderingContext = new RenderingContextFixture();
-
-		$this->assertEquals(
-			'&lt;strong&gt;escape me &amp; don&#039;t do &quot;that&quot; twice&lt;/strong&gt;',
-			$node->evaluate($renderingContext)
-		);
-	}
-
 }


### PR DESCRIPTION
This reverts commit d2e36f5ff2a9d3101130c66302695f207e5d3a50.

With the previous change it is not possible anymore to enforce double
encoding. Thus, the behavior has to be changed using the class member
variables escapeChildren and escapeOutput instead (which has been
done for the view helpers of the core already).

Related: https://forge.typo3.org/issues/75133