### PR TITLE
[TASK] Simplifiy encoding behavior

### DIFF
--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -127,7 +127,11 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 * @return boolean
 	 */
 	public function isChildrenEscapingEnabled() {
-		return $this->escapeChildren !== FALSE;
+		if ($this->escapeChildren === NULL) {
+			// Disable children escaping automatically, if output escaping is on anyway.
+			return !$this->isOutputEscapingEnabled();
+		}
+		return $this->escapeChildren;
 	}
 
 	/**


### PR DESCRIPTION
We now disable children escaping in case output escaping is already on.
This is a saner default so that view helper creators very seldomly need to
think about setting any of the escaping behavior properties.