### PR TITLE
[BUGFIX] Resolve Layout correctly if layout name is a TextNode

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -11,6 +11,7 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -182,6 +183,8 @@ EOD;
 		if ($storedLayoutNameArgument instanceof RootNode) {
 			list ($initialization, $execution) = array_values($this->nodeConverter->convertListOfSubNodes($storedLayoutNameArgument));
 			return $initialization . PHP_EOL . 'return ' . $execution;
+		} elseif ($storedLayoutNameArgument instanceof TextNode && !count($storedLayoutNameArgument->getChildNodes())) {
+			return sprintf('return \'%s\'', $storedLayoutNameArgument->getText());
 		}
 		return 'return $renderingContext->getVariableProvider()->get(\'layoutName\')';
 	}


### PR DESCRIPTION
Resolves an issue where once compiled, if a template used a standard TextNode as name of Layout, the compiled template would fail to render with an exception about failing to resolve a Layout filename due to looking for an unexpected file (missing basename).