### PR TITLE
[TASK] Remove superfluous default values in registerArgument

### DIFF
--- a/doc/FLUID_CREATING_VIEWHELPERS.md
+++ b/doc/FLUID_CREATING_VIEWHELPERS.md
@@ -39,7 +39,7 @@ class CombineViewHelper extends AbstractViewHelper {
      * @return void
      */
     public function initializeArguments() {
-        $this->registerArgument('values', 'array', 'Values to use in array_combine', FALSE, NULL);
+        $this->registerArgument('values', 'array', 'Values to use in array_combine');
         $this->registerArgument('keys', 'array', 'Keys to use in array_combine', TRUE);
     }
 

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -47,7 +47,7 @@ class CountViewHelper extends AbstractViewHelper {
 	 */
 	public function initializeArguments() {
 		parent::initializeArguments();
-		$this->registerArgument('subject', 'array', 'Countable subject, array or \Countable', FALSE, NULL);
+		$this->registerArgument('subject', 'array', 'Countable subject, array or \Countable');
 	}
 
 	/**

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -75,7 +75,7 @@ class ForViewHelper extends AbstractViewHelper {
 		$this->registerArgument('as', 'string', 'The name of the iteration variable', TRUE);
 		$this->registerArgument('key', 'string', 'Variable to assign array key to', FALSE);
 		$this->registerArgument('reverse', 'boolean', 'If TRUE, iterates in reverse', FALSE, FALSE);
-		$this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, isFirst, isLast, isEven, isOdd)', FALSE, NULL);
+		$this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, isFirst, isLast, isEven, isOdd)');
 	}
 
 	/**

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -56,7 +56,7 @@ class CdataViewHelper extends AbstractViewHelper {
 	 * @return void
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('value', 'mixed', 'The value to output', FALSE, NULL);
+		$this->registerArgument('value', 'mixed', 'The value to output');
 	}
 	/**
 	 * @return string

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -52,7 +52,7 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper {
 	 */
 	public function initializeArguments() {
 		parent::initializeArguments();
-		$this->registerArgument('value', 'string', 'Value to format', FALSE, NULL);
+		$this->registerArgument('value', 'string', 'Value to format');
 		$this->registerArgument('keepQuotes', 'boolean', 'If TRUE quotes will not be replaced (ENT_NOQUOTES)', FALSE, FALSE);
 		$this->registerArgument('encoding', 'string', 'Encoding', FALSE, 'UTF-8');
 		$this->registerArgument('doubleEncode', 'boolean', 'If FALSE html entities will not be encoded', FALSE, TRUE);

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -54,7 +54,7 @@ class PrintfViewHelper extends AbstractViewHelper {
 	public function initializeArguments() {
 		parent::initializeArguments();
 		$this->registerArgument('arguments', 'array', 'The arguments for vsprintf', FALSE, array());
-		$this->registerArgument('value', 'string', 'String to format', FALSE, NULL);
+		$this->registerArgument('value', 'string', 'String to format');
 	}
 
 	/**

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -56,7 +56,7 @@ class RawViewHelper extends AbstractViewHelper {
 	 * @return void
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('value', 'mixed', 'The value to output', FALSE, NULL);
+		$this->registerArgument('value', 'mixed', 'The value to output');
 	}
 
 	/**

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -21,7 +21,7 @@ class OrViewHelper extends AbstractViewHelper {
 	public function initializeArguments() {
 		$this->registerArgument('content', 'mixed', 'Content to check if empty', FALSE);
 		$this->registerArgument('alternative', 'mixed', 'Alternative if content is empty', FALSE, '');
-		$this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf', FALSE, NULL);
+		$this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf');
 	}
 
 	/**

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -78,12 +78,12 @@ class RenderViewHelper extends AbstractViewHelper {
 	 */
 	public function initializeArguments() {
 		parent::initializeArguments();
-		$this->registerArgument('section', 'string', 'Section to render - combine with partial to render section in partial', FALSE, NULL);
-		$this->registerArgument('partial', 'string', 'Partial to render, with or without section', FALSE, NULL);
+		$this->registerArgument('section', 'string', 'Section to render - combine with partial to render section in partial');
+		$this->registerArgument('partial', 'string', 'Partial to render, with or without section');
 		$this->registerArgument('arguments', 'array', 'Array of variables to be transferred. Use {_all} for all variables', FALSE, array());
 		$this->registerArgument('optional', 'boolean', 'If TRUE, considers the *section* optional. Partial never is.', FALSE, FALSE);
-		$this->registerArgument('default', 'mixed', 'Value (usually string) to be displayed if the section or partial does not exist', FALSE, NULL);
-		$this->registerArgument('contentAs', 'string', 'If used, renders the child content and adds it as a template variable with this name for use in the partial/section', FALSE, NULL);
+		$this->registerArgument('default', 'mixed', 'Value (usually string) to be displayed if the section or partial does not exist');
+		$this->registerArgument('contentAs', 'string', 'If used, renders the child content and adds it as a template variable with this name for use in the partial/section');
 	}
 
 	/**

--- a/tests/Functional/Fixtures/ViewHelpers/AbstractEscapingViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/AbstractEscapingViewHelper.php
@@ -12,7 +12,7 @@ abstract class AbstractEscapingViewHelper extends AbstractViewHelper {
 	 * @return void
 	 */
     public function initializeArguments() {
-        $this->registerArgument('content', 'string', 'Content provided as argument', FALSE, NULL);
+        $this->registerArgument('content', 'string', 'Content provided as argument');
     }
 
     /**

--- a/tests/Unit/ViewHelpers/ElseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ElseViewHelperTest.php
@@ -19,7 +19,7 @@ class ElseViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function testInitializeArgumentsRegistersExpectedArguments() {
 		$instance = $this->getMock(ElseViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('if', 'boolean', $this->anything(), FALSE, NULL);
+		$instance->expects($this->at(0))->method('registerArgument')->with('if', 'boolean', $this->anything());
 		$instance->initializeArguments();
 	}
 

--- a/tests/Unit/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/OrViewHelperTest.php
@@ -20,7 +20,7 @@ class OrViewHelperTest extends ViewHelperBaseTestcase {
 		$instance = $this->getMock(OrViewHelper::class, array('registerArgument'));
 		$instance->expects($this->at(0))->method('registerArgument')->with('content', 'mixed', $this->anything(), FALSE, '');
 		$instance->expects($this->at(1))->method('registerArgument')->with('alternative', 'mixed', $this->anything(), FALSE, '');
-		$instance->expects($this->at(2))->method('registerArgument')->with('arguments', 'array', $this->anything(), FALSE, NULL);
+		$instance->expects($this->at(2))->method('registerArgument')->with('arguments', 'array', $this->anything());
 		$instance->initializeArguments();
 	}
 

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -47,12 +47,12 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase {
 	 */
 	public function testInitializeArgumentsRegistersExpectedArguments() {
 		$instance = $this->getMock(RenderViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('section', 'string', $this->anything(), FALSE, NULL);
-		$instance->expects($this->at(1))->method('registerArgument')->with('partial', 'string', $this->anything(), FALSE, NULL);
+		$instance->expects($this->at(0))->method('registerArgument')->with('section', 'string', $this->anything());
+		$instance->expects($this->at(1))->method('registerArgument')->with('partial', 'string', $this->anything());
 		$instance->expects($this->at(2))->method('registerArgument')->with('arguments', 'array', $this->anything(), FALSE, array());
 		$instance->expects($this->at(3))->method('registerArgument')->with('optional', 'boolean', $this->anything(), FALSE, FALSE);
-		$instance->expects($this->at(4))->method('registerArgument')->with('default', 'mixed', $this->anything(), FALSE, NULL);
-		$instance->expects($this->at(5))->method('registerArgument')->with('contentAs', 'string', $this->anything(), FALSE, NULL);
+		$instance->expects($this->at(4))->method('registerArgument')->with('default', 'mixed', $this->anything());
+		$instance->expects($this->at(5))->method('registerArgument')->with('contentAs', 'string', $this->anything());
 		$instance->initializeArguments();
 	}
 


### PR DESCRIPTION
This change removes all arguments passed to
registerArgument when those passed values are
the same as the default values (FALSE for required,
NULL for default value).