### PR TITLE
[BUGFIX] Fix typo in constant name

### DIFF
--- a/src/Core/Cache/FluidCacheWarmupResult.php
+++ b/src/Core/Cache/FluidCacheWarmupResult.php
@@ -16,7 +16,7 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 class FluidCacheWarmupResult {
 
 	const RESULT_COMPILABLE = 'compilable';
-	const RESULT_COMPILED_= 'compiled';
+	const RESULT_COMPILED = 'compiled';
 	const RESULT_HASLAYOUT = 'hasLayout';
 	const RESULT_COMPILEDCLASS = 'compiledClassName';
 	const RESULT_FAILURE = 'failure';
@@ -55,7 +55,7 @@ class FluidCacheWarmupResult {
 		$class = get_class($state);
 		$this->results[$templatePathAndFilename] = array(
 			static::RESULT_COMPILABLE => $currentlyCompiled || $state->isCompilable(),
-			static::RESULT_COMPILED_ => $state->isCompiled(),
+			static::RESULT_COMPILED => $state->isCompiled(),
 			static::RESULT_HASLAYOUT => $state->hasLayout(),
 			static::RESULT_COMPILEDCLASS => $state->getIdentifier()
 		);

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -91,7 +91,7 @@ class FluidCacheWarmupResultTest extends UnitTestCase {
 				$subject1,
 				array(
 					FluidCacheWarmupResult::RESULT_COMPILABLE => TRUE,
-					FluidCacheWarmupResult::RESULT_COMPILED_ => FALSE,
+					FluidCacheWarmupResult::RESULT_COMPILED => FALSE,
 					FluidCacheWarmupResult::RESULT_HASLAYOUT => FALSE,
 					FluidCacheWarmupResult::RESULT_COMPILEDCLASS => 'subject1-identifier'
 				)
@@ -100,7 +100,7 @@ class FluidCacheWarmupResultTest extends UnitTestCase {
 				$subject2,
 				array(
 					FluidCacheWarmupResult::RESULT_COMPILABLE => TRUE,
-					FluidCacheWarmupResult::RESULT_COMPILED_ => TRUE,
+					FluidCacheWarmupResult::RESULT_COMPILED => TRUE,
 					FluidCacheWarmupResult::RESULT_HASLAYOUT => TRUE,
 					FluidCacheWarmupResult::RESULT_COMPILEDCLASS => 'subject2-identifier',
 					FluidCacheWarmupResult::RESULT_FAILURE => 'failure-reason',


### PR DESCRIPTION
This fixes a typo in a constant introduced in 1.1.0. The
fix is non-breaking as long as no implementations have
yet been created.