### PR TITLE
[BUGFIX] Avoid reset() on possibly ArrayAccess

### DIFF
--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -372,9 +372,8 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 */
 	protected function getFirstElementOfNonEmpty($value)
 	{
-		if ($value instanceof \ArrayAccess || is_array($value)) {
-			reset($value);
-			return current($value);
+		if (is_array($value)) {
+			return reset($value);
 		} elseif ($value instanceof \Traversable) {
 			foreach ($value as $element) {
 				return $element;


### PR DESCRIPTION
Do not allow reset() nor current() to be called on
ArrayAccess (which does not support these
methods). Should not break, since:

* This only relates to newly added “type[]” notation
* ArrayAccess is mostly implemented by Iterators in
  our main use cases (TYPO3 CMS, Flow)

Furthermore removes a redundant call to current(),
the value of which is already returned from reset().