### PR TITLE
[TASK] Use strpos instead of stristr

### DIFF
--- a/src/Core/Parser/BooleanParser.php
+++ b/src/Core/Parser/BooleanParser.php
@@ -422,7 +422,7 @@ class BooleanParser {
 	 * @return mixed
 	 */
 	public function evaluateTerm($x, $context) {
-		if (substr($x, 0, 1) === '{' && substr($x, -1) === '}') {
+		if (strpos($x, '{') === 0 && substr($x, -1) === '}') {
 			if ($this->compileToCode === TRUE) {
 				return '($context["' . trim($x, '{}') . '"])';
 			}
@@ -433,7 +433,7 @@ class BooleanParser {
 			if ($this->compileToCode === TRUE) {
 				return $x;
 			}
-			if (stristr($x, '.')) {
+			if (strpos($x, '.') !== FALSE) {
 				return floatval($x);
 			} else {
 				return intval($x);

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -98,7 +98,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface 
 			foreach ($matchedVariables as $namespaceMatch) {
 				$viewHelperNamespace = $this->renderingContext->getTemplateParser()->unquoteString($namespaceMatch[2]);
 				$phpNamespace = $viewHelperResolver->resolvePhpNamespaceFromFluidNamespace($viewHelperNamespace);
-				if (stristr($phpNamespace, '/') === FALSE) {
+				if (strpos($phpNamespace, '/') === FALSE) {
 					$viewHelperResolver->addNamespace($namespaceMatch[1], $phpNamespace);
 				}
 			}

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -111,7 +111,7 @@ class VariableExtractor {
 	 * @return array
 	 */
 	protected function resolveSubVariableReferences($subject, $propertyPath) {
-		if (stristr($propertyPath, '{')) {
+		if (strpos($propertyPath, '{')) {
 			preg_match_all('/(\{.*\})/', $propertyPath, $matches);
 			foreach ($matches[1] as $match) {
 				$subPropertyPath = substr($match, 1, -1);

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -111,7 +111,7 @@ class VariableExtractor {
 	 * @return array
 	 */
 	protected function resolveSubVariableReferences($subject, $propertyPath) {
-		if (strpos($propertyPath, '{')) {
+		if (strpos($propertyPath, '{') !== FALSE) {
 			preg_match_all('/(\{.*\})/', $propertyPath, $matches);
 			foreach ($matches[1] as $match) {
 				$subPropertyPath = substr($match, 1, -1);

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -208,7 +208,7 @@ class ViewHelperResolver {
 			return TRUE;
 		}
 		foreach (array_keys($this->namespaces) as $existingNamespaceIdentifier) {
-			if (stristr($existingNamespaceIdentifier, '*') === FALSE) {
+			if (strpos($existingNamespaceIdentifier, '*') === FALSE) {
 				continue;
 			}
 			$pattern = '/' . str_replace(array('.', '*'), array('\\.', '[a-zA-Z0-9\.]*'), $existingNamespaceIdentifier) . '/';


### PR DESCRIPTION
`stristr` creates a copy of the string which is not required if we
just want to check if a string contains a string.
The case insensitive check is also not requird if we check for characters
that do not have an uppercase representation.