### PR TITLE
[FEATURE] Improve the Debug ViewHelper's capabilities

### DIFF
--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -6,19 +6,11 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
- * View helper that outputs its child nodes with \TYPO3Fluid\Flow\var_dump()
  *
- * = Examples =
- *
- * <code>
- * <f:debug>{object}</f:debug>
- * </code>
- * <output>
- * all properties of {object} nicely highlighted
- * </output>
  *
  * <code title="inline notation and custom title">
  * {object -> f:debug(title: 'Custom title')}
@@ -56,6 +48,8 @@ class DebugViewHelper extends AbstractViewHelper {
 	public function initializeArguments() {
 		parent::initializeArguments();
 		$this->registerArgument('typeOnly', 'boolean', 'If TRUE, debugs only the type of variables', FALSE, FALSE);
+		$this->registerArgument('levels', 'integer', 'Levels to render when rendering nested objects/arrays', FALSE, 5);
+		$this->registerArgument('html', 'boolean', 'Render HTML. If FALSE, output is indented plaintext', FALSE, FALSE);
 	}
 
 	/**
@@ -70,6 +64,99 @@ class DebugViewHelper extends AbstractViewHelper {
 			return (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
 		}
 
-		return var_export($expressionToExamine, TRUE);
+		$html = $this->arguments['html'];
+		$levels = $this->arguments['levels'];
+		return static::dumpVariable($expressionToExamine, $html, 1, $levels);
 	}
+
+	/**
+	 * @param mixed $variable
+	 * @param boolean $html
+	 * @param integer $level
+	 * @param integer $levels
+	 * @return string
+	 */
+	protected static function dumpVariable($variable, $html, $level, $levels) {
+		$typeLabel = is_object($variable) ? get_class($variable) : gettype($variable);
+
+		if (!$html) {
+			if (is_scalar($variable)) {
+				$string = sprintf('%s %s', $typeLabel, var_export($variable, TRUE)) . PHP_EOL;
+			} elseif (is_null($variable)) {
+				$string = 'null' . PHP_EOL;
+			} else {
+				$string = sprintf('%s: ', $typeLabel);
+				if ($level > $levels) {
+					$string .= '*Recursion limited*';
+				} else {
+					$string .= PHP_EOL;
+					foreach (static::getValuesOfNonScalarVariable($variable) as $property => $value) {
+						$string .= sprintf(
+							'%s"%s": %s',
+							str_repeat('  ', $level),
+							$property,
+							static::dumpVariable($value, $html, $level + 1, $levels)
+						);
+					}
+				}
+			}
+		} else {
+			if (is_scalar($variable) || is_null($variable)) {
+				$string = sprintf(
+					'<code>%s = %s</code>',
+					$typeLabel,
+					htmlspecialchars(var_export($variable, TRUE), ENT_COMPAT, 'UTF-8', FALSE)
+				);
+			} elseif (is_null($variable)) {
+				$string = 'null' . PHP_EOL;
+			} else {
+				$string = sprintf('<code>%s</code>', $typeLabel);
+				if ($level > $levels) {
+					$string .= '<i>Recursion limited</i>';
+				} else {
+					$string .= '<ul>';
+					foreach (static::getValuesOfNonScalarVariable($variable) as $property => $value) {
+						$string .= sprintf(
+							'<li>%s: %s</li>',
+							$property,
+							static::dumpVariable($value, $html, $level + 1, $levels)
+						);
+					}
+					$string .= '</ul>';
+				}
+			}
+		}
+
+		return $string;
+	}
+
+	/**
+	 * @param mixed $variable
+	 * @retrurn array
+	 */
+	protected static function getValuesOfNonScalarVariable($variable) {
+		if ($variable instanceof \ArrayObject || is_array($variable)) {
+			return (array) $variable;
+		} elseif ($variable instanceof \Iterator) {
+			return iterator_to_array($variable);
+		} elseif (is_resource($variable)) {
+			return stream_get_meta_data($variable);
+		} elseif ($variable instanceof \DateTimeInterface) {
+			return [
+				'class' => get_class($variable),
+				'ISO8601' => $variable->format(\DateTime::ISO8601),
+				'UNIXTIME' => (integer) $variable->format('U')
+			];
+		} else {
+			$reflection = new \ReflectionObject($variable);
+			$properties = $reflection->getProperties();
+			$output = array();
+			foreach ($properties as $property) {
+				$propertyName = $property->getName();
+				$output[$propertyName] = VariableExtractor::extract($variable, $propertyName);
+			}
+			return $output;
+		}
+	}
+
 }

--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString;
 use TYPO3Fluid\Fluid\ViewHelpers\DebugViewHelper;
 
 /**
@@ -41,8 +42,64 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function getRenderTestValues() {
 		return array(
-			array('test', array('typeOnly' => FALSE), "'test'"),
-			array('test', array('typeOnly' => TRUE), 'string'),
+			array('test', array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 1), "string 'test'" . PHP_EOL),
+			array('test', array('typeOnly' => TRUE, 'html' => FALSE, 'levels' => 1), 'string'),
+			array(
+				'test<strong>bold</strong>',
+				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 1),
+				'<code>string = \'test&lt;strong&gt;bold&lt;/strong&gt;\'</code>'
+			),
+			array(
+				array('nested' => 'test<strong>bold</strong>'),
+				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 1),
+				'<code>array</code><ul><li>nested: <code>string = \'test&lt;strong&gt;bold&lt;/strong&gt;\'</code></li></ul>'
+			),
+			array(
+				array('foo' => 'bar'),
+				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 2),
+				'<code>array</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
+			),
+			array(
+				new \ArrayObject(array('foo' => 'bar')),
+				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 2),
+				'<code>ArrayObject</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
+			),
+			array(
+				new \ArrayIterator(array('foo' => 'bar')),
+				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 2),
+				'<code>ArrayIterator</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
+			),
+			array(
+				array('foo' => 'bar'),
+				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
+				'array: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
+			),
+			array(
+				new \ArrayObject(array('foo' => 'bar')),
+				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
+				'ArrayObject: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
+			),
+			array(
+				new \ArrayIterator(array('foo' => 'bar')),
+				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
+				'ArrayIterator: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
+			),
+			array(
+				new UserWithoutToString('username'),
+				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
+				UserWithoutToString::class . ': ' . PHP_EOL . '  "name": string \'username\'' . PHP_EOL
+			),
+			array(
+				NULL,
+				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
+				'null' . PHP_EOL
+			),
+			array(
+				\DateTime::createFromFormat('U', '1468328915'),
+				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
+				'DateTime: ' . PHP_EOL . '  "class": string \'DateTime\'' . PHP_EOL .
+				'  "ISO8601": string \'2016-07-12T13:08:35+0000\'' . PHP_EOL . '  "UNIXTIME": integer 1468328915' . PHP_EOL
+			)
 		);
 	}
 


### PR DESCRIPTION
This change adds the following capabilities to `f:debug`:

* Option to produce HTML output (off by default)
* Option to limit recursion levels (5 by default)
* Ability to render ArrayObject, Iterator as key/value pairs
* Ability to render recursively
* Ability to render stream metadata