### PR TITLE
[TASK] Allow rendering without stack through View

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -322,17 +322,17 @@ abstract class AbstractTemplateView extends AbstractView {
 	 */
 	protected function getCurrentRenderingType() {
 		$currentRendering = end($this->renderingStack);
-		return $currentRendering['type'];
+		return $currentRendering['type'] ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
 	}
 
 	/**
-	 * Get the parsed template which is currently being rendered.
+	 * Get the parsed template which is currently being rendered or compiled.
 	 *
 	 * @return ParsedTemplateInterface
 	 */
 	protected function getCurrentParsedTemplate() {
 		$currentRendering = end($this->renderingStack);
-		return $currentRendering['parsedTemplate'];
+		return $currentRendering['parsedTemplate'] ? $currentRendering['parsedTemplate'] : $this->getCurrentRenderingContext()->getTemplateCompiler()->getCurrentlyProcessingState();
 	}
 
 	/**
@@ -342,7 +342,7 @@ abstract class AbstractTemplateView extends AbstractView {
 	 */
 	protected function getCurrentRenderingContext() {
 		$currentRendering = end($this->renderingStack);
-		return $currentRendering['renderingContext'];
+		return $currentRendering['renderingContext'] ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
 	}
 
 }


### PR DESCRIPTION
This change allows the View class to return a fallback
rendering context, parsed template and rendering
type integer without a pre-parsed rendering stack.

The result is that it becomes possible to render in
sub-views based on an existing ParsedTemplate
including those coming from compiled templates.