### PR TITLE
[BUGFIX] Avoid division by zero

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -76,7 +76,7 @@ class MathExpressionNode extends AbstractExpressionNode {
 		} elseif ($operator === '*') {
 			return $left * $right;
 		} elseif ($operator === '/') {
-			return $left / $right;
+			return (integer) $right !== 0 ? $left / $right : 0;
 		} elseif ($operator === '^') {
 			return pow($left, $right);
 		}


### PR DESCRIPTION
Perform a validation of right-hand side of division
to avoid dividing by zero. Return zero if encountered.