### PR TITLE
[BUGFIX] Tolerate whitespace in tag attribute parsing

### DIFF
--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -24,7 +24,9 @@ abstract class Patterns {
 					(?:(?:[a-z0-9\\.]*):[a-zA-Z0-9\\.]+)  # A tag consists of the namespace prefix and word characters
 					(?:                                   # Begin tag arguments
 						\s*[a-zA-Z0-9:-]+                 # Argument Keys
+						\s*
 						=                                 # =
+						\s*
 						(?>                               # either... If we have found an argument, we will not back-track (That does the Atomic Bracket)
 							"(?:\\\"|[^"])*"              # a double-quoted string
 							|\'(?:\\\\\'|[^\'])*\'        # or a single quoted string
@@ -51,13 +53,15 @@ abstract class Patterns {
 			(?:                                           # A tag might have multiple attributes
 				\s*
 				[a-zA-Z0-9:-]+                            # The attribute name
+				\s*
 				=                                         # =
+				\s*
 				(?>                                       # either... # If we have found an argument, we will not back-track (That does the Atomic Bracket)
 					"(?:\\\"|[^"])*"                      # a double-quoted string
 					|\'(?:\\\\\'|[^\'])*\'                # or a single quoted string
 				)                                         #
 				\s*
-			)*                                            # A tag might have multiple attributes
+			)*
 		)                                                 # End Tag Attributes
 		\s*
 		(?P<Selfclosing>\/?)                              # A tag might be selfclosing
@@ -79,7 +83,9 @@ abstract class Patterns {
 			(?P<Argument>                                # The attribute name
 				[a-zA-Z0-9:-]+                           #
 			)                                            #
+			\s*                                          #
 			=                                            # =
+			\s*                                          #
 			(?>                                          # If we have found an argument, we will not back-track (That does the Atomic Bracket)
 				(?P<ValueQuoted>                         # either...
 					(?:"(?:\\\"|[^"])*")                 # a double-quoted string

--- a/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
+++ b/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
+
+use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
+
+/**
+ * Class WhitespaceToleranceTest
+ */
+class WhitespaceToleranceTest extends BaseFunctionalTestCase {
+
+    /**
+     * @var array
+     */
+    protected $variables = array();
+
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations() {
+        return array(
+            'Normal expected whitespace tolerance' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'No whitespace before self-close of tag' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works"/>',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace before self-close of tag' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works"      />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace before argument name' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace after argument name' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content    ="works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace before argument value' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content= "works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace after argument name and before argument value' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content = "works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace before and after argument name' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled  content ="works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+            'Extra whitespace before argument name and after argument name and before argument value' => array(
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled  content = "works" />',
+                $this->variables,
+                array('works'),
+                array(),
+            ),
+        );
+    }
+
+}


### PR DESCRIPTION
See included functional test for cases which before this
patch would cause the tag attribute(s) to not be caught
by the parser. Adjusting the regular expressions used to
detect ViewHelper tags, split on dynamic tags and split
ViewHelper argument names/values solves the issue.

Note: additional whitespace in the places documented
by the functional test is valid XML and thus valid Fluid.