### PR TITLE
[BUGFIX] Support cached OrViewHelper

### DIFF
--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -19,7 +19,7 @@ class OrViewHelper extends AbstractViewHelper {
 	 * @return void
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('content', 'mixed', 'Content to check if empty', FALSE, '');
+		$this->registerArgument('content', 'mixed', 'Content to check if empty', FALSE);
 		$this->registerArgument('alternative', 'mixed', 'Alternative if content is empty', FALSE, '');
 		$this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf', FALSE, NULL);
 	}


### PR DESCRIPTION
When the OrViewHelper gets cached, the $argumentsX variable
gets filled with NULL and the ViewHelperInvoker tests this
with isset(). If this isset() returns false, the Invoker then
fills the argument with its default value. In this case an empty
string is filled and not NULL, like expected.

You can replicate this by using the OrViewHelper once without cache
and then with cache. The cached version will return an empty string
instead of the provided alternative.