### PR TITLE
[BUGFIX] Fix compiling for renderStatic with content argument

### DIFF
--- a/examples/Resources/Private/Singles/Variables.html
+++ b/examples/Resources/Private/Singles/Variables.html
@@ -31,7 +31,8 @@ Direct access of numeric prefixed variable: {123numericprefix}
 	myVariable: 'Nice string',
 	array: {
 		baz: 42,
-		foobar: 'Escaped string',
+		foobar: '<b>Unescaped string</b>',
+		printf: 'Formatted string, value: %s',
 		xyz: '{
 			foobar: \'Escaped sub-string\'
 		}'
@@ -41,7 +42,8 @@ Direct access of numeric prefixed variable: {123numericprefix}
 </f:section>
 
 <f:section name="Secondary">
-Received $array.foobar with value {array.foobar}
+Received $array.foobar with value {array.foobar -> f:format.raw()}
+Received $array.printf with formatted string {array.printf -> f:format.printf(arguments: {0: 'formatted'})}
 Received $array.baz with value {array.baz}
 Received $array.xyz.foobar with value {array.xyz.foobar}
 Received $myVariable with value {myVariable}

--- a/src/Core/Compiler/ViewHelperCompiler.php
+++ b/src/Core/Compiler/ViewHelperCompiler.php
@@ -121,13 +121,13 @@ class ViewHelperCompiler {
         $argumentsName,
         $renderChildrenClosureName,
         $contentArgumentName,
-        $method = self::RENDER_STATIC,
-        $onClass = NULL
+        $method,
+        $onClass
     ) {
         return array(
             self::DEFAULT_INIT,
             sprintf(
-                '%s::%s(%s, %s[%s] ? function() { use %s; return %s[%s]; } : %s, $renderingContext)',
+                '%s::%s(%s, isset(%s[\'%s\']) ? function() use (%s) { return %s[\'%s\']; } : %s, $renderingContext)',
                 $onClass,
                 $method,
                 $argumentsName,

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -77,7 +77,9 @@ trait CompileWithContentArgumentAndRenderStatic {
             $this,
             $argumentsName,
             $closureName,
-            $contentArgumentName
+            $this->resolveContentArgumentName(),
+            ViewHelperCompiler::RENDER_STATIC,
+            static::class
         );
         $initializationPhpCode .= $initialization;
         return $execution;
@@ -91,7 +93,8 @@ trait CompileWithContentArgumentAndRenderStatic {
             $registeredArguments = call_user_func_array(array($this, 'prepareArguments'), array());
             foreach ($registeredArguments as $registeredArgument) {
                 if (!$registeredArgument->isRequired()) {
-                    return $registeredArgument->getName();
+                    $this->contentArgumentName = $registeredArgument->getName();
+                    return $this->contentArgumentName;
                 }
             }
             throw new Exception(

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -185,7 +185,7 @@ class ExamplesTest extends BaseTestCase {
 			'example_variables.php' => array(
 				'example_variables.php',
 				array(
-				    'Simple variable: string foo',
+					'Simple variable: string foo',
 					'A string with numbers in it: 132',
 					'Ditto, with type name stored in variable: 132',
 					'A comma-separated value iterated as array:' . "\n\t- one\n\t- two",
@@ -193,9 +193,10 @@ class ExamplesTest extends BaseTestCase {
 					'String variable name with dynamic2 part: String using $dynamic2.',
 					'Array member in $array[$dynamic1]: Dynamic key in $array[$dynamic1]',
 					'Array member in $array[$dynamic2]: Dynamic key in $array[$dynamic2]',
-                    'Direct access of numeric prefixed variable: Numeric prefixed variable',
-                    'Aliased access of numeric prefixed variable: Numeric prefixed variable',
-					'Received $array.foobar with value Escaped string',
+					'Direct access of numeric prefixed variable: Numeric prefixed variable',
+					'Aliased access of numeric prefixed variable: Numeric prefixed variable',
+					'Received $array.foobar with value <b>Unescaped string</b>',
+					'Received $array.printf with formatted string Formatted string, value: formatted',
 					'Received $array.baz with value 42',
 					'Received $array.xyz.foobar with value Escaped sub-string',
 					'Received $myVariable with value Nice string'


### PR DESCRIPTION
This change fixes an issue where the mentioned compiling
method would produce invalid PHP syntax if the content
argument could not be resolved.

Furthermore, uses the protected property for content
argument name on the Trait for storing the resolved name.

Also adds examples and test cases that validate this
compiling method.

NB: Do not back-port to 1.0 branch!