### PR TITLE
[BUGFIX] Detect/allow number-prefixed variables in array parts

### DIFF
--- a/examples/Resources/Private/Singles/Variables.html
+++ b/examples/Resources/Private/Singles/Variables.html
@@ -22,6 +22,10 @@ String variable name with dynamic2 part: {stringwith{dynamic2}part}.
 Array member in $array[$dynamic1]: {array.{dynamic1}}
 Array member in $array[$dynamic2]: {array.{dynamic2}}
 
+<!-- Numerically prefixed variables -->
+Direct access of numeric prefixed variable: {123numericprefix}
+<f:alias map="{mappedNumericPrefix: 123numericprefix}">Aliased access of numeric prefixed variable: {mappedNumericPrefix}</f:alias>
+
 <!-- Passing arguments to sections/partials -->
 <f:render section="Secondary" arguments="{
 	myVariable: 'Nice string',

--- a/examples/example_variables.php
+++ b/examples/example_variables.php
@@ -25,6 +25,7 @@ $view->assignMultiple(array(
 		'anArray' => array('one', 'two'),
 		'typeNameInteger' => 'integer'
 	),
+    'foobar' => 'string foo',
 	// The variables we will use as dynamic part names:
 	'dynamic1' => $dynamic1,
 	'dynamic2' => $dynamic2,
@@ -41,7 +42,8 @@ $view->assignMultiple(array(
 		),
 		$dynamic1 => 'Dynamic key in $array[$dynamic1]',
 		$dynamic2 => 'Dynamic key in $array[$dynamic2]',
-	)
+	),
+    '123numericprefix' => 'Numeric prefixed variable'
 ));
 
 // Assigning the template path and filename to be rendered. Doing this overrides

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -234,7 +234,7 @@ abstract class Patterns {
 					(?:"(?:\\\"|[^"])*")
 					|(?:\'(?:\\\\\'|[^\'])*\')
 				)
-				|(?P<VariableIdentifier>[a-zA-Z][a-zA-Z0-9\-_.]*)  # variable identifiers have to start with a letter
+				|(?P<VariableIdentifier>[a-zA-Z0-9\-_.]*[a-zA-Z]+)  # variable identifiers must contain letters (otherwise they are hardcoded numbers)
 				|(?P<Number>[0-9.]+)                               # Number
 				|{\s*(?P<Subarray>(?:(?P>ArrayPart)\s*,?\s*)+)\s*} # Another sub-array
 			)                                                      # END possible value options

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -185,6 +185,7 @@ class ExamplesTest extends BaseTestCase {
 			'example_variables.php' => array(
 				'example_variables.php',
 				array(
+				    'Simple variable: string foo',
 					'A string with numbers in it: 132',
 					'Ditto, with type name stored in variable: 132',
 					'A comma-separated value iterated as array:' . "\n\t- one\n\t- two",
@@ -192,6 +193,8 @@ class ExamplesTest extends BaseTestCase {
 					'String variable name with dynamic2 part: String using $dynamic2.',
 					'Array member in $array[$dynamic1]: Dynamic key in $array[$dynamic1]',
 					'Array member in $array[$dynamic2]: Dynamic key in $array[$dynamic2]',
+                    'Direct access of numeric prefixed variable: Numeric prefixed variable',
+                    'Aliased access of numeric prefixed variable: Numeric prefixed variable',
 					'Received $array.foobar with value Escaped string',
 					'Received $array.baz with value 42',
 					'Received $array.xyz.foobar with value Escaped sub-string',


### PR DESCRIPTION
This change fixes an issue where a template variable named for example "123variable" would render correctly when referenced as `{123variable}` but if used in an array part like for example `<f:alias map="{newVar: 123variable}">` the variable would not be resolved. Instead, a numeric value of `123` would be cast by the parser. Loosening up the expression which required array part variable references to start with a letter solves the issue.

See also: https://forge.typo3.org/issues/76276