### PR TITLE
[BUGFIX] Prevent loop exit when reaching empty template path (#136)

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -659,7 +659,7 @@ class TemplatePaths {
 		// Note about loop: iteration with while + array_pop causes paths to be checked in opposite
 		// order, which is intentional. Paths are considered overlays, e.g. adding a path to the
 		// array means you want that path checked first.
-		while ($path = array_pop($paths)) {
+		while (null !== ($path = array_pop($paths))) {
 			$pathAndFilenameWithoutFormat = $path . $relativePathAndFilename;
 			$pathAndFilename = $pathAndFilenameWithoutFormat . '.' . $format;
 			if (is_file($pathAndFilename)) {


### PR DESCRIPTION
Explicitly check for null when testing for the end of the paths
array when searching for file candidates. This fixes an issue with empty
strings as root path, which would immediately stop the iteration and
trigger an exception.

Resolves: #135