### PR TITLE
[FEATURE] Introduce FailedCompilingState

### DIFF
--- a/src/Core/Compiler/FailedCompilingState.php
+++ b/src/Core/Compiler/FailedCompilingState.php
@@ -1,0 +1,67 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Compiler;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
+use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+
+/**
+ * Class FailedCompilingState
+ *
+ * Replacement ParsingState used when a template fails to compile.
+ * Includes additional reasons why compiling failed.
+ */
+class FailedCompilingState extends ParsingState implements ParsedTemplateInterface  {
+
+    /**
+     * @var string
+     */
+    protected $failureReason;
+
+    /**
+     * @var string[]
+     */
+    protected $mitigations = array();
+
+    /**
+     * @return string
+     */
+    public function getFailureReason() {
+        return $this->failureReason;
+    }
+
+    /**
+     * @param string $failureReason
+     * @return void
+     */
+    public function setFailureReason($failureReason) {
+        $this->failureReason = $failureReason;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMitigations() {
+        return $this->mitigations;
+    }
+
+    /**
+     * @param array $mitigations
+     */
+    public function setMitigations(array $mitigations) {
+        $this->mitigations = $mitigations;
+    }
+
+    /**
+     * @param string $mitigation
+     * @return void
+     */
+    public function addMitigation($mitigation) {
+        $this->mitigations[] = $mitigation;
+    }
+
+}

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
+use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+
+/**
+ * Class FailedCompilingStateTest
+ */
+class FailedCompilingStateTest extends UnitTestCase {
+
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @dataProvider getPropertyTestValues
+     * @test
+     */
+    public function testGetter($property, $value) {
+        $subject = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
+        $subject->_set($property, $value);
+        $method = 'get' . ucfirst($property);
+        $this->assertEquals($value, $subject->$method());
+    }
+
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @dataProvider getPropertyTestValues
+     * @test
+     */
+    public function testSetter($property, $value) {
+        $subject = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
+        $subject->_set($property, $value);
+        $method = 'set' . ucfirst($property);
+        $subject->$method($value);
+        $this->assertAttributeEquals($value, $property, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function testAddMitigation() {
+        $subject = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
+        $subject->_set('mitigations', array('m1'));
+        $subject->addMitigation('m2');
+        $this->assertAttributeEquals(array('m1', 'm2'), 'mitigations', $subject);
+    }
+
+    /**
+     * @return array
+     */
+    public function getPropertyTestValues() {
+        return array(
+            array('failureReason', 'test reason'),
+            array('mitigations', array('m1', 'm2'))
+        );
+    }
+
+}


### PR DESCRIPTION
This change introduces a new type of ParsingState
(ParsedTemplateInterface implementation) which is to
be used when compiling fails.

Currently this new type is not implemented anywhere
but is planned for the coming cache warmup feature as
a way to provide better feedback about failed compiles.
The class includes properties to carry both a failure
description and suggestions to mitigate the problem;
the intention being that such solutions shall be possible
to suggest when throwing Exceptions from ViewHelpers.

In the long run it is the intention to use this parsing state
whenever compiling fails, thus allowing things like debug
inspections to report problems and potential solutions,
while preserving the original ParsingState as a production
alternative that doesn’t catch and report compiling issues.