### PR TITLE
[FEATURE] Introduce expression specific Exception type

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
@@ -8,7 +8,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 use TYPO3Fluid\Fluid\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;
 
 /**
  * Type Casting Node - allows the shorthand version
@@ -54,7 +54,12 @@ class CastingExpressionNode extends AbstractExpressionNode {
 			$type = static::getTemplateVariableOrValueItself($type, $renderingContext);
 		}
 		if (!in_array($type, self::$validTypes)) {
-			throw new Exception(sprintf('Invalid target conversion type "%s" specified in casting expression', $type));
+			throw new ExpressionException(
+			    sprintf(
+			        'Invalid target conversion type "%s" specified in casting expression',
+                    $type
+                )
+            );
 		}
 		return self::convert($variable, $type);
 	}

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
@@ -1,0 +1,15 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * An ExpressionNode evaluation Exception
+ *
+ * @api
+ */
+class ExpressionException extends \TYPO3Fluid\Fluid\Core\Exception {
+}

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -7,9 +7,9 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
  */
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\CastingExpressionNode;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToArray;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -42,7 +42,7 @@ class CastingExpressionNodeTest extends UnitTestCase {
 		$view = new TemplateView();
 		$renderingContext = new RenderingContext($view);
 		$renderingContext->setVariableProvider(new StandardVariableProvider());
-		$this->setExpectedException(Exception::class);
+		$this->setExpectedException(ExpressionException::class);
 		$result = CastingExpressionNode::evaluateExpression($renderingContext, 'suchaninvalidexpression as 1', array());
 	}
 


### PR DESCRIPTION
New Exception type to throw from within ExpressionNode
implementations. Allows catching and handling this type
of error individually (for things like improved error
feedback from template rendering).

Implements new Exception type in CastingExpressionNode.