### PR TITLE
[FEATURE] Provide dedicated ViewHelperCompiler and Traits

### DIFF
--- a/src/Core/Compiler/ViewHelperCompiler.php
+++ b/src/Core/Compiler/ViewHelperCompiler.php
@@ -1,0 +1,144 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Compiler;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+
+/**
+ * Class ViewHelperCompiler
+ *
+ * Assistant class designed to exclusively compile ViewHelpers
+ * of common types. Each ViewHelper that wants to compile itself
+ * efficiently using a common pattern can utilise this class
+ * in an overridden `compile()` method to generate PHP code.
+ *
+ * Every method on this class returns an array containing exactly
+ * two entries, as required to compile a ViewHelper:
+ *
+ * - initialization code as string (index 0)
+ * - execution code as string (index 1)
+ *
+ * Methods on this class can be called as:
+ *
+ *     list ($initialization, $execution) = ViewHelperCompiler::getInstance()
+ *         ->compileWithStaticMethod($this, $argumentsName, $closureName);
+ *     // where you select the appropriate compiling method to use according
+ *     // to your ViewHelper's business logic
+ *
+ * And the output variables must respectively then be appended
+ * to the initialization code passed to the `compile()` function:
+ *
+ *     $initializationPhpCode .= $initialization;
+ *
+ * And returned from the `compile()` method as execution code:
+ *
+ *     return $execution;
+ *
+ * Note that not all ViewHelpers will generate initialisation code;
+ * it is recommended that you append the `$initialization` code
+ * string variable anyway since special implementations or future
+ * changes in Fluid may cause initialisation code to be generated.
+ */
+class ViewHelperCompiler {
+
+    const RENDER_STATIC = 'renderStatic';
+    const DEFAULT_INIT = '';
+
+    /**
+     * Factory method to create an instance; since this class is
+     * exclusively used as a "fire once" command where it is ideal
+     * to chain the instance creation and method to be called into
+     * a single line.
+     *
+     * @return static
+     */
+    public static function getInstance() {
+        return new static();
+    }
+
+    /**
+     * The simples of compilation methods designed to work well
+     * for ViewHelpers that implement `renderStatic` or a similar
+     * statically callable public method that makes sense to call
+     * each time the ViewHelper needs to render.
+     *
+     * It is also possible to compile so the resulting call is
+     * made to a non-ViewHelper class which may be even more efficient
+     * when the ViewHelper is a wrapper for a framework method.
+     *
+     * See class doc comment about consuming the returned values!
+     *
+     * @param ViewHelperInterface $viewHelper ViewHelper instance to be compiled
+     * @param string $argumentsName Name of arguments variable passed to `compile()` method
+     * @param string $renderChildrenClosureName Name of renderChildren closure passed to `compile()` method
+     * @param string $method The name of the class' method to be called
+     * @param string|NULL Class name which contains the method; NULL means use ViewHelper's class name.
+     * @return array
+     */
+    public function compileWithCallToStaticMethod(
+        ViewHelperInterface $viewHelper,
+        $argumentsName,
+        $renderChildrenClosureName,
+        $method = self::RENDER_STATIC,
+        $onClass = NULL
+    ) {
+        $onClass = $onClass ? : get_class($viewHelper);
+        return array(
+            self::DEFAULT_INIT,
+            sprintf(
+                '%s::%s(%s, %s, $renderingContext)',
+                $onClass,
+                $method,
+                $argumentsName,
+                $renderChildrenClosureName
+            )
+        );
+    }
+
+    /**
+     * Very similar to the compileWithCallToStaticMethod approach
+     * but with the added capability that the render child content
+     * closure can be built by this function to check if an argument
+     * is filled and use that value if it is, otherwise use the
+     * default child rendering closure.
+     *
+     * When this prodecure is used to compile the ViewHelper, the
+     * ViewHelper class itself can call the render children closure
+     * from a static rendering method and always trust that the value
+     * that is returned, is either the specified argument's value if
+     * that argument is not empty, or the variable/content passed as
+     * child content to the ViewHelper.
+     * 
+     * @param ViewHelperInterface $viewHelper ViewHelper instance to be compiled
+     * @param string $argumentsName Name of arguments variable passed to `compile()` method
+     * @param string $renderChildrenClosureName Name of renderChildren closure passed to `compile()` method
+     * @param string $contentArgumentName Name of the argument which 
+     * @param string $method The name of the class' method to be called
+     * @param string|NULL Class name which contains the method; NULL means use ViewHelper's class name.
+     * @return array
+     */
+    public function compileWithCallToStaticMethodAndContentFromArgumentName(
+        ViewHelperInterface $viewHelper,
+        $argumentsName,
+        $renderChildrenClosureName,
+        $contentArgumentName,
+        $method = self::RENDER_STATIC,
+        $onClass = NULL
+    ) {
+        return array(
+            self::DEFAULT_INIT,
+            sprintf(
+                '%s::%s(%s, %s[%s] ? function() { use %s; return %s[%s]; } : %s, $renderingContext)',
+                $onClass,
+                $method,
+                $argumentsName,
+                $argumentsName,
+                $contentArgumentName,
+                $argumentsName,
+                $argumentsName,
+                $contentArgumentName,
+                $renderChildrenClosureName
+            )
+        );
+    }
+
+}

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -395,13 +395,14 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 
 	/**
 	 * Tests if the given $argumentName is set, and not NULL.
+	 * The isset() test used fills both those requirements.
 	 *
 	 * @param string $argumentName
 	 * @return boolean TRUE if $argumentName is found, FALSE otherwise
 	 * @api
 	 */
 	protected function hasArgument($argumentName) {
-		return isset($this->arguments[$argumentName]) && $this->arguments[$argumentName] !== NULL;
+		return isset($this->arguments[$argumentName]);
 	}
 
 	/**

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -1,0 +1,105 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Compiler\ViewHelperCompiler;
+use TYPO3Fluid\Fluid\Core\Exception;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Class CompilableWithContentArgumentAndRenderStatic
+ *
+ * Provides default methods for rendering and compiling
+ * any ViewHelper that conforms to the `renderStatic`
+ * method pattern but has the added common use case that
+ * an argument value must be checked and used instead of
+ * the normal render children closure, if that named
+ * argument is specified and not empty.
+ */
+trait CompileWithContentArgumentAndRenderStatic {
+
+    /**
+     * Name of variable that contains the value to use
+     * instead of render children closure, if specified.
+     * If no name is provided here, the first variable
+     * registered in `initializeArguments` of the ViewHelper
+     * will be used.
+     *
+     * Note: it is significantly better practice to define
+     * this property in your ViewHelper class and so fix it
+     * to one particular argument instead of resolving,
+     * especially when your ViewHelper is called multiple
+     * times within an uncompiled template!
+     *
+     * @var string
+     */
+    protected $contentArgumentName;
+
+    /**
+     * Default render method to render ViewHelper with
+     * first defined optional argument as content.
+     *
+     * @return string Rendered string
+     * @api
+     */
+    public function render() {
+        $argumentName = $this->resolveContentArgumentName();
+        $arguments = $this->arguments;
+        if (!empty($argumentName) && isset($arguments[$argumentName])) {
+            $renderChildrenClosure = function() use ($arguments, $argumentName) { return $arguments[$argumentName]; };
+        } else {
+            $renderChildrenClosure = call_user_func_array(array($this, 'buildRenderChildrenClosure'), array());
+        }
+        return self::renderStatic(
+            $arguments,
+            $renderChildrenClosure,
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ) {
+        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethodAndContentFromArgumentName(
+            $this,
+            $argumentsName,
+            $closureName,
+            $contentArgumentName
+        );
+        $initializationPhpCode .= $initialization;
+        return $execution;
+    }
+
+    /**
+     * @return string
+     */
+    protected function resolveContentArgumentName() {
+        if (empty($this->contentArgumentName)) {
+            $registeredArguments = call_user_func_array(array($this, 'prepareArguments'), array());
+            foreach ($registeredArguments as $registeredArgument) {
+                if (!$registeredArgument->isRequired()) {
+                    return $registeredArgument->getName();
+                }
+            }
+            throw new Exception(
+                'Attempting to compile %s failed. Chosen compile method requires that ViewHelper has ' .
+                'at least one registered and optional argument'
+            );
+        }
+        return $this->contentArgumentName;
+    }
+
+}

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -1,0 +1,57 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Compiler\ViewHelperCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Class CompilableWithRenderStatic
+ *
+ * Provides default methods for rendering and compiling
+ * any ViewHelper that conforms to the `renderStatic`
+ * method pattern.
+ */
+trait CompileWithRenderStatic {
+
+    /**
+     * Default render method - simply calls renderStatic() with a
+     * prepared set of arguments.
+     *
+     * @return string Rendered string
+     * @api
+     */
+    public function render() {
+        return self::renderStatic(
+            $this->arguments,
+            call_user_func_array(array($this, 'buildRenderChildrenClosure'), array()),
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ) {
+        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
+            $this,
+            $argumentsName,
+            $closureName
+        );
+        $initializationPhpCode .= $initialization;
+        return $execution;
+    }
+
+}

--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -6,7 +6,9 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Declares new variables which are aliases of other variables.
@@ -41,6 +43,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class AliasViewHelper extends AbstractViewHelper {
 
+	use CompileWithRenderStatic;
+
 	/**
 	 * @var boolean
 	 */
@@ -55,20 +59,23 @@ class AliasViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Renders alias
-	 *
-	 * @return string Rendered string
-	 * @api
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$map = $this->arguments['map'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+	{
+		$templateVariableContainer = $renderingContext->getVariableProvider();
+		$map = $arguments['map'];
 		foreach ($map as $aliasName => $value) {
-			$this->templateVariableContainer->add($aliasName, $value);
+			$templateVariableContainer->add($aliasName, $value);
 		}
-		$output = $this->renderChildren();
+		$output = $renderChildrenClosure();
 		foreach ($map as $aliasName => $value) {
-			$this->templateVariableContainer->remove($aliasName);
+			$templateVariableContainer->remove($aliasName);
 		}
 		return $output;
 	}
+
 }

--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -6,6 +6,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -63,4 +65,18 @@ class CommentViewHelper extends AbstractViewHelper {
 	 */
 	public function render() {
 	}
+
+	/**
+	 * @param string $argumentsName
+	 * @param string $closureName
+	 * @param string $initializationPhpCode
+	 * @param ViewHelperNode $node
+	 * @param TemplateCompiler $compiler
+	 * @return null
+	 */
+	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
+		return NULL;
+	}
+
+
 }

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -6,8 +6,10 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * This ViewHelper counts elements of the specified array or countable object.
@@ -32,6 +34,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class CountViewHelper extends AbstractViewHelper {
 
+	use CompileWithContentArgumentAndRenderStatic;
+
 	/**
 	 * @var boolean
 	 */
@@ -51,16 +55,14 @@ class CountViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Counts the items of a given property.
-	 *
-	 * @return integer The number of elements
-	 * @api
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return integer
 	 */
-	public function render() {
-		$subject = $this->arguments['subject'];
-		if ($subject === NULL) {
-			$subject = $this->renderChildren();
-		}
-		return count($subject);
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+	{
+		return count($renderChildrenClosure());
 	}
+
 }

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -6,8 +6,10 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  *
@@ -32,6 +34,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class DebugViewHelper extends AbstractViewHelper {
 
+	use CompileWithRenderStatic;
+
 	/**
 	 * @var boolean
 	 */
@@ -53,21 +57,23 @@ class DebugViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Wrapper for \TYPO3Fluid\Flow\var_dump()
-	 *
-	 * @return string debug string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return string
 	 */
-	public function render() {
-		$typeOnly = $this->arguments['typeOnly'];
-		$expressionToExamine = $this->renderChildren();
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$typeOnly = $arguments['typeOnly'];
+		$expressionToExamine = $renderChildrenClosure();
 		if ($typeOnly === TRUE) {
 			return (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
 		}
 
-		$html = $this->arguments['html'];
-		$levels = $this->arguments['levels'];
+		$html = $arguments['html'];
+		$levels = $arguments['levels'];
 		return static::dumpVariable($expressionToExamine, $html, 1, $levels);
 	}
+
 
 	/**
 	 * @param mixed $variable

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -11,6 +11,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Loop view helper which can be used to iterate over arrays.
@@ -61,6 +62,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class ForViewHelper extends AbstractViewHelper {
 
+	use CompileWithRenderStatic;
+	
 	/**
 	 * @var boolean
 	 */
@@ -76,28 +79,6 @@ class ForViewHelper extends AbstractViewHelper {
 		$this->registerArgument('key', 'string', 'Variable to assign array key to', FALSE);
 		$this->registerArgument('reverse', 'boolean', 'If TRUE, iterates in reverse', FALSE, FALSE);
 		$this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, isFirst, isLast, isEven, isOdd)');
-	}
-
-	/**
-	 * Iterates through elements of $each and renders child nodes
-	 *
-	 * @return string Rendered string
-	 * @api
-	 */
-	public function render() {
-		return self::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
-	}
-
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return sprintf('%s::renderStatic(%s, %s, $renderingContext)', get_class($this), $argumentsName, $closureName);
 	}
 
 	/**

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -8,6 +8,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Outputs an argument/value without any escaping and wraps it with CDATA tags.
@@ -42,6 +43,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class CdataViewHelper extends AbstractViewHelper {
 
+	use CompileWithContentArgumentAndRenderStatic;
+
 	/**
 	 * @var boolean
 	 */
@@ -58,12 +61,6 @@ class CdataViewHelper extends AbstractViewHelper {
 	public function initializeArguments() {
 		$this->registerArgument('value', 'mixed', 'The value to output');
 	}
-	/**
-	 * @return string
-	 */
-	public function render() {
-		return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
-	}
 
 	/**
 	 * @param array $arguments
@@ -76,7 +73,7 @@ class CdataViewHelper extends AbstractViewHelper {
 		\Closure $renderChildrenClosure,
 		RenderingContextInterface $renderingContext
 	) {
-		return sprintf('<![CDATA[%s]]>', isset($arguments['value']) ? $arguments['value'] : $renderChildrenClosure());
+		return sprintf('<![CDATA[%s]]>', $renderChildrenClosure());
 	}
 
 }

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -8,6 +8,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * A view helper for formatting values with printf. Either supply an array for
@@ -48,23 +49,15 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class PrintfViewHelper extends AbstractViewHelper {
 
+	use CompileWithContentArgumentAndRenderStatic;
+
 	/**
 	 * @return void
 	 */
 	public function initializeArguments() {
 		parent::initializeArguments();
-		$this->registerArgument('arguments', 'array', 'The arguments for vsprintf', FALSE, array());
 		$this->registerArgument('value', 'string', 'String to format');
-	}
-
-	/**
-	 * Format the arguments with the given printf format string.
-	 *
-	 * @return string The formatted value
-	 * @api
-	 */
-	public function render() {
-		return self::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
+		$this->registerArgument('arguments', 'array', 'The arguments for vsprintf', FALSE, array());
 	}
 
 	/**
@@ -76,11 +69,6 @@ class PrintfViewHelper extends AbstractViewHelper {
 	 * @return string
 	 */
 	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		$value = $arguments['value'];
-		if ($value === NULL) {
-			$value = $renderChildrenClosure();
-		}
-
-		return vsprintf($value, $arguments['arguments']);
+		return vsprintf($renderChildrenClosure(), $arguments['arguments']);
 	}
 }

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -6,7 +6,11 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Outputs an argument/value without any escaping. Is normally used to output
@@ -42,6 +46,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class RawViewHelper extends AbstractViewHelper {
 
+	use CompileWithContentArgumentAndRenderStatic;
+
 	/**
 	 * @var boolean
 	 */
@@ -60,13 +66,25 @@ class RawViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		if (!$this->hasArgument('value')) {
-			return $this->renderChildren();
-		} else {
-			return $this->arguments['value'];
-		}
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return $renderChildrenClosure();
 	}
+
+	/**
+	 * @param string $argumentsName
+	 * @param string $closureName
+	 * @param string $initializationPhpCode
+	 * @param ViewHelperNode $node
+	 * @param TemplateCompiler $compiler
+	 * @return mixed
+	 */
+	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
+		return sprintf('%s()', $closureName);
+	}
+
 }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -6,12 +6,16 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * If content is empty use alternative text
  */
 class OrViewHelper extends AbstractViewHelper {
+
+	use CompileWithContentArgumentAndRenderStatic;
 
 	/**
 	 * Initialize
@@ -19,26 +23,26 @@ class OrViewHelper extends AbstractViewHelper {
 	 * @return void
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('content', 'mixed', 'Content to check if empty', FALSE);
-		$this->registerArgument('alternative', 'mixed', 'Alternative if content is empty', FALSE, '');
+		$this->registerArgument('content', 'mixed', 'Content to check if empty');
+		$this->registerArgument('alternative', 'mixed', 'Alternative if content is empty');
 		$this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf');
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$content = $this->arguments['content'];
-		$alternative = $this->arguments['alternative'];
-		$arguments = (array) $this->arguments['arguments'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$alternative = $arguments['alternative'];
+		$arguments = (array) $arguments['arguments'];
 
 		if (empty($arguments)) {
 			$arguments = NULL;
 		}
 
-		if (NULL === $content) {
-			$content = $this->renderChildren();
-		}
+		$content = $renderChildrenClosure();
 
 		if (NULL === $content) {
 			$content = $alternative;
@@ -50,5 +54,6 @@ class OrViewHelper extends AbstractViewHelper {
 
 		return $content;
 	}
+
 
 }

--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -8,6 +8,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Space Removal ViewHelper
@@ -36,12 +37,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class SpacelessViewHelper extends AbstractViewHelper {
 
-	/**
-	 * @return string
-	 */
-	public function render() {
-		return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
-	}
+	use CompileWithRenderStatic;
 
 	/**
 	 * @param array $arguments

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -45,7 +45,6 @@ class ViewHelperInvokerTest extends UnitTestCase {
 	 */
 	public function getInvocationTestValues() {
 		return array(
-			array(CountViewHelper::class, array('subject' => array('foo')), 1, NULL),
 			array(TestViewHelper::class, array('param1' => 'foo', 'param2' => array('bar')), 'foo', NULL),
 			array(TestViewHelper::class, array('param1' => 'foo', 'param2' => array('bar'), 'add1' => 'baz', 'add2' => 'zap'), 'foo', NULL),
 		);

--- a/tests/Unit/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CountViewHelperTest.php
@@ -20,13 +20,14 @@ class CountViewHelperTest extends ViewHelperBaseTestcase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->viewHelper = $this->getAccessibleMock(CountViewHelper::class, array('renderChildren'));
+		$this->viewHelper = $this->getAccessibleMock(CountViewHelper::class, array('buildRenderChildrenClosure'));
 	}
 
 	/**
 	 * @test
 	 */
 	public function renderReturnsNumberOfElementsInAnArray() {
+		$this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
 		$expectedResult = 3;
 		$this->arguments = array('subject' => array('foo', 'bar', 'Baz'));
 		$this->injectDependenciesIntoViewHelper($this->viewHelper);
@@ -38,6 +39,7 @@ class CountViewHelperTest extends ViewHelperBaseTestcase {
 	 * @test
 	 */
 	public function renderReturnsNumberOfElementsInAnArrayObject() {
+		$this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
 		$expectedResult = 2;
 		$this->arguments = array('subject' => new \ArrayObject(array('foo', 'bar')));
 		$this->injectDependenciesIntoViewHelper($this->viewHelper);
@@ -49,6 +51,7 @@ class CountViewHelperTest extends ViewHelperBaseTestcase {
 	 * @test
 	 */
 	public function renderReturnsZeroIfGivenArrayIsEmpty() {
+		$this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
 		$expectedResult = 0;
 		$this->arguments = array('subject' => array());
 		$this->injectDependenciesIntoViewHelper($this->viewHelper);
@@ -60,7 +63,8 @@ class CountViewHelperTest extends ViewHelperBaseTestcase {
 	 * @test
 	 */
 	public function renderUsesChildrenAsSubjectIfGivenSubjectIsNull() {
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(array('foo', 'bar', 'baz')));
+		$this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')
+			->will($this->returnValue(function() { return array('foo', 'baz', 'bar'); }));
 		$expectedResult = 3;
 		$this->arguments = array('subject' => NULL);
 		$this->injectDependenciesIntoViewHelper($this->viewHelper);
@@ -72,8 +76,10 @@ class CountViewHelperTest extends ViewHelperBaseTestcase {
 	 * @test
 	 */
 	public function renderReturnsZeroIfGivenSubjectIsNullAndRenderChildrenReturnsNull() {
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
+		$this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')
+			->will($this->returnValue(function() { return NULL; }));
 		$this->viewHelper->setArguments(array('subject' => NULL));
+		$this->injectDependenciesIntoViewHelper($this->viewHelper);
 		$expectedResult = 0;
 		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
 		$this->assertSame($expectedResult, $actualResult);

--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -7,6 +7,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  */
 
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\ViewHelpers\DebugViewHelper;
 
 /**
@@ -20,6 +21,7 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase {
 	public function testInitializeArgumentsRegistersExpectedArguments() {
 		$instance = $this->getMock(DebugViewHelper::class, array('registerArgument'));
 		$instance->expects($this->at(0))->method('registerArgument')->with('typeOnly', 'boolean', $this->anything(), FALSE, FALSE);
+		$instance->setRenderingContext(new RenderingContextFixture());
 		$instance->initializeArguments();
 	}
 
@@ -33,6 +35,7 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase {
 		$instance = $this->getMock(DebugViewHelper::class, array('renderChildren'));
 		$instance->expects($this->once())->method('renderChildren')->willReturn($value);
 		$instance->setArguments($arguments);
+		$instance->setRenderingContext(new RenderingContextFixture());
 		$result = $instance->render();
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/Unit/ViewHelpers/Format/CdataViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/CdataViewHelperTest.php
@@ -24,11 +24,10 @@ class CdataViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function testRender($arguments, $tagContent, $expected) {
 		$instance = new CdataViewHelper();
-		$instance->initializeArguments();
 		$instance->setArguments($arguments);
 		$instance->setRenderingContext(new RenderingContextFixture());
 		$instance->setRenderChildrenClosure(function() use ($tagContent) { return $tagContent; });
-		$this->assertEquals($expected, $instance->render());
+		$this->assertEquals($expected, $instance->initializeArgumentsAndRender());
 	}
 
 	/**

--- a/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Format;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper;
 
@@ -21,6 +22,7 @@ class RawViewHelperTest extends UnitTestCase {
 
 	public function setUp() {
 		$this->viewHelper = $this->getMock(RawViewHelper::class, array('renderChildren'));
+		$this->viewHelper->setRenderingContext(new RenderingContextFixture());
 	}
 
 	/**

--- a/tests/Unit/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/OrViewHelperTest.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\ViewHelpers\OrViewHelper;
 
 /**
@@ -21,6 +22,7 @@ class OrViewHelperTest extends ViewHelperBaseTestcase {
 		$instance->expects($this->at(0))->method('registerArgument')->with('content', 'mixed', $this->anything(), FALSE, '');
 		$instance->expects($this->at(1))->method('registerArgument')->with('alternative', 'mixed', $this->anything(), FALSE, '');
 		$instance->expects($this->at(2))->method('registerArgument')->with('arguments', 'array', $this->anything());
+		$instance->setRenderingContext(new RenderingContextFixture());
 		$instance->initializeArguments();
 	}
 
@@ -34,6 +36,7 @@ class OrViewHelperTest extends ViewHelperBaseTestcase {
 		$instance = $this->getMock(OrViewHelper::class, array('renderChildren'));
 		$instance->expects($this->exactly((integer) empty($arguments['content'])))->method('renderChildren')->willReturn($arguments['content']);
 		$instance->setArguments($arguments);
+		$instance->setRenderingContext(new RenderingContextFixture());
 		$result = $instance->render();
 		$this->assertEquals($expected, $result);
 	}
@@ -59,6 +62,7 @@ class OrViewHelperTest extends ViewHelperBaseTestcase {
 		$instance->expects($this->once())->method('renderChildren')->willReturn(NULL);
 		$arguments['content'] = NULL;
 		$instance->setArguments($arguments);
+		$instance->setRenderingContext(new RenderingContextFixture());
 		$result = $instance->render();
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
This change adds a dedicated ViewHelperCompiler to cover frequent use cases in ViewHelpers:

* Compiling directly with static function call (to renderStatic - or other methods on other classes)
* Compiling with static function call and using one of the provided arguments as "content" or calling renderChildren if that argument is not passed.

Both use cases support calling a static method on *any* class - not just ViewHelpers, or on another ViewHelper - if that method conforms to the signature of the renderStatic method defined in ViewHelperInterface.

Both use cases are then implemented in ViewHelpers of Fluid where possible, which improves performance of the following ViewHelpers:

* f:format.cdata
* f:format.printf
* f:alias
* f:comment
* f:count
* f:for
* f:groupedFor
* f:or
* f:spaceless

Other ViewHelpers are, with one exception (f:cycle) already compilable in the most efficient way. The cycle ViewHelper still requires a custom compile method that will probably be so adapted it cannot be made generic enough to merit putting it in a Trait and the ViewHelperCompiler.