### PR TITLE
[FEATURE] Allow controller-less resolving in templateRootPaths

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -258,14 +258,14 @@ class TemplatePaths {
 	}
 
 	/**
-	 * @param string $controllerName
+	 * @param string|NULL $controllerName
 	 * @param string $format
 	 * @return array
 	 */
 	public function resolveAvailableTemplateFiles($controllerName, $format = self::DEFAULT_FORMAT) {
 		$paths = $this->getTemplateRootPaths();
 		foreach ($paths as $index => $path) {
-			$paths[$index] = $path . $controllerName . '/';
+			$paths[$index] = rtrim($path . $controllerName, '/') . '/';
 		}
 		return $this->resolveFilesInFolders($paths, $format);
 	}


### PR DESCRIPTION
This change allows resolveAvailableTemplateFiles on
TemplatePaths to be called with a controller name of
NULL, which causes Fluid to look for the action’s
template file in the templateRootPaths directly, no
controller sub-directory being checked.