### PR TITLE
[BUGFIX] Prevent JSONVariableProvider from reading NULL

### DIFF
--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -83,7 +83,7 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
 	 * @return void
 	 */
 	protected function load() {
-		if (time() > ($this->lastLoaded + $this->ttl)) {
+		if ($this->source !== NULL && time() > ($this->lastLoaded + $this->ttl)) {
 			if (!$this->isJSON($this->source)) {
 				$source = file_get_contents($this->source);
 			} else {


### PR DESCRIPTION
The JSONVariableProvider would continuously hammer
and produce warnings about JSON source being NULL.
Avoiding loading if source is NULL prevents this.