### PR TITLE
[BUGFIX] Makes object properties accessible in ArrayAccess (#184)

### DIFF
--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -191,7 +191,7 @@ class VariableExtractor {
 	 * @return string|NULL
 	 */
 	protected function detectAccessor($subject, $propertyName) {
-		if (is_array($subject)) {
+		if (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)) {
 			return self::ACCESSOR_ARRAY;
 		}
 		if (is_object($subject)) {
@@ -206,9 +206,6 @@ class VariableExtractor {
 			}
 			if (property_exists($subject, $propertyName)) {
 				return self::ACCESSOR_PUBLICPROPERTY;
-			}
-			if ($subject instanceof \ArrayAccess) {
-				return self::ACCESSOR_ARRAY;
 			}
 		}
 

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -191,7 +191,7 @@ class VariableExtractor {
 	 * @return string|NULL
 	 */
 	protected function detectAccessor($subject, $propertyName) {
-		if (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)) {
+		if (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName))) {
 			return self::ACCESSOR_ARRAY;
 		}
 		if (is_object($subject)) {

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -191,9 +191,10 @@ class VariableExtractor {
 	 * @return string|NULL
 	 */
 	protected function detectAccessor($subject, $propertyName) {
-		if (is_array($subject) || $subject instanceof \ArrayAccess) {
+		if (is_array($subject)) {
 			return self::ACCESSOR_ARRAY;
-		} elseif (is_object($subject)) {
+		}
+		if (is_object($subject)) {
 			$upperCasePropertyName = ucfirst($propertyName);
 			$getter = 'get' . $upperCasePropertyName;
 			$asserter = 'is' . $upperCasePropertyName;
@@ -206,9 +207,12 @@ class VariableExtractor {
 			if (property_exists($subject, $propertyName)) {
 				return self::ACCESSOR_PUBLICPROPERTY;
 			}
-			return NULL;
+			if ($subject instanceof \ArrayAccess) {
+				return self::ACCESSOR_ARRAY;
+			}
 		}
-		return NULL;
+
+		return null;
 	}
 
 }

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -209,7 +209,7 @@ class VariableExtractor {
 			}
 		}
 
-		return null;
+		return NULL;
 	}
 
 }

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -148,7 +148,7 @@ class VariableExtractor {
 	protected function canExtractWithAccessor($subject, $propertyName, $accessor) {
 		$class = is_object($subject) ? get_class($subject) : FALSE;
 		if ($accessor === self::ACCESSOR_ARRAY) {
-			return (is_array($subject) || $subject instanceof \ArrayAccess);
+			return (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)));
 		} elseif ($accessor === self::ACCESSOR_GETTER) {
 			return ($class !== FALSE && method_exists($subject, 'get' . ucfirst($propertyName)));
 		} elseif ($accessor === self::ACCESSOR_ASSERTER) {

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -76,6 +76,7 @@ class VariableExtractorTest extends UnitTestCase {
 			array(array('inArray' => $inArray), 'inArray.user', array($asArray, $asArray)),
 			array(array('inArray' => $inArray), 'inArray.user.name', array($asArray, $asArray, $asGetter)),
 			array(array('inArrayAccess' => $inArrayAccess), 'inArrayAccess.user.name', array($asArray, $asArray, $asGetter)),
+			array(array('inArrayAccessWithGetter' => $inArrayAccess), 'inArrayAccessWithGetter.allIdentifiers', array($asArray, $asGetter)),
 			array(array('inPublic' => $inPublic), 'inPublic.user.name', array($asArray, $asPublic, $asGetter))
 		);
 	}


### PR DESCRIPTION
Due to the precedence for ArrayAccess accessors a property only
accessible via getter method in an ArrayAccess object cannot be
retrieved via Fluid currently.

This change adjusts the precedence so that for objects the
ArrayAccess is used as fallback after checking getter methods
for the given propertyName.