### PR TITLE
[BUGFIX] Fix interceptor call for self-closing view helpers

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -285,10 +285,10 @@ class TemplateParser {
 		if ($viewHelperNode) {
 			$viewHelperNode->setPointerTemplateCode($templateElement);
 			if ($selfclosing === TRUE) {
-				$node = $state->popNodeFromStack();
+				$state->popNodeFromStack();
 				$this->callInterceptor($viewHelperNode, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
 				// This needs to be called here because closingViewHelperTagHandler() is not triggered for self-closing tags
-				$state->getNodeFromStack()->addChildNode($node);
+				$state->getNodeFromStack()->addChildNode($viewHelperNode);
 			}
 		}
 


### PR DESCRIPTION
The node, which has been wrapped by the interceptor,
needs to be added back to the stack.