### PR TITLE
[TASK] Prevent internal dotted layout name

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -483,6 +483,7 @@ class TemplatePaths {
 	 */
 	public function getLayoutIdentifier($layoutName = 'Default') {
 		$filePathAndFilename = $this->getLayoutPathAndFilename($layoutName);
+		$layoutName = str_replace('.', '_', $layoutName);
 		$prefix = 'layout_' . $layoutName;
 		return $this->createIdentifierForFile($filePathAndFilename, $prefix);
 	}


### PR DESCRIPTION
Prevents internally passing around a resolved layout
name containing a dot and file extension. The format
would eventually be converted to one using underscore
separated names but explicitly doing it early on will
prevent confusion when debugging the code.