### PR TITLE
[BUGFIX] Restore support for php://stdin template reference

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -378,7 +378,9 @@ class TemplatePaths {
 	 * @return string
 	 */
 	protected function sanitizePath($path) {
-		if (!empty($path)) {
+		if (strpos($path, 'php://') === 0) {
+			return $path;
+		} elseif (!empty($path)) {
 			$path = str_replace(array('\\', '//'), '/', $path);
 			$path = $this->ensureAbsolutePath($path);
 			if (is_dir($path)) {

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -42,6 +42,7 @@ class TemplatePathsTest extends BaseTestCase {
 			array(__FILE__, strtr(__FILE__, '\\', '/')),
 			array(__DIR__, strtr(__DIR__, '\\', '/') . '/'),
 			array('composer.json', strtr(getcwd(), '\\', '/') . '/composer.json'),
+            array('php://stdin', 'php://stdin')
 		);
 	}
 


### PR DESCRIPTION
Support was unintentionally removed by added call
to sanitizePath() - restored and added a unit test to
prevent future breaking in this way.