### PR TITLE
[FEATURE] Make getPartialPathAndFilename public

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -637,7 +637,7 @@ class TemplatePaths {
 	 * @return string the full path which should be used. The path definitely exists.
 	 * @throws InvalidTemplateResourceException
 	 */
-	protected function getPartialPathAndFilename($partialName) {
+	public function getPartialPathAndFilename($partialName) {
 		$format = $this->getFormat();
 		$partialKey = $partialName . '.' . $format;
 		if (!array_key_exists($partialKey, self::$resolvedFiles[self::NAME_PARTIALS])) {


### PR DESCRIPTION
This change adds public visibility to the method
getPartialPathAndFilename on TemplatePaths. The
method is useful to call in custom implementations
dealing with rendering of partial templates.

Ref: https://review.typo3.org/#/c/47678/13