### PR TITLE
[TASK] Micro-optimisation in ObjectAccessorNode->evaluate

### DIFF
--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -28,6 +28,20 @@ class ObjectAccessorNode extends AbstractNode {
 	 */
 	protected $accessors = array();
 
+    /**
+     * Reserved variables which have default, static values
+     *
+     * @var array
+     */
+    protected static $reserved = array(
+        'true' => TRUE,
+        'on' => TRUE,
+        'yes' => TRUE,
+        'false' => FALSE,
+        'off' => FALSE,
+        'no' => FALSE
+    );
+
 	/**
 	 * Constructor. Takes an object path as input.
 	 *
@@ -74,21 +88,15 @@ class ObjectAccessorNode extends AbstractNode {
 	 * @return object The evaluated object, can be any object type.
 	 */
 	public function evaluate(RenderingContextInterface $renderingContext) {
-		$variableProvider = $renderingContext->getVariableProvider();
-		switch (strtolower($this->objectPath)) {
-			case '_all':
-				return $variableProvider->getAll();
-			case 'true':
-			case 'on':
-			case 'yes':
-				return TRUE;
-			case 'false':
-			case 'off':
-			case 'no':
-				return FALSE;
-			default:
-				return VariableExtractor::extract($variableProvider, $this->objectPath, $this->accessors);
-		}
+        $objectPath = strtolower($this->objectPath);
+        if (isset(static::$reserved[$objectPath])) {
+            return static::$reserved[$objectPath];
+        }
+        $variableProvider = $renderingContext->getVariableProvider();
+        if ($objectPath === '_all') {
+            return $variableProvider->getAll();
+        }
+        return VariableExtractor::extract($variableProvider, $this->objectPath, $this->accessors);
 	}
 
 }


### PR DESCRIPTION
The method is refactored to clearly declare as class property the list of reserved variable names and their values. The switch is (although nicely performant) replaced by two if-clauses, which avoid calling ->getVariableProvider on RenderingContext if retrieving default constants.

See also: https://github.com/TYPO3Fluid/Fluid/issues/127