### PR TITLE
[FEATURE] Store identifier via ParsedTemplateInterface

### DIFF
--- a/src/Core/Compiler/AbstractCompiledTemplate.php
+++ b/src/Core/Compiler/AbstractCompiledTemplate.php
@@ -19,6 +19,21 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 abstract class AbstractCompiledTemplate implements ParsedTemplateInterface {
 
 	/**
+	 * @param string $identifier
+	 * @return void
+	 */
+	public function setIdentifier($identifier) {
+		// void, ignored.
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getIdentifier() {
+		return static::class;
+	}
+
+	/**
 	 * Returns a variable container used in the PostParse Facet.
 	 *
 	 * @return VariableProviderInterface

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -16,6 +16,17 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 interface ParsedTemplateInterface {
 
 	/**
+	 * @param string $identifier
+	 * @return void
+	 */
+	public function setIdentifier($identifier);
+
+	/**
+	 * @return string
+	 */
+	public function getIdentifier();
+
+	/**
 	 * Render the parsed template with rendering context
 	 *
 	 * @param RenderingContextInterface $renderingContext The rendering context to use

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -20,6 +20,11 @@ use TYPO3Fluid\Fluid\View;
 class ParsingState implements ParsedTemplateInterface {
 
 	/**
+	 * @var string
+	 */
+	protected $identifier;
+
+	/**
 	 * Root node reference
 	 *
 	 * @var RootNode
@@ -52,6 +57,21 @@ class ParsingState implements ParsedTemplateInterface {
 	 * @var boolean
 	 */
 	protected $compilable = TRUE;
+
+	/**
+	 * @param string $identifier
+	 * @return void
+	 */
+	public function setIdentifier($identifier) {
+		$this->identifier = $identifier;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getIdentifier() {
+		return $this->identifier;
+	}
 
 	/**
 	 * Injects a variable container to be used during parsing.

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -163,8 +163,10 @@ class TemplateParser {
 			$parsedTemplate = $compiler->get($templateIdentifier);
 		} else {
 			$parsedTemplate = $this->parse(
-				$templateSourceClosure($this, $this->renderingContext->getTemplatePaths()), $templateIdentifier
+				$templateSourceClosure($this, $this->renderingContext->getTemplatePaths()),
+				$templateIdentifier
 			);
+			$parsedTemplate->setIdentifier($templateIdentifier);
 			$this->parsedTemplates[$templateIdentifier] = $parsedTemplate;
 			if ($parsedTemplate->isCompilable()) {
 				try {

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -19,6 +19,24 @@ class AbstractCompiledTemplateTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
+	public function testSetIdentifierDoesNotChangeObject() {
+		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+		$before = clone $instance;
+		$instance->setIdentifier('test');
+		$this->assertEquals($before, $instance);
+	}
+
+	/**
+	 * @test
+	 */
+	public function testGetIdentifierReturnsClassName() {
+		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+		$this->assertEquals($instance->getIdentifier(), get_class($instance));
+	}
+
+	/**
+	 * @test
+	 */
 	public function testParentGetVariableContainerMethodReturnsStandardVariableProvider() {
 		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
 		$result = $instance->getVariableContainer();

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -35,6 +35,24 @@ class ParsingStateTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
+	public function testSetIdentifierSetsProperty() {
+		$instance = $this->getMockForAbstractClass(ParsingState::class, array(), '', FALSE, array('dummy'));
+		$instance->setIdentifier('test');
+		$this->assertAttributeEquals('test', 'identifier', $instance);
+	}
+
+	/**
+	 * @test
+	 */
+	public function testGetIdentifierReturnsProperty() {
+		$instance = $this->getAccessibleMockForAbstractClass(ParsingState::class, array(), '', FALSE, array('dummy'));
+		$instance->_set('identifier', 'test');
+		$this->assertEquals('test', $instance->getIdentifier());
+	}
+
+	/**
+	 * @test
+	 */
 	public function setRootNodeCanBeReadOutAgain() {
 		$rootNode = new RootNode();
 		$this->parsingState->setRootNode($rootNode);


### PR DESCRIPTION
This change introduces a new property on parsed
and compiled template objects which allow those
parsed/compiled templates to store their own
identifier (the name used for the compiled class).

Prerequisite of up-coming features improving cache
management in Fluid.