### PR TITLE
[BUGFIX] Support dynamic nodes in Layout name attribute

### DIFF
--- a/examples/Resources/Private/Layouts/Dynamic.html
+++ b/examples/Resources/Private/Layouts/Dynamic.html
@@ -1,0 +1,5 @@
+<f:layout name="Dynamic" />
+
+Rendered via DynamicLayout, section "Main":
+
+<f:render section="Main" />

--- a/examples/Resources/Private/Singles/DynamicLayout.html
+++ b/examples/Resources/Private/Singles/DynamicLayout.html
@@ -1,0 +1,9 @@
+<!--
+Setting the format: we force use of a ViewHelper to demonstrate that
+this is also possible - pure {layout} could also be passed
+-->
+<f:layout name="{layout -> f:format.raw()}" />
+
+<f:section name="Main">
+
+</f:section>

--- a/examples/example_dynamiclayout.php
+++ b/examples/example_dynamiclayout.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * EXAMPLE: MVC pattern used with TYPO3.Fluid
+ *
+ * This examples shows how TYPO3.Fluid is integrated
+ * in an MVC context, highlighting which parts may
+ * be replaced in order to adapt the engine to your
+ * favorite MVC framework.
+ *
+ * The alternative to this is single file rendering
+ * - see the other example for that.
+ */
+
+require __DIR__ . '/include/view_init.php';
+
+// Assign Layout name as ViewVariable which we will pass to f:layout as name
+$view->assign('layout', 'Dynamic');
+
+// Set the template path and filename we will render
+$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/DynamicLayout.html');
+
+$output = $view->render();
+
+// Output of Controller "Default" action "Default" using helper from view_init.php
+example_output($output);

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -158,7 +158,8 @@ class ParsingState implements ParsedTemplateInterface {
 	 * @throws View\Exception
 	 */
 	public function getLayoutName(RenderingContextInterface $renderingContext) {
-		return $this->variableContainer->get('layoutName');
+		$layoutName = $this->variableContainer->get('layoutName');
+		return ($layoutName instanceof RootNode ? $layoutName->evaluate($renderingContext) : $layoutName);
 	}
 
 	/**

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -203,6 +203,12 @@ class ExamplesTest extends BaseTestCase {
 					'VariableProvider template from Singles.',
 					'Random: random',
 				)
+			),
+			'example_dynamiclayout.php' => array(
+				'example_dynamiclayout.php',
+				array(
+					'Rendered via DynamicLayout, section "Main":',
+				)
 			)
 		);
 	}

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -188,7 +188,11 @@ class TemplatePathsTest extends BaseTestCase {
 			array(array('examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'), 'html')
 		);
 		$this->assertEquals(
-			array('examples/Resources/Private/Layouts/Default.html', 'examples/Resources/Private/Templates/Default/Default.html'),
+			array(
+				'examples/Resources/Private/Layouts/Default.html',
+				'examples/Resources/Private/Layouts/Dynamic.html',
+				'examples/Resources/Private/Templates/Default/Default.html',
+			),
 			$result
 		);
 	}


### PR DESCRIPTION
This enables use of any dynamic expressions, ViewHelpers
or variable references as part of or only value of the
"name" attribute of `f:layout` - see included example
`example_dynamiclayout.php`.

Marked as BUGFIX since this support was advertised
and intended to be included right from the start.

See also: https://forge.typo3.org/issues/70285
See also: https://forge.typo3.org/issues/76314