### PR TITLE
[BUGFIX] Fix layout resolving when name is static and cache is enabled

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -150,6 +150,7 @@ class TemplateCompiler {
 %s {
 
 public function getLayoutName(\TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface \$renderingContext) {
+\$self = \$this; 
 %s;
 }
 public function hasLayout() {
@@ -182,8 +183,9 @@ EOD;
 		if ($storedLayoutNameArgument instanceof RootNode) {
 			list ($initialization, $execution) = array_values($this->nodeConverter->convertListOfSubNodes($storedLayoutNameArgument));
 			return $initialization . PHP_EOL . 'return ' . $execution;
+		} else {
+			return 'return (string) \'' . $storedLayoutNameArgument . '\'';
 		}
-		return 'return $renderingContext->getVariableProvider()->get(\'layoutName\')';
 	}
 
 	/**

--- a/src/ViewHelpers/SwitchViewHelper.php
+++ b/src/ViewHelpers/SwitchViewHelper.php
@@ -173,7 +173,7 @@ class SwitchViewHelper extends AbstractViewHelper {
 	 * @return string
 	 */
 	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		$phpCode = 'call_user_func(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+		$phpCode = 'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
 			'switch ($arguments[\'expression\']) {' . PHP_EOL;
 		$expressionEvaluationClosureName = $compiler->variableName('switchExpressionClosure');
 		foreach ($node->getChildNodes() as $childNode) {

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -145,6 +145,7 @@ abstract class BaseFunctionalTestCase extends UnitTestCase {
 	public function testTemplateCodeFixtureWithCache($sourceOrStream, array $variables, array $expected, array $notExpected, $expectedException = NULL) {
 		if ($this->getCache()) {
 			$this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, TRUE);
+			$this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, TRUE);
 		}
 	}
 

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -46,6 +46,7 @@ class ExamplesTest extends BaseTestCase {
 		}
 		$cache = vfsStream::url('fakecache/');
 		$this->runExampleScriptTest($script, $expectedOutputs, $cache);
+		$this->runExampleScriptTest($script, $expectedOutputs, $cache);
 	}
 
 	/**

--- a/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
@@ -161,7 +161,7 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase {
 		return array(
 			'Empty switch statement' => array(
 				$emptySwitchNode,
-				'call_user_func(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+				'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
 				'switch ($arguments[\'expression\']) {' .
 				PHP_EOL . '}' . PHP_EOL .
 				'}, array($arguments))',
@@ -169,7 +169,7 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase {
 			),
 			'With default case only' => array(
 				$withDefaultCaseOnly,
-				'call_user_func(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+				'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
 				'switch ($arguments[\'expression\']) {' . PHP_EOL .
 				'default: return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
 				'return NULL;' . PHP_EOL .
@@ -179,7 +179,7 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase {
 			),
 			'With single case only' => array(
 				$withSingleCaseOnly,
-				'call_user_func(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+				'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
 				'switch ($arguments[\'expression\']) {' . PHP_EOL .
 				'case call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
 				'$argument = unserialize(\'s:3:"foo";\'); return $argument->evaluate($renderingContext);' . PHP_EOL .


### PR DESCRIPTION
In compiled templates using static layout names the layout name would not be resolved correctly, causing the template to fail. In addition, an assigned variable $self was lacking in getLayoutName - this variable would be required by closures potentially generated by compiling RootNodes as per https://github.com/TYPO3Fluid/Fluid/commit/1cc3600097b74420c3fc857977b0af6bfbeafed1.

In addition, Switch ViewHelper's compile method has been very slightly changed to use `call_user_func_array` in order to correctly pass arguments to the lambda function that gets called.