### PR TITLE
Allow upper camel case letters as namespace identifier

### DIFF
--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -21,7 +21,7 @@ abstract class Patterns {
 	static public $SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS = '/
 		(
 			(?: <\/?                                      # Start dynamic tags
-					(?:(?:[a-z0-9\\.]*):[a-zA-Z0-9\\.]+)  # A tag consists of the namespace prefix and word characters
+					(?:(?:[a-zA-Z0-9\\.]*):[a-zA-Z0-9\\.]+)  # A tag consists of the namespace prefix and word characters
 					(?:                                   # Begin tag arguments
 						\s*[a-zA-Z0-9:-]+                 # Argument Keys
 						=                                 # =


### PR DESCRIPTION
In earlier versions it was allowed to use lower and upper case letters for namespace identifier. Further upper case letters are still valid via your Pattern: $SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG

So would be cool to see allowed upper case letters in namespace identifiers again in your code.

Stefan