### PR TITLE
[TASK] Include original Exception in rewritten Parser Exception

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -146,7 +146,8 @@ class TemplateParser {
 				$error->getCode(),
 				$templateCode
 			),
-			$error->getCode()
+			$error->getCode(),
+			$error
 		);
 	}
 


### PR DESCRIPTION
Makes $error->getPrevious() return the original error
when handling a Parser-specific error (which rewrites
the exception message to include template excerpts).