### PR TITLE
[TASK] Convert to PSR-2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 	"require-dev": {
 		"phpunit/phpunit": "^4.8",
 		"mikey179/vfsStream": "^1.6",
-		"satooshi/php-coveralls": "^1.0"
+		"satooshi/php-coveralls": "^1.0",
+		"squizlabs/php_codesniffer": "^2.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/examples/example_conditions.php
+++ b/examples/example_conditions.php
@@ -15,8 +15,8 @@ require __DIR__ . '/include/view_init.php';
 // variables to understand what goes on.
 $view->assign('vartrue', TRUE);
 $view->assign('varfalse', FALSE);
-$view->assign('vararray1', array('foo' => 'bar'));
-$view->assign('vararray2', array('bar' => 'foo'));
+$view->assign('vararray1', ['foo' => 'bar']);
+$view->assign('vararray2', ['bar' => 'foo']);
 $view->assign('checkTernary', TRUE);
 $view->assign('ternaryTrue', 'The ternary expression is TRUE');
 $view->assign('ternaryFalse', 'The ternary expression is FALSE');

--- a/examples/example_multiplepaths.php
+++ b/examples/example_multiplepaths.php
@@ -26,20 +26,20 @@ require __DIR__ . '/include/view_init.php';
 // the overrides to a path in, for example, another package's Resources folder.
 // Specifying this array can also be done as constructor argument for the
 // TemplatePaths class which can be passed to the View; see view_init.php.
-$view->getTemplatePaths()->fillFromConfigurationArray(array(
-	\TYPO3Fluid\Fluid\View\TemplatePaths::CONFIG_TEMPLATEROOTPATHS => array(
+$view->getTemplatePaths()->fillFromConfigurationArray([
+	\TYPO3Fluid\Fluid\View\TemplatePaths::CONFIG_TEMPLATEROOTPATHS => [
 		__DIR__ . '/Resources/Private/Templates/',
 		__DIR__ . '/ResourceOverrides/Private/Templates/',
-	),
-	\TYPO3Fluid\Fluid\View\TemplatePaths::CONFIG_LAYOUTROOTPATHS => array(
+	],
+	\TYPO3Fluid\Fluid\View\TemplatePaths::CONFIG_LAYOUTROOTPATHS => [
 		__DIR__ . '/Resources/Private/Layouts/',
 		__DIR__ . '/ResourceOverrides/Private/Layouts/',
-	),
-	\TYPO3Fluid\Fluid\View\TemplatePaths::CONFIG_PARTIALROOTPATHS => array(
+	],
+	\TYPO3Fluid\Fluid\View\TemplatePaths::CONFIG_PARTIALROOTPATHS => [
 		__DIR__ . '/Resources/Private/Partials/',
 		__DIR__ . '/ResourceOverrides/Private/Partials/',
-	)
-));
+	]
+]);
 
 $view->assign('foobar', 'This is foobar');
 $view->assign('baz', 'This is baz');

--- a/examples/example_structures.php
+++ b/examples/example_structures.php
@@ -20,12 +20,12 @@ $view->assign('notTrueEither', FALSE);
 $view->assign('butTrue', TRUE);
 $view->assign('switchValue', 3);
 $view->assign('secondSwitchValue', 'b');
-$view->assign('array', array('one', 'two', 'three'));
-$view->assign('group', array(
-	array('property' => 'one'),
-	array('property' => 'one'),
-	array('property' => 'two')
-));
+$view->assign('array', ['one', 'two', 'three']);
+$view->assign('group', [
+	['property' => 'one'],
+	['property' => 'one'],
+	['property' => 'two']
+]);
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.
 $output = $view->render();

--- a/examples/example_variables.php
+++ b/examples/example_variables.php
@@ -17,14 +17,14 @@ $dynamic2 = 'DYN2'; // used as dynamic part when accessing other variables
 
 // In this example we assign all our variables in one array. Alternative is
 // to repeatedly call $view->assign('name', 'value').
-$view->assignMultiple(array(
+$view->assignMultiple([
 	// Casting types
-	'types' => array(
+	'types' => [
 		'csv' => 'one,two',
 		'aStringWithNumbers' => '132 a string',
-		'anArray' => array('one', 'two'),
+		'anArray' => ['one', 'two'],
 		'typeNameInteger' => 'integer'
-	),
+	],
     'foobar' => 'string foo',
 	// The variables we will use as dynamic part names:
 	'dynamic1' => $dynamic1,
@@ -33,18 +33,18 @@ $view->assignMultiple(array(
 	'stringwith' . $dynamic1 . 'part' => 'String using $dynamic1',
 	'stringwith' . $dynamic2 . 'part' => 'String using $dynamic2',
 	// Arrays we will be accessing dynamically:
-	'array' => array(
+	'array' => [
 		'fixed' => 'Fixed key in $array[fixed]',
 		// A numerically indexed array which we will access directly.
-		'numeric' => array(
+		'numeric' => [
 			'foo',
 			'bar'
-		),
+		],
 		$dynamic1 => 'Dynamic key in $array[$dynamic1]',
 		$dynamic2 => 'Dynamic key in $array[$dynamic2]',
-	),
+	],
     '123numericprefix' => 'Numeric prefixed variable'
-));
+]);
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.

--- a/examples/include/class_customvariableprovider.php
+++ b/examples/include/class_customvariableprovider.php
@@ -33,7 +33,7 @@ class CustomVariableProvider extends StandardVariableProvider implements Variabl
 	 * @param string $path
 	 * @return mixed
 	 */
-	public function getByPath($path, array $accessors = array()) {
+	public function getByPath($path, array $accessors = []) {
 		if ($path === 'random') {
 			return 'random' . sha1(rand(0, 999999999));
 		} elseif ($path === 'incrementer') {

--- a/examples/include/class_customviewhelperresolver.php
+++ b/examples/include/class_customviewhelperresolver.php
@@ -52,7 +52,7 @@ class CustomViewHelperResolver extends ViewHelperResolver {
 				'array', // our argument must now be an array
 				'This is our new description for the argument',
 				FALSE, // argument is no longer mandatory
-				array('foo' => 'bar') // our argument has a new default value if argument is not provided
+				['foo' => 'bar'] // our argument has a new default value if argument is not provided
 			);
 		}
 		return $arguments;

--- a/examples/include/view_init.php
+++ b/examples/include/view_init.php
@@ -26,15 +26,15 @@ $paths = $view->getTemplatePaths();
 // and `TemplatesB` and render that using this MVC approach, you will be
 // rendering the file located in `TemplatesB` becase this folder was last
 // and is checked first (think of these paths as prioritised fallbacks).
-$paths->setTemplateRootPaths(array(
+$paths->setTemplateRootPaths([
 	__DIR__ . '/../Resources/Private/Templates/'
-));
-$paths->setLayoutRootPaths(array(
+]);
+$paths->setLayoutRootPaths([
 	__DIR__ . '/../Resources/Private/Layouts/'
-));
-$paths->setPartialRootPaths(array(
+]);
+$paths->setPartialRootPaths([
 	__DIR__ . '/../Resources/Private/Partials/'
-));
+]);
 
 if ($FLUID_CACHE_DIRECTORY) {
 	// Configure View's caching to use ./examples/cache/ as caching directory.

--- a/src/Core/Cache/FluidCacheInterface.php
+++ b/src/Core/Cache/FluidCacheInterface.php
@@ -12,39 +12,39 @@ namespace TYPO3Fluid\Fluid\Core\Cache;
  * Implemented by classes providing caching
  * features for the Fluid templates being rendered.
  */
-interface FluidCacheInterface {
+interface FluidCacheInterface
+{
 
-	/**
-	 * Gets an entry from the cache or NULL if the
-	 * entry does not exist.
-	 *
-	 * @param string $name
-	 * @return mixed
-	 */
-	public function get($name);
+    /**
+     * Gets an entry from the cache or NULL if the
+     * entry does not exist.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function get($name);
 
-	/**
-	 * Set or updates an entry identified by $name
-	 * into the cache.
-	 *
-	 * @param string $name
-	 * @param mixed $value
-	 * @return void
-	 */
-	public function set($name, $value);
+    /**
+     * Set or updates an entry identified by $name
+     * into the cache.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    public function set($name, $value);
 
-	/**
-	 * Flushes the cache either by entry or flushes
-	 * the entire cache if no entry is provided.
-	 *
-	 * @param string|NULL $name
-	 * @return void
-	 */
-	public function flush($name = NULL);
+    /**
+     * Flushes the cache either by entry or flushes
+     * the entire cache if no entry is provided.
+     *
+     * @param string|NULL $name
+     * @return void
+     */
+    public function flush($name = null);
 
-	/**
-	 * @return FluidCacheWarmerInterface
-	 */
-	public function getCacheWarmer();
-
+    /**
+     * @return FluidCacheWarmerInterface
+     */
+    public function getCacheWarmer();
 }

--- a/src/Core/Cache/FluidCacheWarmerInterface.php
+++ b/src/Core/Cache/FluidCacheWarmerInterface.php
@@ -15,21 +15,21 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * StandardCacheWarmer implementation of this interface
  * for more detailed explanations about warmup.
  */
-interface FluidCacheWarmerInterface {
+interface FluidCacheWarmerInterface
+{
 
-	/**
-	 * Warm up an entire collection of templates based on the
-	 * provided RenderingContext. Returns a FluidCacheWarmupResult
-	 * with feedback about the templates that were processed.
-	 *
-	 * Resolving, compiling, reporting and error handling is
-	 * completely up to the implementing class. Standard file based
-	 * template resolving and compiling can be inherited by subclassing
-	 * the provided StandardCacheWarmer and overriding methods.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return FluidCacheWarmupResult
-	 */
-	public function warm(RenderingContextInterface $renderingContext);
-
+    /**
+     * Warm up an entire collection of templates based on the
+     * provided RenderingContext. Returns a FluidCacheWarmupResult
+     * with feedback about the templates that were processed.
+     *
+     * Resolving, compiling, reporting and error handling is
+     * completely up to the implementing class. Standard file based
+     * template resolving and compiling can be inherited by subclassing
+     * the provided StandardCacheWarmer and overriding methods.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return FluidCacheWarmupResult
+     */
+    public function warm(RenderingContextInterface $renderingContext);
 }

--- a/src/Core/Cache/FluidCacheWarmupResult.php
+++ b/src/Core/Cache/FluidCacheWarmupResult.php
@@ -13,57 +13,60 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 /**
  * Class FluidCacheWarmupResult
  */
-class FluidCacheWarmupResult {
+class FluidCacheWarmupResult
+{
 
-	const RESULT_COMPILABLE = 'compilable';
-	const RESULT_COMPILED = 'compiled';
-	const RESULT_HASLAYOUT = 'hasLayout';
-	const RESULT_COMPILEDCLASS = 'compiledClassName';
-	const RESULT_FAILURE = 'failure';
-	const RESULT_MITIGATIONS = 'mitigations';
+    const RESULT_COMPILABLE = 'compilable';
+    const RESULT_COMPILED = 'compiled';
+    const RESULT_HASLAYOUT = 'hasLayout';
+    const RESULT_COMPILEDCLASS = 'compiledClassName';
+    const RESULT_FAILURE = 'failure';
+    const RESULT_MITIGATIONS = 'mitigations';
 
-	/**
-	 * @var array
-	 */
-	protected $results = array();
+    /**
+     * @var array
+     */
+    protected $results = [];
 
-	/**
-	 * @param FluidCacheWarmupResult $result1...$resultN
-	 * @return self
-	 */
-	public function merge() {
-		foreach (func_get_args() as $result) {
-			$this->results += $result->getResults();
-		}
-		return $this;
-	}
+    /**
+     * @param FluidCacheWarmupResult $result1...$resultN
+     * @return self
+     */
+    public function merge()
+    {
+        foreach (func_get_args() as $result) {
+            $this->results += $result->getResults();
+        }
+        return $this;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getResults() {
-		return $this->results;
-	}
+    /**
+     * @return array
+     */
+    public function getResults()
+    {
+        return $this->results;
+    }
 
-	/**
-	 * @param ParsedTemplateInterface $state
-	 * @param string $templatePathAndFilename
-	 * @return self
-	 */
-	public function add(ParsedTemplateInterface $state, $templatePathAndFilename) {
-		$currentlyCompiled = $state->isCompiled();
-		$class = get_class($state);
-		$this->results[$templatePathAndFilename] = array(
-			static::RESULT_COMPILABLE => $currentlyCompiled || $state->isCompilable(),
-			static::RESULT_COMPILED => $state->isCompiled(),
-			static::RESULT_HASLAYOUT => $state->hasLayout(),
-			static::RESULT_COMPILEDCLASS => $state->getIdentifier()
-		);
-		if ($state instanceof FailedCompilingState) {
-			$this->results[$templatePathAndFilename][static::RESULT_FAILURE] = $state->getFailureReason();
-			$this->results[$templatePathAndFilename][static::RESULT_MITIGATIONS] = $state->getMitigations();
-		}
-		return $this;
-	}
-
+    /**
+     * @param ParsedTemplateInterface $state
+     * @param string $templatePathAndFilename
+     * @return self
+     */
+    public function add(ParsedTemplateInterface $state, $templatePathAndFilename)
+    {
+        $currentlyCompiled = $state->isCompiled();
+        $class = get_class($state);
+        $this->results[$templatePathAndFilename] = [
+            static::RESULT_COMPILABLE => $currentlyCompiled || $state->isCompilable(),
+            static::RESULT_COMPILED => $state->isCompiled(),
+            static::RESULT_HASLAYOUT => $state->hasLayout(),
+            static::RESULT_COMPILEDCLASS => $state->getIdentifier()
+        ];
+        if ($state instanceof FailedCompilingState) {
+            $this->results[$templatePathAndFilename][static::RESULT_FAILURE] = $state->getFailureReason();
+            $this->results[$templatePathAndFilename][static::RESULT_MITIGATIONS] = $state->getMitigations();
+        }
+        return $this;
+    }
 }

--- a/src/Core/Cache/SimpleFileCache.php
+++ b/src/Core/Cache/SimpleFileCache.php
@@ -14,123 +14,132 @@ namespace TYPO3Fluid\Fluid\Core\Cache;
  * as a file that can be included via the
  * get() method.
  */
-class SimpleFileCache implements FluidCacheInterface {
+class SimpleFileCache implements FluidCacheInterface
+{
 
-	/**
-	 * Default cache directory is in "cache/"
-	 * relative to the point of script execution.
-	 */
-	const DIRECTORY_DEFAULT = 'cache';
+    /**
+     * Default cache directory is in "cache/"
+     * relative to the point of script execution.
+     */
+    const DIRECTORY_DEFAULT = 'cache';
 
-	/**
-	 * @var string
-	 */
-	protected $directory = self::DIRECTORY_DEFAULT;
+    /**
+     * @var string
+     */
+    protected $directory = self::DIRECTORY_DEFAULT;
 
-	/**
-	 * @param string $directory
-	 */
-	public function __construct($directory = self::DIRECTORY_DEFAULT) {
-		$this->directory = rtrim($directory, '/') . '/';
-	}
+    /**
+     * @param string $directory
+     */
+    public function __construct($directory = self::DIRECTORY_DEFAULT)
+    {
+        $this->directory = rtrim($directory, '/') . '/';
+    }
 
-	/**
-	 * Get an instance of FluidCacheWarmerInterface which
-	 * can warm up template files that would normally be
-	 * cached on-the-fly to this FluidCacheInterface
-	 * implementaion.
-	 *
-	 * @return FluidCacheWarmerInterface
-	 */
-	public function getCacheWarmer() {
-		return new StandardCacheWarmer();
-	}
+    /**
+     * Get an instance of FluidCacheWarmerInterface which
+     * can warm up template files that would normally be
+     * cached on-the-fly to this FluidCacheInterface
+     * implementaion.
+     *
+     * @return FluidCacheWarmerInterface
+     */
+    public function getCacheWarmer()
+    {
+        return new StandardCacheWarmer();
+    }
 
-	/**
-	 * Gets an entry from the cache or NULL if the
-	 * entry does not exist. Returns TRUE if the cached
-	 * class file was included, FALSE if it does not
-	 * exist in the cache directory.
-	 *
-	 * @param string $name
-	 * @return boolean
-	 */
-	public function get($name) {
-		if (class_exists($name)) {
-			return TRUE;
-		}
-		$file = $this->getCachedFilePathAndFilename($name);
-		if (file_exists($file) && !class_exists($name)) {
-			include_once($file);
-			return TRUE;
-		}
-		return FALSE;
-	}
+    /**
+     * Gets an entry from the cache or NULL if the
+     * entry does not exist. Returns TRUE if the cached
+     * class file was included, FALSE if it does not
+     * exist in the cache directory.
+     *
+     * @param string $name
+     * @return boolean
+     */
+    public function get($name)
+    {
+        if (class_exists($name)) {
+            return true;
+        }
+        $file = $this->getCachedFilePathAndFilename($name);
+        if (file_exists($file) && !class_exists($name)) {
+            include_once($file);
+            return true;
+        }
+        return false;
+    }
 
-	/**
-	 * Set or updates an entry identified by $name
-	 * into the cache.
-	 *
-	 * @param string $name
-	 * @param mixed $value
-	 * @return void
-	 * @throws \RuntimeException
-	 */
-	public function set($name, $value) {
-		if (!file_exists(rtrim($this->directory, '/'))) {
-			throw new \RuntimeException(sprintf('Invalid Fluid cache directory - %s does not exist!', $this->directory));
-		}
-		file_put_contents($this->getCachedFilePathAndFilename($name), $value);
-	}
+    /**
+     * Set or updates an entry identified by $name
+     * into the cache.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     * @throws \RuntimeException
+     */
+    public function set($name, $value)
+    {
+        if (!file_exists(rtrim($this->directory, '/'))) {
+            throw new \RuntimeException(sprintf('Invalid Fluid cache directory - %s does not exist!', $this->directory));
+        }
+        file_put_contents($this->getCachedFilePathAndFilename($name), $value);
+    }
 
-	/**
-	 * Flushes the cache either by entry or flushes
-	 * the entire cache if no entry is provided.
-	 *
-	 * @param string|NULL $name
-	 * @return void
-	 */
-	public function flush($name = NULL) {
-		if ($name !== NULL) {
-			$this->flushByName($name);
-		} else {
-			$files = $this->getCachedFilenames();
-			if (is_array($files)) {
-				array_walk($files, array($this, 'flushByFilename'));
-			}
-		}
-	}
+    /**
+     * Flushes the cache either by entry or flushes
+     * the entire cache if no entry is provided.
+     *
+     * @param string|NULL $name
+     * @return void
+     */
+    public function flush($name = null)
+    {
+        if ($name !== null) {
+            $this->flushByName($name);
+        } else {
+            $files = $this->getCachedFilenames();
+            if (is_array($files)) {
+                array_walk($files, [$this, 'flushByFilename']);
+            }
+        }
+    }
 
-	/**
-	 * @codeCoverageIgnore
-	 * @return array
-	 */
-	protected function getCachedFilenames() {
-		return scandir($this->directory . '*.php');
-	}
+    /**
+     * @codeCoverageIgnore
+     * @return array
+     */
+    protected function getCachedFilenames()
+    {
+        return scandir($this->directory . '*.php');
+    }
 
-	/**
-	 * @param string $name
-	 * @return void
-	 */
-	protected function flushByName($name) {
-		$this->flushByFilename($this->getCachedFilePathAndFilename($name));
-	}
+    /**
+     * @param string $name
+     * @return void
+     */
+    protected function flushByName($name)
+    {
+        $this->flushByFilename($this->getCachedFilePathAndFilename($name));
+    }
 
-	/**
-	 * @param string $filename
-	 * @return void
-	 */
-	protected function flushByFilename($filename) {
-		unlink($filename);
-	}
+    /**
+     * @param string $filename
+     * @return void
+     */
+    protected function flushByFilename($filename)
+    {
+        unlink($filename);
+    }
 
-	/**
-	 * @param string $identifier
-	 * @return string
-	 */
-	protected function getCachedFilePathAndFilename($identifier) {
-		return $this->directory . $identifier . '.php';
-	}
-
+    /**
+     * @param string $identifier
+     * @return string
+     */
+    protected function getCachedFilePathAndFilename($identifier)
+    {
+        return $this->directory . $identifier . '.php';
+    }
 }

--- a/src/Core/Cache/StandardCacheWarmer.php
+++ b/src/Core/Cache/StandardCacheWarmer.php
@@ -46,256 +46,263 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
  * The default set of mitigation suggestions are based on the
  * standard errors which can be thrown by the Fluid engine.
  */
-class StandardCacheWarmer implements FluidCacheWarmerInterface {
+class StandardCacheWarmer implements FluidCacheWarmerInterface
+{
 
-	/**
-	 * Template file formats (file extensions) supported by this
-	 * cache warmer implementation.
-	 *
-	 * @var array
-	 */
-	protected $formats = array('html', 'xml', 'txt', 'json', 'rtf', 'atom', 'rss');
+    /**
+     * Template file formats (file extensions) supported by this
+     * cache warmer implementation.
+     *
+     * @var array
+     */
+    protected $formats = ['html', 'xml', 'txt', 'json', 'rtf', 'atom', 'rss'];
 
-	/**
-	 * Warm up an entire collection of templates based on the
-	 * provided RenderingContext (the TemplatePaths carried by
-	 * the RenderingContext, to be precise).
-	 *
-	 * Returns a FluidCacheWarmupResult with result information
-	 * about all detected template files and the compiling of
-	 * those files. If a template fails to compile or throws an
-	 * error, a mitigation suggestion is included for that file.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return FluidCacheWarmupResult
-	 */
-	public function warm(RenderingContextInterface $renderingContext) {
-		$renderingContext->getTemplateCompiler()->enterWarmupMode();
-		$result = new FluidCacheWarmupResult();
-		$result->merge(
-			$this->warmupTemplateRootPaths($renderingContext),
-			$this->warmupPartialRootPaths($renderingContext),
-			$this->warmupLayoutRootPaths($renderingContext)
-		);
-		return $result;
-	}
+    /**
+     * Warm up an entire collection of templates based on the
+     * provided RenderingContext (the TemplatePaths carried by
+     * the RenderingContext, to be precise).
+     *
+     * Returns a FluidCacheWarmupResult with result information
+     * about all detected template files and the compiling of
+     * those files. If a template fails to compile or throws an
+     * error, a mitigation suggestion is included for that file.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return FluidCacheWarmupResult
+     */
+    public function warm(RenderingContextInterface $renderingContext)
+    {
+        $renderingContext->getTemplateCompiler()->enterWarmupMode();
+        $result = new FluidCacheWarmupResult();
+        $result->merge(
+            $this->warmupTemplateRootPaths($renderingContext),
+            $this->warmupPartialRootPaths($renderingContext),
+            $this->warmupLayoutRootPaths($renderingContext)
+        );
+        return $result;
+    }
 
-	/**
-	 * Warm up _templateRootPaths_ of the RenderingContext's
-	 * TemplatePaths instance.
-	 *
-	 * Scans for template files recursively in all template root
-	 * paths while respecting overlays, e.g. if a path replaces
-	 * the template file of a lower priority path then only
-	 * one result is returned - the overlayed template file. In
-	 * other words the resolving happens exactly as if you were
-	 * attempting to render each detected controller, so that the
-	 * compiled template will be the same that is resolved when
-	 * rendering that controller.
-	 *
-	 * Also scans the root level of all templateRootPaths for
-	 * controller-less/fallback-action template files, e.g. files
-	 * which would be rendered if a specified controller's action
-	 * template does not exist (fallback-action) or if no controller
-	 * name was specified in the context (controller-less).
-	 *
-	 * Like other methods, returns a FluidCacheWarmupResult instance
-	 * which can be merged with other result instances.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return FluidCacheWarmupResult
-	 */
-	protected function warmupTemplateRootPaths(RenderingContextInterface $renderingContext) {
-		$result = new FluidCacheWarmupResult();
-		$paths = $renderingContext->getTemplatePaths();
-		foreach ($this->formats as $format) {
-			$paths->setFormat($format);
-			foreach ($this->detectControllerNamesInTemplateRootPaths($paths->getTemplateRootPaths()) as $controllerName) {
-				foreach ($paths->resolveAvailableTemplateFiles($controllerName, $format) as $templateFile) {
-					$state = $this->warmSingleFile(
-						$templateFile,
-						$paths->getTemplateIdentifier(
-							$controllerName,
-							basename($templateFile, '.' . $format)
-						),
-						$renderingContext);
-					$result->add($state, $templateFile);
-				}
-			}
-			foreach ($paths->resolveAvailableTemplateFiles(NULL, $format) as $templateFile) {
-				$state = $this->warmSingleFile(
-					$templateFile,
-					$paths->getTemplateIdentifier(
-						'Default',
-						basename($templateFile, '.' . $format)
-					),
-					$renderingContext);
-				$result->add($state, $templateFile);
-			}
-		}
-		return $result;
-	}
+    /**
+     * Warm up _templateRootPaths_ of the RenderingContext's
+     * TemplatePaths instance.
+     *
+     * Scans for template files recursively in all template root
+     * paths while respecting overlays, e.g. if a path replaces
+     * the template file of a lower priority path then only
+     * one result is returned - the overlayed template file. In
+     * other words the resolving happens exactly as if you were
+     * attempting to render each detected controller, so that the
+     * compiled template will be the same that is resolved when
+     * rendering that controller.
+     *
+     * Also scans the root level of all templateRootPaths for
+     * controller-less/fallback-action template files, e.g. files
+     * which would be rendered if a specified controller's action
+     * template does not exist (fallback-action) or if no controller
+     * name was specified in the context (controller-less).
+     *
+     * Like other methods, returns a FluidCacheWarmupResult instance
+     * which can be merged with other result instances.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return FluidCacheWarmupResult
+     */
+    protected function warmupTemplateRootPaths(RenderingContextInterface $renderingContext)
+    {
+        $result = new FluidCacheWarmupResult();
+        $paths = $renderingContext->getTemplatePaths();
+        foreach ($this->formats as $format) {
+            $paths->setFormat($format);
+            foreach ($this->detectControllerNamesInTemplateRootPaths($paths->getTemplateRootPaths()) as $controllerName) {
+                foreach ($paths->resolveAvailableTemplateFiles($controllerName, $format) as $templateFile) {
+                    $state = $this->warmSingleFile(
+                        $templateFile,
+                        $paths->getTemplateIdentifier(
+                            $controllerName,
+                            basename($templateFile, '.' . $format)
+                        ),
+                        $renderingContext
+                    );
+                    $result->add($state, $templateFile);
+                }
+            }
+            foreach ($paths->resolveAvailableTemplateFiles(null, $format) as $templateFile) {
+                $state = $this->warmSingleFile(
+                    $templateFile,
+                    $paths->getTemplateIdentifier(
+                        'Default',
+                        basename($templateFile, '.' . $format)
+                    ),
+                    $renderingContext
+                );
+                $result->add($state, $templateFile);
+            }
+        }
+        return $result;
+    }
 
-	/**
-	 * Warm up _partialRootPaths_ of the provided RenderingContext's
-	 * TemplatePaths instance. Simple, recursive processing of all
-	 * supported format template files in path(s), compiling only
-	 * the topmost (override) template file if the same template
-	 * exists in multiple partial root paths.
-	 *
-	 * Like other methods, returns a FluidCacheWarmupResult instance
-	 * which can be merged with other result instances.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return FluidCacheWarmupResult
-	 */
-	protected function warmupPartialRootPaths(RenderingContextInterface $renderingContext) {
-		$result = new FluidCacheWarmupResult();
-		$paths = $renderingContext->getTemplatePaths();
-		foreach ($this->formats as $format) {
-			foreach ($paths->resolveAvailablePartialFiles($format) as $partialFile) {
-				$paths->setFormat($format);
-				$state = $this->warmSingleFile(
-					$partialFile,
-					$paths->getPartialIdentifier(basename($partialFile, '.' . $format)),
-					$renderingContext
-				);
-				$result->add($state, $partialFile);
-			}
-		}
-		return $result;
-	}
+    /**
+     * Warm up _partialRootPaths_ of the provided RenderingContext's
+     * TemplatePaths instance. Simple, recursive processing of all
+     * supported format template files in path(s), compiling only
+     * the topmost (override) template file if the same template
+     * exists in multiple partial root paths.
+     *
+     * Like other methods, returns a FluidCacheWarmupResult instance
+     * which can be merged with other result instances.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return FluidCacheWarmupResult
+     */
+    protected function warmupPartialRootPaths(RenderingContextInterface $renderingContext)
+    {
+        $result = new FluidCacheWarmupResult();
+        $paths = $renderingContext->getTemplatePaths();
+        foreach ($this->formats as $format) {
+            foreach ($paths->resolveAvailablePartialFiles($format) as $partialFile) {
+                $paths->setFormat($format);
+                $state = $this->warmSingleFile(
+                    $partialFile,
+                    $paths->getPartialIdentifier(basename($partialFile, '.' . $format)),
+                    $renderingContext
+                );
+                $result->add($state, $partialFile);
+            }
+        }
+        return $result;
+    }
 
-	/**
-	 * Warm up _layoutRootPaths_ of the provided RenderingContext's
-	 * TemplatePaths instance. Simple, recursive processing of all
-	 * supported format template files in path(s), compiling only
-	 * the topmost (override) template file if the same template
-	 * exists in multiple layout root paths.
-	 *
-	 * Like other methods, returns a FluidCacheWarmupResult instance
-	 * which can be merged with other result instances.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return FluidCacheWarmupResult
-	 */
-	protected function warmupLayoutRootPaths(RenderingContextInterface $renderingContext) {
-		$result = new FluidCacheWarmupResult();
-		$paths = $renderingContext->getTemplatePaths();
-		foreach ($this->formats as $format) {
-			foreach ($paths->resolveAvailableLayoutFiles($format) as $layoutFile) {
-				$paths->setFormat($format);
-				$state = $this->warmSingleFile(
-					$layoutFile,
-					$paths->getLayoutIdentifier(basename($layoutFile, '.' . $layoutFile)),
-					$renderingContext
-				);
-				$result->add($state, $layoutFile);
-			}
-		}
-		return $result;
-	}
+    /**
+     * Warm up _layoutRootPaths_ of the provided RenderingContext's
+     * TemplatePaths instance. Simple, recursive processing of all
+     * supported format template files in path(s), compiling only
+     * the topmost (override) template file if the same template
+     * exists in multiple layout root paths.
+     *
+     * Like other methods, returns a FluidCacheWarmupResult instance
+     * which can be merged with other result instances.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return FluidCacheWarmupResult
+     */
+    protected function warmupLayoutRootPaths(RenderingContextInterface $renderingContext)
+    {
+        $result = new FluidCacheWarmupResult();
+        $paths = $renderingContext->getTemplatePaths();
+        foreach ($this->formats as $format) {
+            foreach ($paths->resolveAvailableLayoutFiles($format) as $layoutFile) {
+                $paths->setFormat($format);
+                $state = $this->warmSingleFile(
+                    $layoutFile,
+                    $paths->getLayoutIdentifier(basename($layoutFile, '.' . $layoutFile)),
+                    $renderingContext
+                );
+                $result->add($state, $layoutFile);
+            }
+        }
+        return $result;
+    }
 
-	/**
-	 * Detect all available controller names in provided TemplateRootPaths
-	 * array, returning the "basename" components of controller-template
-	 * directories encountered, as an array.
-	 *
-	 * @param string $templateRootPaths
-	 * @return \Generator
-	 */
-	protected function detectControllerNamesInTemplateRootPaths(array $templateRootPaths) {
-		foreach ($templateRootPaths as $templateRootPath) {
-			foreach ((array) glob(rtrim($templateRootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $pathName) {
-				if (is_dir($pathName)) {
-					yield basename($pathName);
-				}
-			}
-		}
-	}
+    /**
+     * Detect all available controller names in provided TemplateRootPaths
+     * array, returning the "basename" components of controller-template
+     * directories encountered, as an array.
+     *
+     * @param string $templateRootPaths
+     * @return \Generator
+     */
+    protected function detectControllerNamesInTemplateRootPaths(array $templateRootPaths)
+    {
+        foreach ($templateRootPaths as $templateRootPath) {
+            foreach ((array) glob(rtrim($templateRootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $pathName) {
+                if (is_dir($pathName)) {
+                    yield basename($pathName);
+                }
+            }
+        }
+    }
 
-	/**
-	 * Warm up a single template file.
-	 *
-	 * Performs reading, parsing and attempts compiling of a single
-	 * template file. Catches errors that may occur and reports them
-	 * in a FailedCompilingState (which can then be `add()`'ed to
-	 * the FluidCacheWarmupResult to assimilate the information within.
-	 *
-	 * Adds basic mitigation suggestions for each specific type of error,
-	 * giving hints to developers if a certain template fails to compile.
-	 *
-	 * @param string $templatePathAndFilename
-	 * @param string $identifier
-	 * @param RenderingContextInterface $renderingContext
-	 * @return ParsedTemplateInterface
-	 */
-	protected function warmSingleFile($templatePathAndFilename, $identifier, RenderingContextInterface $renderingContext) {
-		$parsedTemplate = new FailedCompilingState();
-		$parsedTemplate->setVariableProvider($renderingContext->getVariableProvider());
-		$parsedTemplate->setCompilable(FALSE);
-		$parsedTemplate->setIdentifier($identifier);
-		try {
-			$parsedTemplate = $renderingContext->getTemplateParser()->getOrParseAndStoreTemplate(
-				$identifier,
-				function (TemplateParser $parser, TemplatePaths $templatePaths) use ($templatePathAndFilename) {
-					return file_get_contents($templatePathAndFilename, FILE_TEXT);
-				}
-			);
-		} catch (StopCompilingException $error) {
-			$parsedTemplate->setFailureReason(sprintf('Compiling is intentionally disabled. Specific reason unknown. Message: "%s"', $error->getMessage()));
-			$parsedTemplate->setMitigations(array(
-				'Can be caused by specific ViewHelpers. If this is is not intentional: avoid ViewHelpers which disable caches.',
-				'If cache is intentionally disabled: consider using `f:cache.static` to cause otherwise uncompilable ViewHelpers\' output to be replaced with a static string in compiled templates.'
-			));
-		} catch (ExpressionException $error) {
-			$parsedTemplate->setFailureReason(sprintf('ExpressionNode evaluation error: %s', $error->getMessage()));
-			$parsedTemplate->setMitigations(array(
-				'Emulate variables used in ExpressionNode using `f:cache.warmup` or assign in warming RenderingContext'
-			));
-		} catch (\TYPO3Fluid\Fluid\Core\Parser\Exception $error) {
-			$parsedTemplate->setFailureReason($error->getMessage());
-			$parsedTemplate->setMitigations(array(
-				'Fix possible syntax errors.',
-				'Check that all ViewHelpers are correctly referenced and namespaces loaded (note: namespaces may be added externally!)',
-				'Check that all ExpressionNode types used by the template are loaded (note: may depend on RenderingContext implementation!)',
-				'Emulate missing variables used in expressions by using `f:cache.warmup` around your template code.'
-			));
-		} catch (\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error) {
-			$parsedTemplate->setFailureReason(sprintf('ViewHelper threw Exception: %s', $error->getMessage()));
-			$parsedTemplate->setMitigations(array(
-				'Emulate missing variables using `f:cache.warmup` around failing ViewHelper.',
-				'Emulate globals / context required by ViewHelper.',
-				'Disable caching for template if ViewHelper depends on globals / context that cannot be emulated.'
-			));
-		} catch (\TYPO3Fluid\Fluid\Core\Exception $error) {
-			$parsedTemplate->setFailureReason(sprintf('Fluid engine error: %s', $error->getMessage()));
-			$parsedTemplate->setMitigations(array(
-				'Search online for additional information about specific error.'
-			));
-		} catch (Exception $error) {
-			$parsedTemplate->setFailureReason(sprintf('Fluid view error: %s', $error->getMessage()));
-			$parsedTemplate->setMitigations(array(
-				'Investigate reported error in View class for missing variable checks, missing configuration etc.',
-				'Consider using a different View class for rendering in warmup mode (a custom rendering context can provide it)'
-			));
-		} catch (\RuntimeException $error) {
-			$parsedTemplate->setFailureReason(
-				sprintf(
-					'General error: %s line %s threw %s (code: %d)',
-					get_class($error),
-					$error->getFile(),
-					$error->getLine(),
-					$error->getMessage(),
-					$error->getCode()
-				)
-			);
-			$parsedTemplate->setMitigations(array(
-				'There are no automated suggestions for mitigating this issue. An online search may yield more information.'
-			));
-		}
-		return $parsedTemplate;
-	}
-
-
+    /**
+     * Warm up a single template file.
+     *
+     * Performs reading, parsing and attempts compiling of a single
+     * template file. Catches errors that may occur and reports them
+     * in a FailedCompilingState (which can then be `add()`'ed to
+     * the FluidCacheWarmupResult to assimilate the information within.
+     *
+     * Adds basic mitigation suggestions for each specific type of error,
+     * giving hints to developers if a certain template fails to compile.
+     *
+     * @param string $templatePathAndFilename
+     * @param string $identifier
+     * @param RenderingContextInterface $renderingContext
+     * @return ParsedTemplateInterface
+     */
+    protected function warmSingleFile($templatePathAndFilename, $identifier, RenderingContextInterface $renderingContext)
+    {
+        $parsedTemplate = new FailedCompilingState();
+        $parsedTemplate->setVariableProvider($renderingContext->getVariableProvider());
+        $parsedTemplate->setCompilable(false);
+        $parsedTemplate->setIdentifier($identifier);
+        try {
+            $parsedTemplate = $renderingContext->getTemplateParser()->getOrParseAndStoreTemplate(
+                $identifier,
+                function (TemplateParser $parser, TemplatePaths $templatePaths) use ($templatePathAndFilename) {
+                    return file_get_contents($templatePathAndFilename, FILE_TEXT);
+                }
+            );
+        } catch (StopCompilingException $error) {
+            $parsedTemplate->setFailureReason(sprintf('Compiling is intentionally disabled. Specific reason unknown. Message: "%s"', $error->getMessage()));
+            $parsedTemplate->setMitigations([
+                'Can be caused by specific ViewHelpers. If this is is not intentional: avoid ViewHelpers which disable caches.',
+                'If cache is intentionally disabled: consider using `f:cache.static` to cause otherwise uncompilable ViewHelpers\' output to be replaced with a static string in compiled templates.'
+            ]);
+        } catch (ExpressionException $error) {
+            $parsedTemplate->setFailureReason(sprintf('ExpressionNode evaluation error: %s', $error->getMessage()));
+            $parsedTemplate->setMitigations([
+                'Emulate variables used in ExpressionNode using `f:cache.warmup` or assign in warming RenderingContext'
+            ]);
+        } catch (\TYPO3Fluid\Fluid\Core\Parser\Exception $error) {
+            $parsedTemplate->setFailureReason($error->getMessage());
+            $parsedTemplate->setMitigations([
+                'Fix possible syntax errors.',
+                'Check that all ViewHelpers are correctly referenced and namespaces loaded (note: namespaces may be added externally!)',
+                'Check that all ExpressionNode types used by the template are loaded (note: may depend on RenderingContext implementation!)',
+                'Emulate missing variables used in expressions by using `f:cache.warmup` around your template code.'
+            ]);
+        } catch (\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error) {
+            $parsedTemplate->setFailureReason(sprintf('ViewHelper threw Exception: %s', $error->getMessage()));
+            $parsedTemplate->setMitigations([
+                'Emulate missing variables using `f:cache.warmup` around failing ViewHelper.',
+                'Emulate globals / context required by ViewHelper.',
+                'Disable caching for template if ViewHelper depends on globals / context that cannot be emulated.'
+            ]);
+        } catch (\TYPO3Fluid\Fluid\Core\Exception $error) {
+            $parsedTemplate->setFailureReason(sprintf('Fluid engine error: %s', $error->getMessage()));
+            $parsedTemplate->setMitigations([
+                'Search online for additional information about specific error.'
+            ]);
+        } catch (Exception $error) {
+            $parsedTemplate->setFailureReason(sprintf('Fluid view error: %s', $error->getMessage()));
+            $parsedTemplate->setMitigations([
+                'Investigate reported error in View class for missing variable checks, missing configuration etc.',
+                'Consider using a different View class for rendering in warmup mode (a custom rendering context can provide it)'
+            ]);
+        } catch (\RuntimeException $error) {
+            $parsedTemplate->setFailureReason(
+                sprintf(
+                    'General error: %s line %s threw %s (code: %d)',
+                    get_class($error),
+                    $error->getFile(),
+                    $error->getLine(),
+                    $error->getMessage(),
+                    $error->getCode()
+                )
+            );
+            $parsedTemplate->setMitigations([
+                'There are no automated suggestions for mitigating this issue. An online search may yield more information.'
+            ]);
+        }
+        return $parsedTemplate;
+    }
 }

--- a/src/Core/Compiler/AbstractCompiledTemplate.php
+++ b/src/Core/Compiler/AbstractCompiledTemplate.php
@@ -16,76 +16,85 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * INTERNAL!!
  */
-abstract class AbstractCompiledTemplate implements ParsedTemplateInterface {
+abstract class AbstractCompiledTemplate implements ParsedTemplateInterface
+{
 
-	/**
-	 * @param string $identifier
-	 * @return void
-	 */
-	public function setIdentifier($identifier) {
-		// void, ignored.
-	}
+    /**
+     * @param string $identifier
+     * @return void
+     */
+    public function setIdentifier($identifier)
+    {
+        // void, ignored.
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getIdentifier() {
-		return static::class;
-	}
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return static::class;
+    }
 
-	/**
-	 * Returns a variable container used in the PostParse Facet.
-	 *
-	 * @return VariableProviderInterface
-	 */
-	public function getVariableContainer() {
-		return new StandardVariableProvider();
-	}
+    /**
+     * Returns a variable container used in the PostParse Facet.
+     *
+     * @return VariableProviderInterface
+     */
+    public function getVariableContainer()
+    {
+        return new StandardVariableProvider();
+    }
 
-	/**
-	 * Render the parsed template with rendering context
-	 *
-	 * @param RenderingContextInterface $renderingContext The rendering context to use
-	 * @return string Rendered string
-	 */
-	public function render(RenderingContextInterface $renderingContext) {
-		return '';
-	}
+    /**
+     * Render the parsed template with rendering context
+     *
+     * @param RenderingContextInterface $renderingContext The rendering context to use
+     * @return string Rendered string
+     */
+    public function render(RenderingContextInterface $renderingContext)
+    {
+        return '';
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCompilable() {
-		return FALSE;
-	}
+    /**
+     * @return boolean
+     */
+    public function isCompilable()
+    {
+        return false;
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCompiled() {
-		return TRUE;
-	}
+    /**
+     * @return boolean
+     */
+    public function isCompiled()
+    {
+        return true;
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function hasLayout() {
-		return FALSE;
-	}
+    /**
+     * @return boolean
+     */
+    public function hasLayout()
+    {
+        return false;
+    }
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 */
-	public function getLayoutName(RenderingContextInterface $renderingContext) {
-		return '';
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public function getLayoutName(RenderingContextInterface $renderingContext)
+    {
+        return '';
+    }
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {
-	}
-
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext)
+    {
+    }
 }

--- a/src/Core/Compiler/FailedCompilingState.php
+++ b/src/Core/Compiler/FailedCompilingState.php
@@ -15,7 +15,8 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
  * Replacement ParsingState used when a template fails to compile.
  * Includes additional reasons why compiling failed.
  */
-class FailedCompilingState extends ParsingState implements ParsedTemplateInterface  {
+class FailedCompilingState extends ParsingState implements ParsedTemplateInterface
+{
 
     /**
      * @var string
@@ -25,12 +26,13 @@ class FailedCompilingState extends ParsingState implements ParsedTemplateInterfa
     /**
      * @var string[]
      */
-    protected $mitigations = array();
+    protected $mitigations = [];
 
     /**
      * @return string
      */
-    public function getFailureReason() {
+    public function getFailureReason()
+    {
         return $this->failureReason;
     }
 
@@ -38,21 +40,24 @@ class FailedCompilingState extends ParsingState implements ParsedTemplateInterfa
      * @param string $failureReason
      * @return void
      */
-    public function setFailureReason($failureReason) {
+    public function setFailureReason($failureReason)
+    {
         $this->failureReason = $failureReason;
     }
 
     /**
      * @return array
      */
-    public function getMitigations() {
+    public function getMitigations()
+    {
         return $this->mitigations;
     }
 
     /**
      * @param array $mitigations
      */
-    public function setMitigations(array $mitigations) {
+    public function setMitigations(array $mitigations)
+    {
         $this->mitigations = $mitigations;
     }
 
@@ -60,8 +65,8 @@ class FailedCompilingState extends ParsingState implements ParsedTemplateInterfa
      * @param string $mitigation
      * @return void
      */
-    public function addMitigation($mitigation) {
+    public function addMitigation($mitigation)
+    {
         $this->mitigations[] = $mitigation;
     }
-
 }

--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -22,380 +22,389 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 /**
  * Class NodeConverter
  */
-class NodeConverter {
+class NodeConverter
+{
 
-	/**
-	 * @var integer
-	 */
-	protected $variableCounter = 0;
+    /**
+     * @var integer
+     */
+    protected $variableCounter = 0;
 
-	/**
-	 * @var TemplateCompiler
-	 */
-	protected $templateCompiler;
+    /**
+     * @var TemplateCompiler
+     */
+    protected $templateCompiler;
 
-	/**
-	 * @param TemplateCompiler $templateCompiler
-	 */
-	public function __construct(TemplateCompiler $templateCompiler) {
-		$this->templateCompiler = $templateCompiler;
-	}
+    /**
+     * @param TemplateCompiler $templateCompiler
+     */
+    public function __construct(TemplateCompiler $templateCompiler)
+    {
+        $this->templateCompiler = $templateCompiler;
+    }
 
-	/**
-	 * @param integer $variableCounter
-	 * @return void
-	 */
-	public function setVariableCounter($variableCounter) {
-		$this->variableCounter = $variableCounter;
-	}
+    /**
+     * @param integer $variableCounter
+     * @return void
+     */
+    public function setVariableCounter($variableCounter)
+    {
+        $this->variableCounter = $variableCounter;
+    }
 
-	/**
-	 * Returns an array with two elements:
-	 * - initialization: contains PHP code which is inserted *before* the actual rendering call. Must be valid, i.e. end with semi-colon.
-	 * - execution: contains *a single PHP instruction* which needs to return the rendered output of the given element. Should NOT end with semi-colon.
-	 *
-	 * @param NodeInterface $node
-	 * @return array two-element array, see above
-	 * @throws FluidException
-	 */
-	public function convert(NodeInterface $node) {
-		switch (TRUE) {
-			case $node instanceof TextNode:
-				$converted = $this->convertTextNode($node);
-				break;
-			case $node instanceof ExpressionNodeInterface:
-				$converted = $this->convertExpressionNode($node);
-				break;
-			case $node instanceof NumericNode:
-				$converted = $this->convertNumericNode($node);
-				break;
-			case $node instanceof ViewHelperNode:
-				$converted = $this->convertViewHelperNode($node);
-				break;
-			case $node instanceof ObjectAccessorNode:
-				$converted = $this->convertObjectAccessorNode($node);
-				break;
-			case $node instanceof ArrayNode:
-				$converted = $this->convertArrayNode($node);
-				break;
-			case $node instanceof RootNode:
-				$converted = $this->convertListOfSubNodes($node);
-				break;
-			case $node instanceof BooleanNode:
-				$converted = $this->convertBooleanNode($node);
-				break;
-			case $node instanceof EscapingNode:
-				$converted = $this->convertEscapingNode($node);
-				break;
-			default:
-				$converted = array(
-					'initialization' => '// Uncompilable/convertible node type: ' . get_class($node) . chr(10),
-					'execution' => ''
-				);
-		}
-		return $converted;
-	}
+    /**
+     * Returns an array with two elements:
+     * - initialization: contains PHP code which is inserted *before* the actual rendering call. Must be valid, i.e. end with semi-colon.
+     * - execution: contains *a single PHP instruction* which needs to return the rendered output of the given element. Should NOT end with semi-colon.
+     *
+     * @param NodeInterface $node
+     * @return array two-element array, see above
+     * @throws FluidException
+     */
+    public function convert(NodeInterface $node)
+    {
+        switch (true) {
+            case $node instanceof TextNode:
+                $converted = $this->convertTextNode($node);
+                break;
+            case $node instanceof ExpressionNodeInterface:
+                $converted = $this->convertExpressionNode($node);
+                break;
+            case $node instanceof NumericNode:
+                $converted = $this->convertNumericNode($node);
+                break;
+            case $node instanceof ViewHelperNode:
+                $converted = $this->convertViewHelperNode($node);
+                break;
+            case $node instanceof ObjectAccessorNode:
+                $converted = $this->convertObjectAccessorNode($node);
+                break;
+            case $node instanceof ArrayNode:
+                $converted = $this->convertArrayNode($node);
+                break;
+            case $node instanceof RootNode:
+                $converted = $this->convertListOfSubNodes($node);
+                break;
+            case $node instanceof BooleanNode:
+                $converted = $this->convertBooleanNode($node);
+                break;
+            case $node instanceof EscapingNode:
+                $converted = $this->convertEscapingNode($node);
+                break;
+            default:
+                $converted = [
+                    'initialization' => '// Uncompilable/convertible node type: ' . get_class($node) . chr(10),
+                    'execution' => ''
+                ];
+        }
+        return $converted;
+    }
 
-	/**
-	 * @param EscapingNode $node
-	 * @return array
-	 */
-	protected function convertEscapingNode(EscapingNode $node) {
-		$configuration = $this->convert($node->getNode());
-		$configuration['execution'] = sprintf('htmlspecialchars(%s, ENT_QUOTES)', $configuration['execution']);
-		return $configuration;
-	}
+    /**
+     * @param EscapingNode $node
+     * @return array
+     */
+    protected function convertEscapingNode(EscapingNode $node)
+    {
+        $configuration = $this->convert($node->getNode());
+        $configuration['execution'] = sprintf('htmlspecialchars(%s, ENT_QUOTES)', $configuration['execution']);
+        return $configuration;
+    }
 
-	/**
-	 * @param TextNode $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertTextNode(TextNode $node) {
-		return array(
-			'initialization' => '',
-			'execution' => '\'' . $this->escapeTextForUseInSingleQuotes($node->getText()) . '\''
-		);
-	}
+    /**
+     * @param TextNode $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertTextNode(TextNode $node)
+    {
+        return [
+            'initialization' => '',
+            'execution' => '\'' . $this->escapeTextForUseInSingleQuotes($node->getText()) . '\''
+        ];
+    }
 
-	/**
-	 * @param NumericNode $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertNumericNode(NumericNode $node) {
-		return array(
-			'initialization' => '',
-			'execution' => $node->getValue()
-		);
-	}
+    /**
+     * @param NumericNode $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertNumericNode(NumericNode $node)
+    {
+        return [
+            'initialization' => '',
+            'execution' => $node->getValue()
+        ];
+    }
 
-	/**
-	 * Convert a single ViewHelperNode into its cached representation. If the ViewHelper implements the "Compilable" facet,
-	 * the ViewHelper itself is asked for its cached PHP code representation. If not, a ViewHelper is built and then invoked.
-	 *
-	 * @param ViewHelperNode $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertViewHelperNode(ViewHelperNode $node) {
-		$initializationPhpCode = '// Rendering ViewHelper ' . $node->getViewHelperClassName() . chr(10);
+    /**
+     * Convert a single ViewHelperNode into its cached representation. If the ViewHelper implements the "Compilable" facet,
+     * the ViewHelper itself is asked for its cached PHP code representation. If not, a ViewHelper is built and then invoked.
+     *
+     * @param ViewHelperNode $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertViewHelperNode(ViewHelperNode $node)
+    {
+        $initializationPhpCode = '// Rendering ViewHelper ' . $node->getViewHelperClassName() . chr(10);
 
-		// Build up $arguments array
-		$argumentsVariableName = $this->variableName('arguments');
-		$renderChildrenClosureVariableName = $this->variableName('renderChildrenClosure');
-		$viewHelperInitializationPhpCode = '';
+        // Build up $arguments array
+        $argumentsVariableName = $this->variableName('arguments');
+        $renderChildrenClosureVariableName = $this->variableName('renderChildrenClosure');
+        $viewHelperInitializationPhpCode = '';
 
-		try {
+        try {
+            $convertedViewHelperExecutionCode = $node->getUninitializedViewHelper()->compile(
+                $argumentsVariableName,
+                $renderChildrenClosureVariableName,
+                $viewHelperInitializationPhpCode,
+                $node,
+                $this->templateCompiler
+            );
 
-			$convertedViewHelperExecutionCode = $node->getUninitializedViewHelper()->compile(
-				$argumentsVariableName,
-				$renderChildrenClosureVariableName,
-				$viewHelperInitializationPhpCode,
-				$node,
-				$this->templateCompiler
-			);
+            $arguments = $node->getArgumentDefinitions();
+            $argumentInitializationCode = sprintf('%s = array();', $argumentsVariableName) . chr(10);
+            foreach ($arguments as $argumentName => $argumentDefinition) {
+                if (!isset($alreadyBuiltArguments[$argumentName])) {
+                    $argumentInitializationCode .= sprintf(
+                        '%s[\'%s\'] = %s;%s',
+                        $argumentsVariableName,
+                        $argumentName,
+                        var_export($argumentDefinition->getDefaultValue(), true),
+                        chr(10)
+                    );
+                }
+            }
 
-			$arguments = $node->getArgumentDefinitions();
-			$argumentInitializationCode = sprintf('%s = array();', $argumentsVariableName) . chr(10);
-			foreach ($arguments  as $argumentName => $argumentDefinition) {
-				if (!isset($alreadyBuiltArguments[$argumentName])) {
-					$argumentInitializationCode .= sprintf(
-						'%s[\'%s\'] = %s;%s',
-						$argumentsVariableName,
-						$argumentName,
-						var_export($argumentDefinition->getDefaultValue(), TRUE),
-						chr(10)
-					);
-				}
-			}
+            $alreadyBuiltArguments = [];
+            foreach ($node->getArguments() as $argumentName => $argumentValue) {
+                if ($argumentValue instanceof NodeInterface) {
+                    $converted = $this->convert($argumentValue);
+                } else {
+                    $converted = [
+                        'initialization' => '',
+                        'execution' => $argumentValue
+                    ];
+                }
+                $argumentInitializationCode .= $converted['initialization'];
+                $argumentInitializationCode .= sprintf(
+                    '%s[\'%s\'] = %s;',
+                    $argumentsVariableName,
+                    $argumentName,
+                    $converted['execution']
+                ) . chr(10);
+                $alreadyBuiltArguments[$argumentName] = true;
+            }
 
-			$alreadyBuiltArguments = array();
-			foreach ($node->getArguments() as $argumentName => $argumentValue) {
-				if ($argumentValue instanceof NodeInterface) {
-					$converted = $this->convert($argumentValue);
-				} else {
-					$converted = array(
-						'initialization' => '',
-						'execution' => $argumentValue
-					);
-				}
-				$argumentInitializationCode .= $converted['initialization'];
-				$argumentInitializationCode .= sprintf(
-					'%s[\'%s\'] = %s;',
-					$argumentsVariableName,
-					$argumentName,
-					$converted['execution']
-				) . chr(10);
-				$alreadyBuiltArguments[$argumentName] = TRUE;
-			}
+            // Build up closure which renders the child nodes
+            $initializationPhpCode .= sprintf(
+                '%s = %s;',
+                $renderChildrenClosureVariableName,
+                $this->templateCompiler->wrapChildNodesInClosure($node)
+            ) . chr(10);
 
-			// Build up closure which renders the child nodes
-			$initializationPhpCode .= sprintf(
-					'%s = %s;',
-					$renderChildrenClosureVariableName,
-					$this->templateCompiler->wrapChildNodesInClosure($node)
-				) . chr(10);
+            $initializationPhpCode .= $argumentInitializationCode . $viewHelperInitializationPhpCode;
+        } catch (StopCompilingChildrenException $stopCompilingChildrenException) {
+            $convertedViewHelperExecutionCode = '\'' . $stopCompilingChildrenException->getReplacementString() . '\'';
+        }
+        $initializationArray = [
+            'initialization' => $initializationPhpCode,
+            'execution' => $convertedViewHelperExecutionCode === null ? 'NULL' : $convertedViewHelperExecutionCode
+        ];
+        return $initializationArray;
+    }
 
-			$initializationPhpCode .= $argumentInitializationCode . $viewHelperInitializationPhpCode;
+    /**
+     * @param ObjectAccessorNode $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertObjectAccessorNode(ObjectAccessorNode $node)
+    {
+        $arrayVariableName = $this->variableName('array');
+        $accessors = $node->getAccessors();
+        $providerReference = '$renderingContext->getVariableProvider()';
+        $path = $node->getObjectPath();
+        $pathSegments = explode('.', $path);
+        if ($path === '_all') {
+            return [
+                'initialization' => '',
+                'execution' => sprintf('%s->getAll()', $providerReference)
+            ];
+        } elseif (1 === count(array_unique($accessors))
+            && reset($accessors) === VariableExtractor::ACCESSOR_ARRAY
+            && count($accessors) === count($pathSegments)
+            && false === strpos($path, '{')
+        ) {
+            // every extractor used in this path is a straight-forward arrayaccess.
+            // Create the compiled code as a plain old variable assignment:
+            return [
+                'initialization' => '',
+                'execution' => sprintf(
+                    'isset(%s[\'%s\']) ? %s[\'%s\'] : NULL',
+                    $providerReference,
+                    str_replace('.', '\'][\'', $path),
+                    $providerReference,
+                    str_replace('.', '\'][\'', $path)
+                )
+            ];
+        }
+        $accessorsVariable = var_export($accessors, true);
+        $initialization = sprintf('%s = %s;', $arrayVariableName, $accessorsVariable);
+        return [
+            'initialization' => $initialization,
+            'execution' => sprintf(
+                '%s->getByPath(\'%s\', %s)',
+                $providerReference,
+                $path,
+                $arrayVariableName
+            )
+        ];
+    }
 
-		} catch (StopCompilingChildrenException $stopCompilingChildrenException) {
+    /**
+     * @param ArrayNode $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertArrayNode(ArrayNode $node)
+    {
+        $initializationPhpCode = '// Rendering Array' . chr(10);
+        $arrayVariableName = $this->variableName('array');
 
-			$convertedViewHelperExecutionCode = '\'' . $stopCompilingChildrenException->getReplacementString() . '\'';
+        $initializationPhpCode .= sprintf('%s = array();', $arrayVariableName) . chr(10);
 
-		}
-		$initializationArray = array(
-			'initialization' => $initializationPhpCode,
-			'execution' => $convertedViewHelperExecutionCode === NULL ? 'NULL' : $convertedViewHelperExecutionCode
-		);
-		return $initializationArray;
-	}
+        foreach ($node->getInternalArray() as $key => $value) {
+            if ($value instanceof NodeInterface) {
+                $converted = $this->convert($value);
+                $initializationPhpCode .= $converted['initialization'];
+                $initializationPhpCode .= sprintf(
+                    '%s[\'%s\'] = %s;',
+                    $arrayVariableName,
+                    $key,
+                    $converted['execution']
+                ) . chr(10);
+            } elseif (is_numeric($value)) {
+                // this case might happen for simple values
+                $initializationPhpCode .= sprintf(
+                    '%s[\'%s\'] = %s;',
+                    $arrayVariableName,
+                    $key,
+                    $value
+                ) . chr(10);
+            } else {
+                // this case might happen for simple values
+                $initializationPhpCode .= sprintf(
+                    '%s[\'%s\'] = \'%s\';',
+                    $arrayVariableName,
+                    $key,
+                    $this->escapeTextForUseInSingleQuotes($value)
+                ) . chr(10);
+            }
+        }
+        return [
+            'initialization' => $initializationPhpCode,
+            'execution' => $arrayVariableName
+        ];
+    }
 
-	/**
-	 * @param ObjectAccessorNode $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertObjectAccessorNode(ObjectAccessorNode $node) {
-		$arrayVariableName = $this->variableName('array');
-		$accessors = $node->getAccessors();
-		$providerReference = '$renderingContext->getVariableProvider()';
-		$path = $node->getObjectPath();
-		$pathSegments = explode('.', $path);
-		if ($path === '_all') {
-			return array(
-				'initialization' => '',
-				'execution' => sprintf('%s->getAll()', $providerReference)
-			);
-		} elseif (
-			1 === count(array_unique($accessors))
-			&& reset($accessors) === VariableExtractor::ACCESSOR_ARRAY
-			&& count($accessors) === count($pathSegments)
-			&& FALSE === strpos($path, '{')
-		) {
-			// every extractor used in this path is a straight-forward arrayaccess.
-			// Create the compiled code as a plain old variable assignment:
-			return array(
-				'initialization' => '',
-				'execution' => sprintf(
-					'isset(%s[\'%s\']) ? %s[\'%s\'] : NULL',
-					$providerReference,
-					str_replace('.', '\'][\'', $path),
-					$providerReference,
-					str_replace('.', '\'][\'', $path)
-				)
-			);
-		}
-		$accessorsVariable = var_export($accessors, TRUE);
-		$initialization = sprintf('%s = %s;', $arrayVariableName, $accessorsVariable);
-		return array(
-			'initialization' => $initialization,
-			'execution' => sprintf(
-				'%s->getByPath(\'%s\', %s)',
-				$providerReference,
-				$path,
-				$arrayVariableName
-			)
-		);
-	}
+    /**
+     * @param NodeInterface $node
+     * @return array
+     * @see convert()
+     */
+    public function convertListOfSubNodes(NodeInterface $node)
+    {
+        switch (count($node->getChildNodes())) {
+            case 0:
+                return [
+                    'initialization' => '',
+                    'execution' => 'NULL'
+                ];
+            case 1:
+                $childNode = current($node->getChildNodes());
+                if ($childNode instanceof NodeInterface) {
+                    return $this->convert($childNode);
+                }
+            default:
+                $outputVariableName = $this->variableName('output');
+                $initializationPhpCode = sprintf('%s = \'\';', $outputVariableName) . chr(10);
 
-	/**
-	 * @param ArrayNode $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertArrayNode(ArrayNode $node) {
-		$initializationPhpCode = '// Rendering Array' . chr(10);
-		$arrayVariableName = $this->variableName('array');
+                foreach ($node->getChildNodes() as $childNode) {
+                    $converted = $this->convert($childNode);
 
-		$initializationPhpCode .= sprintf('%s = array();', $arrayVariableName) . chr(10);
+                    $initializationPhpCode .= $converted['initialization'] . chr(10);
+                    $initializationPhpCode .= sprintf('%s .= %s;', $outputVariableName, $converted['execution']) . chr(10);
+                }
 
-		foreach ($node->getInternalArray() as $key => $value) {
-			if ($value instanceof NodeInterface) {
-				$converted = $this->convert($value);
-				$initializationPhpCode .= $converted['initialization'];
-				$initializationPhpCode .= sprintf(
-						'%s[\'%s\'] = %s;',
-						$arrayVariableName,
-						$key,
-						$converted['execution']
-					) . chr(10);
-			} elseif (is_numeric($value)) {
-				// this case might happen for simple values
-				$initializationPhpCode .= sprintf(
-						'%s[\'%s\'] = %s;',
-						$arrayVariableName,
-						$key,
-						$value
-					) . chr(10);
-			} else {
-				// this case might happen for simple values
-				$initializationPhpCode .= sprintf(
-						'%s[\'%s\'] = \'%s\';',
-						$arrayVariableName,
-						$key,
-						$this->escapeTextForUseInSingleQuotes($value)
-					) . chr(10);
-			}
-		}
-		return array(
-			'initialization' => $initializationPhpCode,
-			'execution' => $arrayVariableName
-		);
-	}
+                return [
+                    'initialization' => $initializationPhpCode,
+                    'execution' => $outputVariableName
+                ];
+        }
+    }
 
-	/**
-	 * @param NodeInterface $node
-	 * @return array
-	 * @see convert()
-	 */
-	public function convertListOfSubNodes(NodeInterface $node) {
-		switch (count($node->getChildNodes())) {
-			case 0:
-				return array(
-					'initialization' => '',
-					'execution' => 'NULL'
-				);
-			case 1:
-				$childNode = current($node->getChildNodes());
-				if ($childNode instanceof NodeInterface) {
-					return $this->convert($childNode);
-				}
-			default:
-				$outputVariableName = $this->variableName('output');
-				$initializationPhpCode = sprintf('%s = \'\';', $outputVariableName) . chr(10);
+    /**
+     * @param ExpressionNodeInterface $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertExpressionNode(ExpressionNodeInterface $node)
+    {
+        return $node->compile($this->templateCompiler);
+    }
 
-				foreach ($node->getChildNodes() as $childNode) {
-					$converted = $this->convert($childNode);
+    /**
+     * @param BooleanNode $node
+     * @return array
+     * @see convert()
+     */
+    protected function convertBooleanNode(BooleanNode $node)
+    {
+        $stack = $this->convertArrayNode(new ArrayNode($node->getStack()));
+        $initializationPhpCode = '// Rendering Boolean node' . chr(10);
+        $initializationPhpCode .= $stack['initialization'] . chr(10);
 
-					$initializationPhpCode .= $converted['initialization'] . chr(10);
-					$initializationPhpCode .= sprintf('%s .= %s;', $outputVariableName, $converted['execution']) . chr(10);
-				}
+        $parser = new BooleanParser();
+        $compiledExpression = $parser->compile(BooleanNode::reconcatenateExpression($node->getStack()));
+        $functionName = $this->variableName('expression');
+        $initializationPhpCode .= $functionName . ' = function($context) {return ' . $compiledExpression . ';};' . chr(10);
 
-				return array(
-					'initialization' => $initializationPhpCode,
-					'execution' => $outputVariableName
-				);
-		}
-	}
-
-	/**
-	 * @param ExpressionNodeInterface $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertExpressionNode(ExpressionNodeInterface $node) {
-		return $node->compile($this->templateCompiler);
-	}
-
-	/**
-	 * @param BooleanNode $node
-	 * @return array
-	 * @see convert()
-	 */
-	protected function convertBooleanNode(BooleanNode $node) {
-		$stack = $this->convertArrayNode(new ArrayNode($node->getStack()));
-		$initializationPhpCode = '// Rendering Boolean node' . chr(10);
-		$initializationPhpCode .= $stack['initialization'] . chr(10);
-
-		$parser = new BooleanParser();
-		$compiledExpression = $parser->compile(BooleanNode::reconcatenateExpression($node->getStack()));
-		$functionName = $this->variableName('expression');
-		$initializationPhpCode .= $functionName . ' = function($context) {return ' . $compiledExpression . ';};' . chr(10);
-
-		return array(
-			'initialization' => $initializationPhpCode,
-			'execution' => sprintf(
-				'%s::convertToBoolean(
+        return [
+            'initialization' => $initializationPhpCode,
+            'execution' => sprintf(
+                '%s::convertToBoolean(
 					%s(
 						%s::gatherContext($renderingContext, %s)
 					),
 					$renderingContext
 				)',
-				BooleanNode::class,
-				$functionName,
-				BooleanNode::class,
-				$stack['execution']
-			)
-		);
-	}
+                BooleanNode::class,
+                $functionName,
+                BooleanNode::class,
+                $stack['execution']
+            )
+        ];
+    }
 
-	/**
-	 * @param string $text
-	 * @return string
-	 */
-	protected function escapeTextForUseInSingleQuotes($text) {
-		return str_replace(array('\\', '\''), array('\\\\', '\\\''), $text);
-	}
+    /**
+     * @param string $text
+     * @return string
+     */
+    protected function escapeTextForUseInSingleQuotes($text)
+    {
+        return str_replace(['\\', '\''], ['\\\\', '\\\''], $text);
+    }
 
-	/**
-	 * Returns a unique variable name by appending a global index to the given prefix
-	 *
-	 * @param string $prefix
-	 * @return string
-	 */
-	public function variableName($prefix) {
-		return '$' . $prefix . $this->variableCounter++;
-	}
-
+    /**
+     * Returns a unique variable name by appending a global index to the given prefix
+     *
+     * @param string $prefix
+     * @return string
+     */
+    public function variableName($prefix)
+    {
+        return '$' . $prefix . $this->variableCounter++;
+    }
 }

--- a/src/Core/Compiler/StopCompilingChildrenException.php
+++ b/src/Core/Compiler/StopCompilingChildrenException.php
@@ -25,25 +25,27 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
  *
  * @api
  */
-class StopCompilingChildrenException extends \TYPO3Fluid\Fluid\Core\Exception {
+class StopCompilingChildrenException extends \TYPO3Fluid\Fluid\Core\Exception
+{
 
-	/**
-	 * @var string
-	 */
-	protected $replacementString;
+    /**
+     * @var string
+     */
+    protected $replacementString;
 
-	/**
-	 * @return string
-	 */
-	public function getReplacementString() {
-		return $this->replacementString;
-	}
+    /**
+     * @return string
+     */
+    public function getReplacementString()
+    {
+        return $this->replacementString;
+    }
 
-	/**
-	 * @param string $replacementString
-	 */
-	public function setReplacementString($replacementString) {
-		$this->replacementString = $replacementString;
-	}
-
+    /**
+     * @param string $replacementString
+     */
+    public function setReplacementString($replacementString)
+    {
+        $this->replacementString = $replacementString;
+    }
 }

--- a/src/Core/Compiler/StopCompilingException.php
+++ b/src/Core/Compiler/StopCompilingException.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
  *
  * @api
  */
-class StopCompilingException extends \TYPO3Fluid\Fluid\Core\Exception {
+class StopCompilingException extends \TYPO3Fluid\Fluid\Core\Exception
+{
 
 }

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -17,173 +17,187 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Class TemplateCompiler
  */
-class TemplateCompiler {
+class TemplateCompiler
+{
 
-	const SHOULD_GENERATE_VIEWHELPER_INVOCATION = '##should_gen_viewhelper##';
-	const MODE_NORMAL = 'normal';
-	const MODE_WARMUP = 'warmup';
+    const SHOULD_GENERATE_VIEWHELPER_INVOCATION = '##should_gen_viewhelper##';
+    const MODE_NORMAL = 'normal';
+    const MODE_WARMUP = 'warmup';
 
-	/**
-	 * @var array
-	 */
-	protected $syntaxTreeInstanceCache = array();
+    /**
+     * @var array
+     */
+    protected $syntaxTreeInstanceCache = [];
 
-	/**
-	 * @var NodeConverter
-	 */
-	protected $nodeConverter;
+    /**
+     * @var NodeConverter
+     */
+    protected $nodeConverter;
 
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
 
-	/**
-	 * @var string
-	 */
-	protected $mode = self::MODE_NORMAL;
+    /**
+     * @var string
+     */
+    protected $mode = self::MODE_NORMAL;
 
-	/**
-	 * @var ParsedTemplateInterface
-	 */
-	protected $currentlyProcessingState;
+    /**
+     * @var ParsedTemplateInterface
+     */
+    protected $currentlyProcessingState;
 
-	/**
-	 * Constructor
-	 */
-	public function __construct() {
-		$this->nodeConverter = new NodeConverter($this);
-	}
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->nodeConverter = new NodeConverter($this);
+    }
 
-	/**
-	 * Instruct the TemplateCompiler to enter warmup mode, assigning
-	 * additional context allowing cache-related implementations to
-	 * subsequently check the mode.
-	 *
-	 * Cannot be reversed once done - should only be used from within
-	 * FluidCacheWarmerInterface implementations!
-	 */
-	public function enterWarmupMode() {
-		$this->mode = static::MODE_WARMUP;
-	}
+    /**
+     * Instruct the TemplateCompiler to enter warmup mode, assigning
+     * additional context allowing cache-related implementations to
+     * subsequently check the mode.
+     *
+     * Cannot be reversed once done - should only be used from within
+     * FluidCacheWarmerInterface implementations!
+     */
+    public function enterWarmupMode()
+    {
+        $this->mode = static::MODE_WARMUP;
+    }
 
-	/**
-	 * Returns TRUE only if the TemplateCompiler is in warmup mode.
-	 */
-	public function isWarmupMode() {
-		return $this->mode === static::MODE_WARMUP;
-	}
+    /**
+     * Returns TRUE only if the TemplateCompiler is in warmup mode.
+     */
+    public function isWarmupMode()
+    {
+        return $this->mode === static::MODE_WARMUP;
+    }
 
-	/**
-	 * @return ParsedTemplateInterface|NULL
-	 */
-	public function getCurrentlyProcessingState() {
-		return $this->currentlyProcessingState;
-	}
+    /**
+     * @return ParsedTemplateInterface|NULL
+     */
+    public function getCurrentlyProcessingState()
+    {
+        return $this->currentlyProcessingState;
+    }
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext) {
-		$this->renderingContext = $renderingContext;
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        $this->renderingContext = $renderingContext;
+    }
 
-	/**
-	 * @return RenderingContextInterface
-	 */
-	public function getRenderingContext() {
-		return $this->renderingContext;
-	}
+    /**
+     * @return RenderingContextInterface
+     */
+    public function getRenderingContext()
+    {
+        return $this->renderingContext;
+    }
 
-	/**
-	 * @param NodeConverter $nodeConverter
-	 * @return void
-	 */
-	public function setNodeConverter(NodeConverter $nodeConverter) {
-		$this->nodeConverter = $nodeConverter;
-	}
+    /**
+     * @param NodeConverter $nodeConverter
+     * @return void
+     */
+    public function setNodeConverter(NodeConverter $nodeConverter)
+    {
+        $this->nodeConverter = $nodeConverter;
+    }
 
-	/**
-	 * @return NodeConverter
-	 */
-	public function getNodeConverter() {
-		return $this->nodeConverter;
-	}
+    /**
+     * @return NodeConverter
+     */
+    public function getNodeConverter()
+    {
+        return $this->nodeConverter;
+    }
 
-	/**
-	 * @return void
-	 */
-	public function disable() {
-		throw new StopCompilingException('Compiling stopped');
-	}
+    /**
+     * @return void
+     */
+    public function disable()
+    {
+        throw new StopCompilingException('Compiling stopped');
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isDisabled() {
-		return !$this->renderingContext->isCacheEnabled();
-	}
+    /**
+     * @return boolean
+     */
+    public function isDisabled()
+    {
+        return !$this->renderingContext->isCacheEnabled();
+    }
 
-	/**
-	 * @param string $identifier
-	 * @return boolean
-	 */
-	public function has($identifier) {
-		if (isset($this->syntaxTreeInstanceCache[$identifier])) {
-			return TRUE;
-		}
-		if (!$this->renderingContext->isCacheEnabled()) {
-			return FALSE;
-		}
-		$identifier = $this->sanitizeIdentifier($identifier);
-		return !empty($identifier) && $this->renderingContext->getCache()->get($identifier);
-	}
+    /**
+     * @param string $identifier
+     * @return boolean
+     */
+    public function has($identifier)
+    {
+        if (isset($this->syntaxTreeInstanceCache[$identifier])) {
+            return true;
+        }
+        if (!$this->renderingContext->isCacheEnabled()) {
+            return false;
+        }
+        $identifier = $this->sanitizeIdentifier($identifier);
+        return !empty($identifier) && $this->renderingContext->getCache()->get($identifier);
+    }
 
-	/**
-	 * @param string $identifier
-	 * @return ParsedTemplateInterface
-	 */
-	public function get($identifier) {
-		$identifier = $this->sanitizeIdentifier($identifier);
+    /**
+     * @param string $identifier
+     * @return ParsedTemplateInterface
+     */
+    public function get($identifier)
+    {
+        $identifier = $this->sanitizeIdentifier($identifier);
 
-		if (!isset($this->syntaxTreeInstanceCache[$identifier])) {
-			$this->renderingContext->getCache()->get($identifier);
-			$this->syntaxTreeInstanceCache[$identifier] = new $identifier();
-		}
+        if (!isset($this->syntaxTreeInstanceCache[$identifier])) {
+            $this->renderingContext->getCache()->get($identifier);
+            $this->syntaxTreeInstanceCache[$identifier] = new $identifier();
+        }
 
-		return $this->syntaxTreeInstanceCache[$identifier];
-	}
+        return $this->syntaxTreeInstanceCache[$identifier];
+    }
 
-	/**
-	 * @param string $identifier
-	 * @param ParsingState $parsingState
-	 * @return void
-	 */
-	public function store($identifier, ParsingState $parsingState) {
-		if ($this->isDisabled()) {
-			if ($this->renderingContext->isCacheEnabled()) {
-				// Compiler is disabled but cache is enabled. Flush cache to make sure.
-				$this->renderingContext->getCache()->flush($identifier);
-			}
-			$parsingState->setCompilable(FALSE);
-			return;
-		}
+    /**
+     * @param string $identifier
+     * @param ParsingState $parsingState
+     * @return void
+     */
+    public function store($identifier, ParsingState $parsingState)
+    {
+        if ($this->isDisabled()) {
+            if ($this->renderingContext->isCacheEnabled()) {
+                // Compiler is disabled but cache is enabled. Flush cache to make sure.
+                $this->renderingContext->getCache()->flush($identifier);
+            }
+            $parsingState->setCompilable(false);
+            return;
+        }
 
-		$this->currentlyProcessingState = $parsingState;
-		$identifier = $this->sanitizeIdentifier($identifier);
-		$this->nodeConverter->setVariableCounter(0);
-		$generatedRenderFunctions = $this->generateSectionCodeFromParsingState($parsingState);
+        $this->currentlyProcessingState = $parsingState;
+        $identifier = $this->sanitizeIdentifier($identifier);
+        $this->nodeConverter->setVariableCounter(0);
+        $generatedRenderFunctions = $this->generateSectionCodeFromParsingState($parsingState);
 
-		$generatedRenderFunctions .= $this->generateCodeForSection(
-			$this->nodeConverter->convertListOfSubNodes($parsingState->getRootNode()),
-			'render',
-			'Main Render function'
-		);
+        $generatedRenderFunctions .= $this->generateCodeForSection(
+            $this->nodeConverter->convertListOfSubNodes($parsingState->getRootNode()),
+            'render',
+            'Main Render function'
+        );
 
-		$classDefinition = 'class ' . $identifier . ' extends \TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate';
+        $classDefinition = 'class ' . $identifier . ' extends \TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate';
 
-		$templateCode = <<<EOD
+        $templateCode = <<<EOD
 <?php
 
 %s {
@@ -203,68 +217,73 @@ public function addCompiledNamespaces(\TYPO3Fluid\Fluid\Core\Rendering\Rendering
 
 }
 EOD;
-		$storedLayoutName = $parsingState->getVariableContainer()->get('layoutName');
-		$templateCode = sprintf(
-			$templateCode,
-			$classDefinition,
-			$this->generateCodeForLayoutName($storedLayoutName),
-			($parsingState->hasLayout() ? 'TRUE' : 'FALSE'),
-			var_export($this->renderingContext->getViewHelperResolver()->getNamespaces(), TRUE),
-			$generatedRenderFunctions);
-		$this->renderingContext->getCache()->set($identifier, $templateCode);
-	}
+        $storedLayoutName = $parsingState->getVariableContainer()->get('layoutName');
+        $templateCode = sprintf(
+            $templateCode,
+            $classDefinition,
+            $this->generateCodeForLayoutName($storedLayoutName),
+            ($parsingState->hasLayout() ? 'TRUE' : 'FALSE'),
+            var_export($this->renderingContext->getViewHelperResolver()->getNamespaces(), true),
+            $generatedRenderFunctions
+        );
+        $this->renderingContext->getCache()->set($identifier, $templateCode);
+    }
 
-	/**
-	 * @param RootNode|string $storedLayoutNameArgument
-	 * @return string
-	 */
-	protected function generateCodeForLayoutName($storedLayoutNameArgument) {
-		if ($storedLayoutNameArgument instanceof RootNode) {
-			list ($initialization, $execution) = array_values($this->nodeConverter->convertListOfSubNodes($storedLayoutNameArgument));
-			return $initialization . PHP_EOL . 'return ' . $execution;
-		} else {
-			return 'return (string) \'' . $storedLayoutNameArgument . '\'';
-		}
-	}
+    /**
+     * @param RootNode|string $storedLayoutNameArgument
+     * @return string
+     */
+    protected function generateCodeForLayoutName($storedLayoutNameArgument)
+    {
+        if ($storedLayoutNameArgument instanceof RootNode) {
+            list ($initialization, $execution) = array_values($this->nodeConverter->convertListOfSubNodes($storedLayoutNameArgument));
+            return $initialization . PHP_EOL . 'return ' . $execution;
+        } else {
+            return 'return (string) \'' . $storedLayoutNameArgument . '\'';
+        }
+    }
 
-	/**
-	 * @param ParsingState $parsingState
-	 * @return string
-	 */
-	protected function generateSectionCodeFromParsingState(ParsingState $parsingState) {
-		$generatedRenderFunctions = '';
-		if ($parsingState->getVariableContainer()->exists('1457379500_sections')) {
-			$sections = $parsingState->getVariableContainer()->get('1457379500_sections'); // TODO: refactor to $parsedTemplate->getSections()
-			foreach ($sections as $sectionName => $sectionRootNode) {
-				$generatedRenderFunctions .= $this->generateCodeForSection(
-					$this->nodeConverter->convertListOfSubNodes($sectionRootNode),
-					'section_' . sha1($sectionName),
-					'section ' . $sectionName
-				);
-			}
-		}
-		return $generatedRenderFunctions;
-	}
+    /**
+     * @param ParsingState $parsingState
+     * @return string
+     */
+    protected function generateSectionCodeFromParsingState(ParsingState $parsingState)
+    {
+        $generatedRenderFunctions = '';
+        if ($parsingState->getVariableContainer()->exists('1457379500_sections')) {
+            $sections = $parsingState->getVariableContainer()->get('1457379500_sections'); // TODO: refactor to $parsedTemplate->getSections()
+            foreach ($sections as $sectionName => $sectionRootNode) {
+                $generatedRenderFunctions .= $this->generateCodeForSection(
+                    $this->nodeConverter->convertListOfSubNodes($sectionRootNode),
+                    'section_' . sha1($sectionName),
+                    'section ' . $sectionName
+                );
+            }
+        }
+        return $generatedRenderFunctions;
+    }
 
-	/**
-	 * Replaces special characters by underscores
-	 * @see http://www.php.net/manual/en/language.variables.basics.php
-	 *
-	 * @param string $identifier
-	 * @return string the sanitized identifier
-	 */
-	protected function sanitizeIdentifier($identifier) {
-		return preg_replace('([^a-zA-Z0-9_\x7f-\xff])', '_', $identifier);
-	}
+    /**
+     * Replaces special characters by underscores
+     * @see http://www.php.net/manual/en/language.variables.basics.php
+     *
+     * @param string $identifier
+     * @return string the sanitized identifier
+     */
+    protected function sanitizeIdentifier($identifier)
+    {
+        return preg_replace('([^a-zA-Z0-9_\x7f-\xff])', '_', $identifier);
+    }
 
-	/**
-	 * @param array $converted
-	 * @param string $expectedFunctionName
-	 * @param string $comment
-	 * @return string
-	 */
-	protected function generateCodeForSection(array $converted, $expectedFunctionName, $comment) {
-		$templateCode = <<<EOD
+    /**
+     * @param array $converted
+     * @param string $expectedFunctionName
+     * @param string $comment
+     * @return string
+     */
+    protected function generateCodeForSection(array $converted, $expectedFunctionName, $comment)
+    {
+        $templateCode = <<<EOD
 /**
  * %s
  */
@@ -275,58 +294,60 @@ return %s;
 }
 
 EOD;
-		return sprintf($templateCode, $comment, $expectedFunctionName, $converted['initialization'], $converted['execution']);
-	}
+        return sprintf($templateCode, $comment, $expectedFunctionName, $converted['initialization'], $converted['execution']);
+    }
 
-	/**
-	 * Returns a unique variable name by appending a global index to the given prefix
-	 *
-	 * @param string $prefix
-	 * @return string
-	 */
-	public function variableName($prefix) {
-		return $this->nodeConverter->variableName($prefix);
-	}
+    /**
+     * Returns a unique variable name by appending a global index to the given prefix
+     *
+     * @param string $prefix
+     * @return string
+     */
+    public function variableName($prefix)
+    {
+        return $this->nodeConverter->variableName($prefix);
+    }
 
-	/**
-	 * @param NodeInterface $node
-	 * @return string
-	 */
-	public function wrapChildNodesInClosure(NodeInterface $node) {
-		$closure = '';
-		$closure .= 'function() use ($renderingContext, $self) {' . chr(10);
-		$convertedSubNodes = $this->nodeConverter->convertListOfSubNodes($node);
-		$closure .= $convertedSubNodes['initialization'];
-		$closure .= sprintf('return %s;', $convertedSubNodes['execution']) . chr(10);
-		$closure .= '}';
-		return $closure;
-	}
+    /**
+     * @param NodeInterface $node
+     * @return string
+     */
+    public function wrapChildNodesInClosure(NodeInterface $node)
+    {
+        $closure = '';
+        $closure .= 'function() use ($renderingContext, $self) {' . chr(10);
+        $convertedSubNodes = $this->nodeConverter->convertListOfSubNodes($node);
+        $closure .= $convertedSubNodes['initialization'];
+        $closure .= sprintf('return %s;', $convertedSubNodes['execution']) . chr(10);
+        $closure .= '}';
+        return $closure;
+    }
 
-	/**
-	 * Wraps one ViewHelper argument evaluation in a closure that can be
-	 * rendered by passing a rendering context.
-	 *
-	 * @param ViewHelperNode $node
-	 * @param string $argumentName
-	 * @return string
-	 */
-	public function wrapViewHelperNodeArgumentEvaluationInClosure(ViewHelperNode $node, $argumentName) {
-		$arguments = $node->getArguments();
-		$argument = $arguments[$argumentName];
-		$closure = 'function() use ($renderingContext, $self) {' . chr(10);
-		if ($node->getArgumentDefinition($argumentName)->getType() === 'boolean') {
-			// We treat boolean nodes by compiling a closure to evaluate the stack of the boolean argument
-			$compiledIfArgumentStack = $this->nodeConverter->convert(new ArrayNode($argument->getStack()));
-			$closure .= $compiledIfArgumentStack['initialization'] . chr(10);
-			$closure .= sprintf(
-				'return \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::evaluateStack($renderingContext, %s);',
-				$compiledIfArgumentStack['execution']
-			) . chr(10);
-		} else {
-			$closure .= sprintf('$argument = unserialize(\'%s\'); return $argument->evaluate($renderingContext);', serialize($argument)) . chr(10);
-		}
-		$closure .= '}';
-		return $closure;
-	}
-
+    /**
+     * Wraps one ViewHelper argument evaluation in a closure that can be
+     * rendered by passing a rendering context.
+     *
+     * @param ViewHelperNode $node
+     * @param string $argumentName
+     * @return string
+     */
+    public function wrapViewHelperNodeArgumentEvaluationInClosure(ViewHelperNode $node, $argumentName)
+    {
+        $arguments = $node->getArguments();
+        $argument = $arguments[$argumentName];
+        $closure = 'function() use ($renderingContext, $self) {' . chr(10);
+        if ($node->getArgumentDefinition($argumentName)->getType() === 'boolean') {
+            // We treat boolean nodes by compiling a closure to evaluate the stack of the boolean argument
+            $compiledIfArgumentStack = $this->nodeConverter->convert(new ArrayNode($argument->getStack()));
+            $closure .= $compiledIfArgumentStack['initialization'] . chr(10);
+            $closure .= sprintf(
+                'return \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::evaluateStack($renderingContext, %s);',
+                $compiledIfArgumentStack['execution']
+            ) . chr(10);
+        } else {
+            $closure .= sprintf('$argument = unserialize(\'%s\'); return $argument->evaluate($renderingContext);', serialize($argument)) . chr(10);
+        }
+        $closure .= '}';
+        return $closure;
+    }
 }

--- a/src/Core/Compiler/ViewHelperCompiler.php
+++ b/src/Core/Compiler/ViewHelperCompiler.php
@@ -38,107 +38,108 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
  * string variable anyway since special implementations or future
  * changes in Fluid may cause initialisation code to be generated.
  */
-class ViewHelperCompiler {
+class ViewHelperCompiler
+{
 
-	const RENDER_STATIC = 'renderStatic';
-	const DEFAULT_INIT = '';
+    const RENDER_STATIC = 'renderStatic';
+    const DEFAULT_INIT = '';
 
-	/**
-	 * Factory method to create an instance; since this class is
-	 * exclusively used as a "fire once" command where it is ideal
-	 * to chain the instance creation and method to be called into
-	 * a single line.
-	 *
-	 * @return static
-	 */
-	public static function getInstance() {
-		return new static();
-	}
+    /**
+     * Factory method to create an instance; since this class is
+     * exclusively used as a "fire once" command where it is ideal
+     * to chain the instance creation and method to be called into
+     * a single line.
+     *
+     * @return static
+     */
+    public static function getInstance()
+    {
+        return new static();
+    }
 
-	/**
-	 * The simples of compilation methods designed to work well
-	 * for ViewHelpers that implement `renderStatic` or a similar
-	 * statically callable public method that makes sense to call
-	 * each time the ViewHelper needs to render.
-	 *
-	 * It is also possible to compile so the resulting call is
-	 * made to a non-ViewHelper class which may be even more efficient
-	 * when the ViewHelper is a wrapper for a framework method.
-	 *
-	 * See class doc comment about consuming the returned values!
-	 *
-	 * @param ViewHelperInterface $viewHelper ViewHelper instance to be compiled
-	 * @param string $argumentsName Name of arguments variable passed to `compile()` method
-	 * @param string $renderChildrenClosureName Name of renderChildren closure passed to `compile()` method
-	 * @param string $method The name of the class' method to be called
-	 * @param string|NULL Class name which contains the method; NULL means use ViewHelper's class name.
-	 * @return array
-	 */
-	public function compileWithCallToStaticMethod(
-		ViewHelperInterface $viewHelper,
-		$argumentsName,
-		$renderChildrenClosureName,
-		$method = self::RENDER_STATIC,
-		$onClass = NULL
-	) {
-		$onClass = $onClass ? : get_class($viewHelper);
-		return array(
-			self::DEFAULT_INIT,
-			sprintf(
-				'%s::%s(%s, %s, $renderingContext)',
-				$onClass,
-				$method,
-				$argumentsName,
-				$renderChildrenClosureName
-			)
-		);
-	}
+    /**
+     * The simples of compilation methods designed to work well
+     * for ViewHelpers that implement `renderStatic` or a similar
+     * statically callable public method that makes sense to call
+     * each time the ViewHelper needs to render.
+     *
+     * It is also possible to compile so the resulting call is
+     * made to a non-ViewHelper class which may be even more efficient
+     * when the ViewHelper is a wrapper for a framework method.
+     *
+     * See class doc comment about consuming the returned values!
+     *
+     * @param ViewHelperInterface $viewHelper ViewHelper instance to be compiled
+     * @param string $argumentsName Name of arguments variable passed to `compile()` method
+     * @param string $renderChildrenClosureName Name of renderChildren closure passed to `compile()` method
+     * @param string $method The name of the class' method to be called
+     * @param string|NULL Class name which contains the method; NULL means use ViewHelper's class name.
+     * @return array
+     */
+    public function compileWithCallToStaticMethod(
+        ViewHelperInterface $viewHelper,
+        $argumentsName,
+        $renderChildrenClosureName,
+        $method = self::RENDER_STATIC,
+        $onClass = null
+    ) {
+        $onClass = $onClass ? : get_class($viewHelper);
+        return [
+            self::DEFAULT_INIT,
+            sprintf(
+                '%s::%s(%s, %s, $renderingContext)',
+                $onClass,
+                $method,
+                $argumentsName,
+                $renderChildrenClosureName
+            )
+        ];
+    }
 
-	/**
-	 * Very similar to the compileWithCallToStaticMethod approach
-	 * but with the added capability that the render child content
-	 * closure can be built by this function to check if an argument
-	 * is filled and use that value if it is, otherwise use the
-	 * default child rendering closure.
-	 *
-	 * When this prodecure is used to compile the ViewHelper, the
-	 * ViewHelper class itself can call the render children closure
-	 * from a static rendering method and always trust that the value
-	 * that is returned, is either the specified argument's value if
-	 * that argument is not empty, or the variable/content passed as
-	 * child content to the ViewHelper.
-	 *
-	 * @param ViewHelperInterface $viewHelper ViewHelper instance to be compiled
-	 * @param string $argumentsName Name of arguments variable passed to `compile()` method
-	 * @param string $renderChildrenClosureName Name of renderChildren closure passed to `compile()` method
-	 * @param string $contentArgumentName Name of the argument which
-	 * @param string $method The name of the class' method to be called
-	 * @param string|NULL Class name which contains the method; NULL means use ViewHelper's class name.
-	 * @return array
-	 */
-	public function compileWithCallToStaticMethodAndContentFromArgumentName(
-		ViewHelperInterface $viewHelper,
-		$argumentsName,
-		$renderChildrenClosureName,
-		$contentArgumentName,
-		$method,
-		$onClass
-	) {
-		return array(
-			self::DEFAULT_INIT,
-			sprintf(
-				'%s::%s(%s, isset(%s[\'%s\']) ? function() use (%s) { return %s[\'%s\']; } : %s, $renderingContext)',
-				$onClass,
-				$method,
-				$argumentsName,
-				$argumentsName,
-				$contentArgumentName,
-				$argumentsName,
-				$argumentsName,
-				$contentArgumentName,
-				$renderChildrenClosureName
-			)
-		);
-	}
-
+    /**
+     * Very similar to the compileWithCallToStaticMethod approach
+     * but with the added capability that the render child content
+     * closure can be built by this function to check if an argument
+     * is filled and use that value if it is, otherwise use the
+     * default child rendering closure.
+     *
+     * When this prodecure is used to compile the ViewHelper, the
+     * ViewHelper class itself can call the render children closure
+     * from a static rendering method and always trust that the value
+     * that is returned, is either the specified argument's value if
+     * that argument is not empty, or the variable/content passed as
+     * child content to the ViewHelper.
+     *
+     * @param ViewHelperInterface $viewHelper ViewHelper instance to be compiled
+     * @param string $argumentsName Name of arguments variable passed to `compile()` method
+     * @param string $renderChildrenClosureName Name of renderChildren closure passed to `compile()` method
+     * @param string $contentArgumentName Name of the argument which
+     * @param string $method The name of the class' method to be called
+     * @param string|NULL Class name which contains the method; NULL means use ViewHelper's class name.
+     * @return array
+     */
+    public function compileWithCallToStaticMethodAndContentFromArgumentName(
+        ViewHelperInterface $viewHelper,
+        $argumentsName,
+        $renderChildrenClosureName,
+        $contentArgumentName,
+        $method,
+        $onClass
+    ) {
+        return [
+            self::DEFAULT_INIT,
+            sprintf(
+                '%s::%s(%s, isset(%s[\'%s\']) ? function() use (%s) { return %s[\'%s\']; } : %s, $renderingContext)',
+                $onClass,
+                $method,
+                $argumentsName,
+                $argumentsName,
+                $contentArgumentName,
+                $argumentsName,
+                $argumentsName,
+                $contentArgumentName,
+                $renderChildrenClosureName
+            )
+        ];
+    }
 }

--- a/src/Core/Exception.php
+++ b/src/Core/Exception.php
@@ -11,5 +11,6 @@ namespace TYPO3Fluid\Fluid\Core;
  *
  * @api
  */
-class Exception extends \TYPO3Fluid\Fluid\Exception {
+class Exception extends \TYPO3Fluid\Fluid\Exception
+{
 }

--- a/src/Core/Parser/BooleanParser.php
+++ b/src/Core/Parser/BooleanParser.php
@@ -18,32 +18,33 @@ use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
  *
  * Parsingtree:
  *
- *	evaluate/compile: start the whole cycle
- *		parseOrToken: takes care of "||" parts
- *			evaluateOr: evaluate the "||" part if found
- *			parseAndToken: take care of "&&" parts
- *				evaluateAnd: evaluate "&&" part if found
- *				parseCompareToken: takes care any comparisons "==,!=,>,<,..."
- *					evaluateCompare: evaluate the comparison if found
- *					parseNotToken: takes care of any "!" negations
- *						evaluateNot: evaluate the negation if found
- *						parseBracketToken: takes care of any '()' parts and restarts the cycle
- *							parseStringToken: takes care of any strings
- *								evaluateTerm: evaluate terms from true/false/numeric/context
+ *  evaluate/compile: start the whole cycle
+ *      parseOrToken: takes care of "||" parts
+ *          evaluateOr: evaluate the "||" part if found
+ *          parseAndToken: take care of "&&" parts
+ *              evaluateAnd: evaluate "&&" part if found
+ *              parseCompareToken: takes care any comparisons "==,!=,>,<,..."
+ *                  evaluateCompare: evaluate the comparison if found
+ *                  parseNotToken: takes care of any "!" negations
+ *                      evaluateNot: evaluate the negation if found
+ *                      parseBracketToken: takes care of any '()' parts and restarts the cycle
+ *                          parseStringToken: takes care of any strings
+ *                              evaluateTerm: evaluate terms from true/false/numeric/context
  *
  */
-class BooleanParser {
+class BooleanParser
+{
 
-	/**
-	 * List of comparators to check in the parseCompareToken if the current
-	 * part of the expression is a comparator and needs to be compared
-	 */
-	CONST COMPARATORS = '==,===,!==,!=,<=,>=,<,>,%';
+    /**
+     * List of comparators to check in the parseCompareToken if the current
+     * part of the expression is a comparator and needs to be compared
+     */
+    const COMPARATORS = '==,===,!==,!=,<=,>=,<,>,%';
 
-	/**
-	 * Regex to parse a expression into tokens
-	 */
-	CONST TOKENREGEX = '/
+    /**
+     * Regex to parse a expression into tokens
+     */
+    const TOKENREGEX = '/
 			\s*(
 				\\\\\'
 			|
@@ -79,393 +80,410 @@ class BooleanParser {
 			)\s*
 	/xs';
 
-	/**
-	 * Cursor that contains a integer value pointing to the location inside the
-	 * expression string that is used by the peek function to look for the part of
-	 * the expression that needs to be focused on next. This cursor is changed
-	 * by the consume method, by "consuming" part of the expression.
-	 *
-	 * @var integer
-	 */
-	protected $cursor = 0;
+    /**
+     * Cursor that contains a integer value pointing to the location inside the
+     * expression string that is used by the peek function to look for the part of
+     * the expression that needs to be focused on next. This cursor is changed
+     * by the consume method, by "consuming" part of the expression.
+     *
+     * @var integer
+     */
+    protected $cursor = 0;
 
-	/**
-	 * Expression that is parsed through peek and consume methods
-	 *
-	 * @var string
-	 */
-	protected $expression;
+    /**
+     * Expression that is parsed through peek and consume methods
+     *
+     * @var string
+     */
+    protected $expression;
 
-	/**
-	 * Context containing all variables that are references in the expression
-	 *
-	 * @var array
-	 */
-	protected $context;
+    /**
+     * Context containing all variables that are references in the expression
+     *
+     * @var array
+     */
+    protected $context;
 
-	/**
-	 * Switch to enable compiling
-	 *
-	 * @var boolean
-	 */
-	protected $compileToCode = FALSE;
+    /**
+     * Switch to enable compiling
+     *
+     * @var boolean
+     */
+    protected $compileToCode = false;
 
-	/**
-	 * Evaluate a expression to a boolean
-	 *
-	 * @param string $expression to be parsed
-	 * @param array $context containing variables that can be used in the expression
-	 * @return boolean
-	 */
-	public function evaluate($expression, $context) {
-		$this->context = $context;
-		$this->expression = $expression;
-		$this->cursor = 0;
-		return $this->parseOrToken();
-	}
+    /**
+     * Evaluate a expression to a boolean
+     *
+     * @param string $expression to be parsed
+     * @param array $context containing variables that can be used in the expression
+     * @return boolean
+     */
+    public function evaluate($expression, $context)
+    {
+        $this->context = $context;
+        $this->expression = $expression;
+        $this->cursor = 0;
+        return $this->parseOrToken();
+    }
 
-	/**
-	 * Parse and compile an expression into an php equivalent
-	 *
-	 * @param string $expression to be parsed
-	 * @return string
-	 */
-	public function compile($expression) {
-		$this->expression = $expression;
-		$this->cursor = 0;
-		$this->compileToCode = TRUE;
-		return $this->parseOrToken();
-	}
+    /**
+     * Parse and compile an expression into an php equivalent
+     *
+     * @param string $expression to be parsed
+     * @return string
+     */
+    public function compile($expression)
+    {
+        $this->expression = $expression;
+        $this->cursor = 0;
+        $this->compileToCode = true;
+        return $this->parseOrToken();
+    }
 
-	/**
-	 * The part of the expression we're currently focusing on based on the
-	 * tokenizing regex offset by the internally tracked cursor.
-	 *
-	 * @param boolean $includeWhitespace return surrounding whitespace with token
-	 * @return string
-	 */
-	protected function peek($includeWhitespace = FALSE) {
-		preg_match(static::TOKENREGEX, substr($this->expression, $this->cursor), $matches);
-		if ($includeWhitespace === TRUE) {
-			return $matches[0];
-		}
-		return $matches[1];
-	}
+    /**
+     * The part of the expression we're currently focusing on based on the
+     * tokenizing regex offset by the internally tracked cursor.
+     *
+     * @param boolean $includeWhitespace return surrounding whitespace with token
+     * @return string
+     */
+    protected function peek($includeWhitespace = false)
+    {
+        preg_match(static::TOKENREGEX, substr($this->expression, $this->cursor), $matches);
+        if ($includeWhitespace === true) {
+            return $matches[0];
+        }
+        return $matches[1];
+    }
 
-	/**
-	 * Consume part of the current expression by setting the internal cursor
-	 * to the position of the string in the expression and it's length
-	 *
-	 * @param string $string
-	 * @return void
-	 */
-	protected function consume($string) {
-		if (strlen($string) === 0) {
-			return;
-		}
-		$this->cursor = strpos($this->expression, $string, $this->cursor) + strlen($string);
-	}
+    /**
+     * Consume part of the current expression by setting the internal cursor
+     * to the position of the string in the expression and it's length
+     *
+     * @param string $string
+     * @return void
+     */
+    protected function consume($string)
+    {
+        if (strlen($string) === 0) {
+            return;
+        }
+        $this->cursor = strpos($this->expression, $string, $this->cursor) + strlen($string);
+    }
 
-	/**
-	 * Passes the torch down to the next deeper parsing leve (and)
-	 * and checks then if there's a "or" expression that needs to be handled
-	 *
-	 * @return mixed
-	 */
-	protected function parseOrToken() {
-		$x = $this->parseAndToken();
-		while ($this->peek() === '||') {
-			$this->consume('||');
-			$y = $this->parseAndToken();
+    /**
+     * Passes the torch down to the next deeper parsing leve (and)
+     * and checks then if there's a "or" expression that needs to be handled
+     *
+     * @return mixed
+     */
+    protected function parseOrToken()
+    {
+        $x = $this->parseAndToken();
+        while ($this->peek() === '||') {
+            $this->consume('||');
+            $y = $this->parseAndToken();
 
-			if ($this->compileToCode === TRUE) {
-				$x = '(' . $x . ' || ' . $y . ')';
-				continue;
-			}
-			$x = $this->evaluateOr($x, $y);
-		}
-		return $x;
-	}
+            if ($this->compileToCode === true) {
+                $x = '(' . $x . ' || ' . $y . ')';
+                continue;
+            }
+            $x = $this->evaluateOr($x, $y);
+        }
+        return $x;
+    }
 
-	/**
-	 * Passes the torch down to the next deeper parsing leve (compare)
-	 * and checks then if there's a "and" expression that needs to be handled
-	 *
-	 * @return mixed
-	 */
-	protected function parseAndToken() {
-		$x = $this->parseCompareToken();
-		while ($this->peek() === '&&') {
-			$this->consume('&&');
-			$y = $this->parseCompareToken();
+    /**
+     * Passes the torch down to the next deeper parsing leve (compare)
+     * and checks then if there's a "and" expression that needs to be handled
+     *
+     * @return mixed
+     */
+    protected function parseAndToken()
+    {
+        $x = $this->parseCompareToken();
+        while ($this->peek() === '&&') {
+            $this->consume('&&');
+            $y = $this->parseCompareToken();
 
-			if ($this->compileToCode === TRUE) {
-				$x = '(' . $x . ' && ' . $y . ')';
-				continue;
-			}
-			$x = $this->evaluateAnd($x, $y);
-		}
-		return $x;
-	}
+            if ($this->compileToCode === true) {
+                $x = '(' . $x . ' && ' . $y . ')';
+                continue;
+            }
+            $x = $this->evaluateAnd($x, $y);
+        }
+        return $x;
+    }
 
-	/**
-	 * Passes the torch down to the next deeper parsing leven (not)
-	 * and checks then if there's a "compare" expression that needs to be handled
-	 *
-	 * @return mixed
-	 */
-	protected function parseCompareToken() {
-		$x = $this->parseNotToken();
-		while (in_array($comparator = $this->peek(), explode(',', static::COMPARATORS))) {
-			$this->consume($comparator);
-			$y = $this->parseNotToken();
-			$x = $this->evaluateCompare($x, $y, $comparator);
-		}
-		return $x;
-	}
+    /**
+     * Passes the torch down to the next deeper parsing leven (not)
+     * and checks then if there's a "compare" expression that needs to be handled
+     *
+     * @return mixed
+     */
+    protected function parseCompareToken()
+    {
+        $x = $this->parseNotToken();
+        while (in_array($comparator = $this->peek(), explode(',', static::COMPARATORS))) {
+            $this->consume($comparator);
+            $y = $this->parseNotToken();
+            $x = $this->evaluateCompare($x, $y, $comparator);
+        }
+        return $x;
+    }
 
-	/**
-	 * Check if we have encountered an not expression or pass the torch down
-	 * to the simpleToken method.
-	 *
-	 * @return mixed
-	 */
-	protected function parseNotToken() {
-		if ($this->peek() === '!') {
-			$this->consume('!');
-			$x = $this->parseNotToken();
+    /**
+     * Check if we have encountered an not expression or pass the torch down
+     * to the simpleToken method.
+     *
+     * @return mixed
+     */
+    protected function parseNotToken()
+    {
+        if ($this->peek() === '!') {
+            $this->consume('!');
+            $x = $this->parseNotToken();
 
-			if ($this->compileToCode === TRUE) {
-				return '!(' . $x . ')';
-			}
-			return $this->evaluateNot($x);
-		}
+            if ($this->compileToCode === true) {
+                return '!(' . $x . ')';
+            }
+            return $this->evaluateNot($x);
+        }
 
-		return $this->parseBracketToken();
-	}
+        return $this->parseBracketToken();
+    }
 
-	/**
-	 * Takes care of restarting the whole parsing loop if it encounters a "(" or ")"
-	 * token or pass the torch down to the parseStringToken method
-	 *
-	 * @return mixed
-	 */
-	protected function parseBracketToken() {
-		$t = $this->peek();
-		if ($t === '(') {
-			$this->consume('(');
-			$result = $this->parseOrToken();
-			$this->consume(')');
-			return $result;
-		}
+    /**
+     * Takes care of restarting the whole parsing loop if it encounters a "(" or ")"
+     * token or pass the torch down to the parseStringToken method
+     *
+     * @return mixed
+     */
+    protected function parseBracketToken()
+    {
+        $t = $this->peek();
+        if ($t === '(') {
+            $this->consume('(');
+            $result = $this->parseOrToken();
+            $this->consume(')');
+            return $result;
+        }
 
-		return $this->parseStringToken();
-	}
+        return $this->parseStringToken();
+    }
 
-	/**
-	 * Takes care of consuming pure string including whitespace or passes the torch
-	 * down to the parseTermToken method
-	 *
-	 * @return mixed
-	 */
-	protected function parseStringToken() {
-		$t = $this->peek();
-		if ($t === '\'' || $t === '"') {
-			$stringIdentifier = $t;
-			$string = $stringIdentifier;
-			$this->consume($stringIdentifier);
-			while (trim($t = $this->peek(TRUE)) !== $stringIdentifier) {
-				$this->consume($t);
-				$string .= $t;
-			}
-			$this->consume($stringIdentifier);
-			$string .= $stringIdentifier;
-			if ($this->compileToCode === TRUE) {
-				return $string;
-			}
-			return $this->evaluateTerm($string, $this->context);
-		}
+    /**
+     * Takes care of consuming pure string including whitespace or passes the torch
+     * down to the parseTermToken method
+     *
+     * @return mixed
+     */
+    protected function parseStringToken()
+    {
+        $t = $this->peek();
+        if ($t === '\'' || $t === '"') {
+            $stringIdentifier = $t;
+            $string = $stringIdentifier;
+            $this->consume($stringIdentifier);
+            while (trim($t = $this->peek(true)) !== $stringIdentifier) {
+                $this->consume($t);
+                $string .= $t;
+            }
+            $this->consume($stringIdentifier);
+            $string .= $stringIdentifier;
+            if ($this->compileToCode === true) {
+                return $string;
+            }
+            return $this->evaluateTerm($string, $this->context);
+        }
 
-		return $this->parseTermToken();
-	}
+        return $this->parseTermToken();
+    }
 
-	/**
-	 * Takes care of restarting the whole parsing loop if it encounters a "(" or ")"
-	 * token, consumes a pure string including whitespace or passes the torch
-	 * down to the evaluateTerm method
-	 *
-	 * @return mixed
-	 */
-	protected function parseTermToken() {
-		$t = $this->peek();
-		if ($this->isTerm($t)) {
-			$this->consume($t);
-			return $this->evaluateTerm($t, $this->context);
-		}
-		throw ParserException(sprintf('%t is not a valid expression term', $t));
-	}
+    /**
+     * Takes care of restarting the whole parsing loop if it encounters a "(" or ")"
+     * token, consumes a pure string including whitespace or passes the torch
+     * down to the evaluateTerm method
+     *
+     * @return mixed
+     */
+    protected function parseTermToken()
+    {
+        $t = $this->peek();
+        if ($this->isTerm($t)) {
+            $this->consume($t);
+            return $this->evaluateTerm($t, $this->context);
+        }
+        throw ParserException(sprintf('%t is not a valid expression term', $t));
+    }
 
-	/**
-	 * Checks if the given string is a term or keyword
-	 *
-	 * @param string $x
-	 */
-	protected function isTerm($x) {
-		if (in_array($x, array('&&', '||', '!', '==', '\''))) {
-			return FALSE;
-		}
+    /**
+     * Checks if the given string is a term or keyword
+     *
+     * @param string $x
+     */
+    protected function isTerm($x)
+    {
+        if (in_array($x, ['&&', '||', '!', '==', '\''])) {
+            return false;
+        }
 
-		return is_string($x);
-	}
+        return is_string($x);
+    }
 
-	/**
-	 * Evaluate an "and" comparison
-	 *
-	 * @param mixed $x
-	 * @param mixed $y
-	 * @return boolean
-	 */
-	protected function evaluateAnd($x, $y) {
-		return $x && $y;
-	}
+    /**
+     * Evaluate an "and" comparison
+     *
+     * @param mixed $x
+     * @param mixed $y
+     * @return boolean
+     */
+    protected function evaluateAnd($x, $y)
+    {
+        return $x && $y;
+    }
 
-	/**
-	 * Evaluate an "or" comparison
-	 *
-	 * @param mixed $x
-	 * @param mixed $y
-	 * @return boolean
-	 */
-	protected function evaluateOr($x, $y) {
-		return $x || $y;
-	}
+    /**
+     * Evaluate an "or" comparison
+     *
+     * @param mixed $x
+     * @param mixed $y
+     * @return boolean
+     */
+    protected function evaluateOr($x, $y)
+    {
+        return $x || $y;
+    }
 
-	/**
-	 * Evaluate an "not" comparison
-	 *
-	 * @param mixed $x
-	 * @return boolean|string
-	 */
-	protected function evaluateNot($x) {
-		if ($this->compileToCode === TRUE) {
-			return '!(' . $x . ')';
-		}
-		return !$x;
-	}
+    /**
+     * Evaluate an "not" comparison
+     *
+     * @param mixed $x
+     * @return boolean|string
+     */
+    protected function evaluateNot($x)
+    {
+        if ($this->compileToCode === true) {
+            return '!(' . $x . ')';
+        }
+        return !$x;
+    }
 
-	/**
-	 * Compare two variables based on a specified comparator
-	 *
-	 * @param mixed $x
-	 * @param mixed $y
-	 * @param string $comparator
-	 * @return boolean|string
-	 */
-	protected function evaluateCompare($x, $y, $comparator) {
-		// enfore strong comparison for comparing two objects
-		if ($comparator == '==' && is_object($x) && is_object($y)) {
-			$comparator = '===';
-		}
-		if ($comparator == '!=' && is_object($x) && is_object($y)) {
-			$comparator = '!==';
-		}
+    /**
+     * Compare two variables based on a specified comparator
+     *
+     * @param mixed $x
+     * @param mixed $y
+     * @param string $comparator
+     * @return boolean|string
+     */
+    protected function evaluateCompare($x, $y, $comparator)
+    {
+        // enfore strong comparison for comparing two objects
+        if ($comparator == '==' && is_object($x) && is_object($y)) {
+            $comparator = '===';
+        }
+        if ($comparator == '!=' && is_object($x) && is_object($y)) {
+            $comparator = '!==';
+        }
 
-		if ($this->compileToCode === TRUE) {
-			return sprintf('(%s %s %s)', $x, $comparator, $y);
-		}
+        if ($this->compileToCode === true) {
+            return sprintf('(%s %s %s)', $x, $comparator, $y);
+        }
 
-		switch ($comparator) {
-			case '==':
-				$x = ($x == $y);
-				break;
+        switch ($comparator) {
+            case '==':
+                $x = ($x == $y);
+                break;
 
-			case '===':
-				$x = ($x === $y);
-				break;
+            case '===':
+                $x = ($x === $y);
+                break;
 
-			case '!=':
-				$x = ($x != $y);
-				break;
+            case '!=':
+                $x = ($x != $y);
+                break;
 
-			case '!==':
-				$x = ($x !== $y);
-				break;
+            case '!==':
+                $x = ($x !== $y);
+                break;
 
-			case '<=':
-				$x = ($x <= $y);
-				break;
+            case '<=':
+                $x = ($x <= $y);
+                break;
 
-			case '>=':
-				$x = ($x >= $y);
-				break;
+            case '>=':
+                $x = ($x >= $y);
+                break;
 
-			case '<':
-				$x = ($x < $y);
-				break;
+            case '<':
+                $x = ($x < $y);
+                break;
 
-			case '>':
-				$x = ($x > $y);
-				break;
+            case '>':
+                $x = ($x > $y);
+                break;
 
-			case '%':
-				$x = ($x % $y);
-				break;
-		}
-		return $x;
-	}
+            case '%':
+                $x = ($x % $y);
+                break;
+        }
+        return $x;
+    }
 
-	/**
-	 * Takes care of fetching terms from the context, converting to float/int,
-	 * converting true/false keywords into boolean or trim the final string of
-	 * quotation marks
-	 *
-	 * @param string $x
-	 * @param array $context
-	 * @return mixed
-	 */
-	protected function evaluateTerm($x, $context) {
-		if (strpos($x, '{') === 0 && substr($x, -1) === '}') {
-			if ($this->compileToCode === TRUE) {
-				return '($context["' . trim($x, '{}') . '"])';
-			}
-			return $context[trim($x, '{}')];
-		}
+    /**
+     * Takes care of fetching terms from the context, converting to float/int,
+     * converting true/false keywords into boolean or trim the final string of
+     * quotation marks
+     *
+     * @param string $x
+     * @param array $context
+     * @return mixed
+     */
+    protected function evaluateTerm($x, $context)
+    {
+        if (strpos($x, '{') === 0 && substr($x, -1) === '}') {
+            if ($this->compileToCode === true) {
+                return '($context["' . trim($x, '{}') . '"])';
+            }
+            return $context[trim($x, '{}')];
+        }
 
-		if (is_numeric($x)) {
-			if ($this->compileToCode === TRUE) {
-				return $x;
-			}
-			if (strpos($x, '.') !== FALSE) {
-				return floatval($x);
-			} else {
-				return intval($x);
-			}
-		}
+        if (is_numeric($x)) {
+            if ($this->compileToCode === true) {
+                return $x;
+            }
+            if (strpos($x, '.') !== false) {
+                return floatval($x);
+            } else {
+                return intval($x);
+            }
+        }
 
-		if (trim(strtolower($x)) === 'true') {
-			if ($this->compileToCode === TRUE) {
-				return 'TRUE';
-			}
-			return TRUE;
-		}
-		if (trim(strtolower($x)) === 'false') {
-			if ($this->compileToCode === TRUE) {
-				return 'FALSE';
-			}
-			return FALSE;
-		}
+        if (trim(strtolower($x)) === 'true') {
+            if ($this->compileToCode === true) {
+                return 'TRUE';
+            }
+            return true;
+        }
+        if (trim(strtolower($x)) === 'false') {
+            if ($this->compileToCode === true) {
+                return 'FALSE';
+            }
+            return false;
+        }
 
-		if (isset($context[$x]) === TRUE) {
-			if ($this->compileToCode === TRUE) {
-				return '($context["' . $x . '"])';
-			}
-			return $context[$x];
-		}
+        if (isset($context[$x]) === true) {
+            if ($this->compileToCode === true) {
+                return '($context["' . $x . '"])';
+            }
+            return $context[$x];
+        }
 
-		if ($this->compileToCode === TRUE) {
-			return '"' . trim($x, '\'"') . '"';
-		}
+        if ($this->compileToCode === true) {
+            return '"' . trim($x, '\'"') . '"';
+        }
 
-		return trim($x, '\'"');
-	}
+        return trim($x, '\'"');
+    }
 }

--- a/src/Core/Parser/Configuration.php
+++ b/src/Core/Parser/Configuration.php
@@ -10,79 +10,84 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  * The parser configuration. Contains all configuration needed to configure
  * the building of a SyntaxTree.
  */
-class Configuration {
+class Configuration
+{
 
-	/**
-	 * Generic interceptors registered with the configuration.
-	 *
-	 * @var \SplObjectStorage[]
-	 */
-	protected $interceptors = array();
+    /**
+     * Generic interceptors registered with the configuration.
+     *
+     * @var \SplObjectStorage[]
+     */
+    protected $interceptors = [];
 
-	/**
-	 * Escaping interceptors registered with the configuration.
-	 *
-	 * @var \SplObjectStorage[]
-	 */
-	protected $escapingInterceptors = array();
+    /**
+     * Escaping interceptors registered with the configuration.
+     *
+     * @var \SplObjectStorage[]
+     */
+    protected $escapingInterceptors = [];
 
-	/**
-	 * Adds an interceptor to apply to values coming from object accessors.
-	 *
-	 * @param InterceptorInterface $interceptor
-	 * @return void
-	 */
-	public function addInterceptor(InterceptorInterface $interceptor) {
-		$this->addInterceptorToArray($interceptor, $this->interceptors);
-	}
+    /**
+     * Adds an interceptor to apply to values coming from object accessors.
+     *
+     * @param InterceptorInterface $interceptor
+     * @return void
+     */
+    public function addInterceptor(InterceptorInterface $interceptor)
+    {
+        $this->addInterceptorToArray($interceptor, $this->interceptors);
+    }
 
-	/**
-	 * Adds an escaping interceptor to apply to values coming from object accessors if escaping is enabled
-	 *
-	 * @param InterceptorInterface $interceptor
-	 * @return void
-	 */
-	public function addEscapingInterceptor(InterceptorInterface $interceptor) {
-		$this->addInterceptorToArray($interceptor, $this->escapingInterceptors);
-	}
+    /**
+     * Adds an escaping interceptor to apply to values coming from object accessors if escaping is enabled
+     *
+     * @param InterceptorInterface $interceptor
+     * @return void
+     */
+    public function addEscapingInterceptor(InterceptorInterface $interceptor)
+    {
+        $this->addInterceptorToArray($interceptor, $this->escapingInterceptors);
+    }
 
-	/**
-	 * Adds an interceptor to apply to values coming from object accessors.
-	 *
-	 * @param InterceptorInterface $interceptor
-	 * @param \SplObjectStorage[] $interceptorArray
-	 * @return void
-	 */
-	protected function addInterceptorToArray(InterceptorInterface $interceptor, array &$interceptorArray) {
-		foreach ($interceptor->getInterceptionPoints() as $interceptionPoint) {
-			if (!isset($interceptorArray[$interceptionPoint])) {
-				$interceptorArray[$interceptionPoint] = new \SplObjectStorage();
-			}
-			$interceptors = $interceptorArray[$interceptionPoint];
-			if (!$interceptors->contains($interceptor)) {
-				$interceptors->attach($interceptor);
-			}
-		}
-	}
+    /**
+     * Adds an interceptor to apply to values coming from object accessors.
+     *
+     * @param InterceptorInterface $interceptor
+     * @param \SplObjectStorage[] $interceptorArray
+     * @return void
+     */
+    protected function addInterceptorToArray(InterceptorInterface $interceptor, array &$interceptorArray)
+    {
+        foreach ($interceptor->getInterceptionPoints() as $interceptionPoint) {
+            if (!isset($interceptorArray[$interceptionPoint])) {
+                $interceptorArray[$interceptionPoint] = new \SplObjectStorage();
+            }
+            $interceptors = $interceptorArray[$interceptionPoint];
+            if (!$interceptors->contains($interceptor)) {
+                $interceptors->attach($interceptor);
+            }
+        }
+    }
 
-	/**
-	 * Returns all interceptors for a given Interception Point.
-	 *
-	 * @param integer $interceptionPoint one of the InterceptorInterface::INTERCEPT_* constants,
-	 * @return InterceptorInterface[]
-	 */
-	public function getInterceptors($interceptionPoint) {
-		return isset($this->interceptors[$interceptionPoint]) ? $this->interceptors[$interceptionPoint] : new \SplObjectStorage();
-	}
+    /**
+     * Returns all interceptors for a given Interception Point.
+     *
+     * @param integer $interceptionPoint one of the InterceptorInterface::INTERCEPT_* constants,
+     * @return InterceptorInterface[]
+     */
+    public function getInterceptors($interceptionPoint)
+    {
+        return isset($this->interceptors[$interceptionPoint]) ? $this->interceptors[$interceptionPoint] : new \SplObjectStorage();
+    }
 
-	/**
-	 * Returns all escaping interceptors for a given Interception Point.
-	 *
-	 * @param integer $interceptionPoint one of the InterceptorInterface::INTERCEPT_* constants,
-	 * @return InterceptorInterface[]
-	 */
-	public function getEscapingInterceptors($interceptionPoint) {
-		return isset($this->escapingInterceptors[$interceptionPoint]) ? $this->escapingInterceptors[$interceptionPoint] : new \SplObjectStorage();
-	}
-
+    /**
+     * Returns all escaping interceptors for a given Interception Point.
+     *
+     * @param integer $interceptionPoint one of the InterceptorInterface::INTERCEPT_* constants,
+     * @return InterceptorInterface[]
+     */
+    public function getEscapingInterceptors($interceptionPoint)
+    {
+        return isset($this->escapingInterceptors[$interceptionPoint]) ? $this->escapingInterceptors[$interceptionPoint] : new \SplObjectStorage();
+    }
 }

--- a/src/Core/Parser/Exception.php
+++ b/src/Core/Parser/Exception.php
@@ -11,5 +11,6 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  *
  * @api
  */
-class Exception extends \TYPO3Fluid\Fluid\Core\Exception {
+class Exception extends \TYPO3Fluid\Fluid\Core\Exception
+{
 }

--- a/src/Core/Parser/Interceptor/Escape.php
+++ b/src/Core/Parser/Interceptor/Escape.php
@@ -17,66 +17,69 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 /**
  * An interceptor adding the "Htmlspecialchars" viewhelper to the suitable places.
  */
-class Escape implements InterceptorInterface {
+class Escape implements InterceptorInterface
+{
 
-	/**
-	 * Is the interceptor enabled right now for child nodes?
-	 *
-	 * @var boolean
-	 */
-	protected $childrenEscapingEnabled = TRUE;
+    /**
+     * Is the interceptor enabled right now for child nodes?
+     *
+     * @var boolean
+     */
+    protected $childrenEscapingEnabled = true;
 
-	/**
-	 * A stack of ViewHelperNodes which currently disable the interceptor.
-	 * Needed to enable the interceptor again.
-	 *
-	 * @var NodeInterface[]
-	 */
-	protected $viewHelperNodesWhichDisableTheInterceptor = array();
+    /**
+     * A stack of ViewHelperNodes which currently disable the interceptor.
+     * Needed to enable the interceptor again.
+     *
+     * @var NodeInterface[]
+     */
+    protected $viewHelperNodesWhichDisableTheInterceptor = [];
 
-	/**
-	 * Adds a ViewHelper node using the Format\HtmlspecialcharsViewHelper to the given node.
-	 * If "escapingInterceptorEnabled" in the ViewHelper is FALSE, will disable itself inside the ViewHelpers body.
-	 *
-	 * @param NodeInterface $node
-	 * @param integer $interceptorPosition One of the INTERCEPT_* constants for the current interception point
-	 * @param ParsingState $parsingState the current parsing state. Not needed in this interceptor.
-	 * @return NodeInterface
-	 */
-	public function process(NodeInterface $node, $interceptorPosition, ParsingState $parsingState) {
-		if ($interceptorPosition === InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER) {
-			/** @var ViewHelperNode $node */
-			if (!$node->getUninitializedViewHelper()->isChildrenEscapingEnabled()) {
-				$this->childrenEscapingEnabled = FALSE;
-				$this->viewHelperNodesWhichDisableTheInterceptor[] = $node;
-			}
-		} elseif ($interceptorPosition === InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER) {
-			if (end($this->viewHelperNodesWhichDisableTheInterceptor) === $node) {
-				array_pop($this->viewHelperNodesWhichDisableTheInterceptor);
-				if (count($this->viewHelperNodesWhichDisableTheInterceptor) === 0) {
-					$this->childrenEscapingEnabled = TRUE;
-				}
-			}
-			/** @var ViewHelperNode $node */
-			if ($this->childrenEscapingEnabled && $node->getUninitializedViewHelper()->isOutputEscapingEnabled()) {
-				$node = new EscapingNode($node);
-			}
-		} elseif ($this->childrenEscapingEnabled && $node instanceof ObjectAccessorNode) {
-			$node = new EscapingNode($node);
-		}
-		return $node;
-	}
+    /**
+     * Adds a ViewHelper node using the Format\HtmlspecialcharsViewHelper to the given node.
+     * If "escapingInterceptorEnabled" in the ViewHelper is FALSE, will disable itself inside the ViewHelpers body.
+     *
+     * @param NodeInterface $node
+     * @param integer $interceptorPosition One of the INTERCEPT_* constants for the current interception point
+     * @param ParsingState $parsingState the current parsing state. Not needed in this interceptor.
+     * @return NodeInterface
+     */
+    public function process(NodeInterface $node, $interceptorPosition, ParsingState $parsingState)
+    {
+        if ($interceptorPosition === InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER) {
+            /** @var ViewHelperNode $node */
+            if (!$node->getUninitializedViewHelper()->isChildrenEscapingEnabled()) {
+                $this->childrenEscapingEnabled = false;
+                $this->viewHelperNodesWhichDisableTheInterceptor[] = $node;
+            }
+        } elseif ($interceptorPosition === InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER) {
+            if (end($this->viewHelperNodesWhichDisableTheInterceptor) === $node) {
+                array_pop($this->viewHelperNodesWhichDisableTheInterceptor);
+                if (count($this->viewHelperNodesWhichDisableTheInterceptor) === 0) {
+                    $this->childrenEscapingEnabled = true;
+                }
+            }
+            /** @var ViewHelperNode $node */
+            if ($this->childrenEscapingEnabled && $node->getUninitializedViewHelper()->isOutputEscapingEnabled()) {
+                $node = new EscapingNode($node);
+            }
+        } elseif ($this->childrenEscapingEnabled && $node instanceof ObjectAccessorNode) {
+            $node = new EscapingNode($node);
+        }
+        return $node;
+    }
 
-	/**
-	 * This interceptor wants to hook into object accessor creation, and opening / closing ViewHelpers.
-	 *
-	 * @return array Array of INTERCEPT_* constants
-	 */
-	public function getInterceptionPoints() {
-		return array(
-			InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER,
-			InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER,
-			InterceptorInterface::INTERCEPT_OBJECTACCESSOR
-		);
-	}
+    /**
+     * This interceptor wants to hook into object accessor creation, and opening / closing ViewHelpers.
+     *
+     * @return array Array of INTERCEPT_* constants
+     */
+    public function getInterceptionPoints()
+    {
+        return [
+            InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER,
+            InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER,
+            InterceptorInterface::INTERCEPT_OBJECTACCESSOR
+        ];
+    }
 }

--- a/src/Core/Parser/InterceptorInterface.php
+++ b/src/Core/Parser/InterceptorInterface.php
@@ -12,28 +12,29 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
  * An interceptor interface. Interceptors are used in the parsing stage to change
  * the syntax tree of a template, e.g. by adding viewhelper nodes.
  */
-interface InterceptorInterface {
+interface InterceptorInterface
+{
 
-	const INTERCEPT_OPENING_VIEWHELPER = 1;
-	const INTERCEPT_CLOSING_VIEWHELPER = 2;
-	const INTERCEPT_TEXT = 3;
-	const INTERCEPT_OBJECTACCESSOR = 4;
+    const INTERCEPT_OPENING_VIEWHELPER = 1;
+    const INTERCEPT_CLOSING_VIEWHELPER = 2;
+    const INTERCEPT_TEXT = 3;
+    const INTERCEPT_OBJECTACCESSOR = 4;
 
-	/**
-	 * The interceptor can process the given node at will and must return a node
-	 * that will be used in place of the given node.
-	 *
-	 * @param NodeInterface $node
-	 * @param integer $interceptorPosition One of the INTERCEPT_* constants for the current interception point
-	 * @param ParsingState $parsingState the parsing state
-	 * @return NodeInterface
-	 */
-	public function process(NodeInterface $node, $interceptorPosition, ParsingState $parsingState);
+    /**
+     * The interceptor can process the given node at will and must return a node
+     * that will be used in place of the given node.
+     *
+     * @param NodeInterface $node
+     * @param integer $interceptorPosition One of the INTERCEPT_* constants for the current interception point
+     * @param ParsingState $parsingState the parsing state
+     * @return NodeInterface
+     */
+    public function process(NodeInterface $node, $interceptorPosition, ParsingState $parsingState);
 
-	/**
-	 * The interceptor should define at which interception positions it wants to be called.
-	 *
-	 * @return array Array of INTERCEPT_* constants
-	 */
-	public function getInterceptionPoints();
+    /**
+     * The interceptor should define at which interception positions it wants to be called.
+     *
+     * @return array Array of INTERCEPT_* constants
+     */
+    public function getInterceptionPoints();
 }

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -13,70 +13,71 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  * This interface is returned by \TYPO3Fluid\Fluid\Core\Parser\TemplateParser->parse()
  * method and is a parsed template
  */
-interface ParsedTemplateInterface {
+interface ParsedTemplateInterface
+{
 
-	/**
-	 * @param string $identifier
-	 * @return void
-	 */
-	public function setIdentifier($identifier);
+    /**
+     * @param string $identifier
+     * @return void
+     */
+    public function setIdentifier($identifier);
 
-	/**
-	 * @return string
-	 */
-	public function getIdentifier();
+    /**
+     * @return string
+     */
+    public function getIdentifier();
 
-	/**
-	 * Render the parsed template with rendering context
-	 *
-	 * @param RenderingContextInterface $renderingContext The rendering context to use
-	 * @return string Rendered string
-	 */
-	public function render(RenderingContextInterface $renderingContext);
+    /**
+     * Render the parsed template with rendering context
+     *
+     * @param RenderingContextInterface $renderingContext The rendering context to use
+     * @return string Rendered string
+     */
+    public function render(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Returns a variable container used in the PostParse Facet.
-	 *
-	 * @return VariableProviderInterface
-	 */
-	public function getVariableContainer();
+    /**
+     * Returns a variable container used in the PostParse Facet.
+     *
+     * @return VariableProviderInterface
+     */
+    public function getVariableContainer();
 
-	/**
-	 * Returns the name of the layout that is defined within the current template via <f:layout name="..." />
-	 * If no layout is defined, this returns NULL
-	 * This requires the current rendering context in order to be able to evaluate the layout name
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 */
-	public function getLayoutName(RenderingContextInterface $renderingContext);
+    /**
+     * Returns the name of the layout that is defined within the current template via <f:layout name="..." />
+     * If no layout is defined, this returns NULL
+     * This requires the current rendering context in order to be able to evaluate the layout name
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public function getLayoutName(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Method generated on compiled templates to add ViewHelper namespaces which were defined in-template
-	 * and add those to the ones already defined in the ViewHelperResolver.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function addCompiledNamespaces(RenderingContextInterface $renderingContext);
+    /**
+     * Method generated on compiled templates to add ViewHelper namespaces which were defined in-template
+     * and add those to the ones already defined in the ViewHelperResolver.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Returns TRUE if the current template has a template defined via <f:layout name="..." />
-	 *
-	 * @return boolean
-	 */
-	public function hasLayout();
+    /**
+     * Returns TRUE if the current template has a template defined via <f:layout name="..." />
+     *
+     * @return boolean
+     */
+    public function hasLayout();
 
-	/**
-	 * If the template contains constructs which prevent the compiler from compiling the template
-	 * correctly, isCompilable() will return FALSE.
-	 *
-	 * @return boolean TRUE if the template can be compiled
-	 */
-	public function isCompilable();
+    /**
+     * If the template contains constructs which prevent the compiler from compiling the template
+     * correctly, isCompilable() will return FALSE.
+     *
+     * @return boolean TRUE if the template can be compiled
+     */
+    public function isCompilable();
 
-	/**
-	 * @return boolean TRUE if the template is already compiled, FALSE otherwise
-	 */
-	public function isCompiled();
+    /**
+     * @return boolean TRUE if the template is already compiled, FALSE otherwise
+     */
+    public function isCompiled();
 }

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -17,196 +17,214 @@ use TYPO3Fluid\Fluid\View;
  * and the current stack of open nodes (nodeStack) and a variable container used
  * for PostParseFacets.
  */
-class ParsingState implements ParsedTemplateInterface {
+class ParsingState implements ParsedTemplateInterface
+{
 
-	/**
-	 * @var string
-	 */
-	protected $identifier;
+    /**
+     * @var string
+     */
+    protected $identifier;
 
-	/**
-	 * Root node reference
-	 *
-	 * @var RootNode
-	 */
-	protected $rootNode;
+    /**
+     * Root node reference
+     *
+     * @var RootNode
+     */
+    protected $rootNode;
 
-	/**
-	 * Array of node references currently open.
-	 *
-	 * @var array
-	 */
-	protected $nodeStack = array();
+    /**
+     * Array of node references currently open.
+     *
+     * @var array
+     */
+    protected $nodeStack = [];
 
-	/**
-	 * Variable container where ViewHelpers implementing the PostParseFacet can
-	 * store things in.
-	 *
-	 * @var VariableProviderInterface
-	 */
-	protected $variableContainer;
+    /**
+     * Variable container where ViewHelpers implementing the PostParseFacet can
+     * store things in.
+     *
+     * @var VariableProviderInterface
+     */
+    protected $variableContainer;
 
-	/**
-	 * The layout name of the current template or NULL if the template does not contain a layout definition
-	 *
-	 * @var AbstractNode
-	 */
-	protected $layoutNameNode;
+    /**
+     * The layout name of the current template or NULL if the template does not contain a layout definition
+     *
+     * @var AbstractNode
+     */
+    protected $layoutNameNode;
 
-	/**
-	 * @var boolean
-	 */
-	protected $compilable = TRUE;
+    /**
+     * @var boolean
+     */
+    protected $compilable = true;
 
-	/**
-	 * @param string $identifier
-	 * @return void
-	 */
-	public function setIdentifier($identifier) {
-		$this->identifier = $identifier;
-	}
+    /**
+     * @param string $identifier
+     * @return void
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getIdentifier() {
-		return $this->identifier;
-	}
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
 
-	/**
-	 * Injects a variable container to be used during parsing.
-	 *
-	 * @param VariableProviderInterface $variableContainer
-	 * @return void
-	 */
-	public function setVariableProvider(VariableProviderInterface $variableContainer) {
-		$this->variableContainer = $variableContainer;
-	}
+    /**
+     * Injects a variable container to be used during parsing.
+     *
+     * @param VariableProviderInterface $variableContainer
+     * @return void
+     */
+    public function setVariableProvider(VariableProviderInterface $variableContainer)
+    {
+        $this->variableContainer = $variableContainer;
+    }
 
-	/**
-	 * Set root node of this parsing state.
-	 *
-	 * @param NodeInterface $rootNode
-	 * @return void
-	 */
-	public function setRootNode(RootNode $rootNode) {
-		$this->rootNode = $rootNode;
-	}
+    /**
+     * Set root node of this parsing state.
+     *
+     * @param NodeInterface $rootNode
+     * @return void
+     */
+    public function setRootNode(RootNode $rootNode)
+    {
+        $this->rootNode = $rootNode;
+    }
 
-	/**
-	 * Get root node of this parsing state.
-	 *
-	 * @return NodeInterface The root node
-	 */
-	public function getRootNode() {
-		return $this->rootNode;
-	}
+    /**
+     * Get root node of this parsing state.
+     *
+     * @return NodeInterface The root node
+     */
+    public function getRootNode()
+    {
+        return $this->rootNode;
+    }
 
-	/**
-	 * Render the parsed template with rendering context
-	 *
-	 * @param RenderingContextInterface $renderingContext The rendering context to use
-	 * @return string Rendered string
-	 */
-	public function render(RenderingContextInterface $renderingContext) {
-		return $this->rootNode->evaluate($renderingContext);
-	}
+    /**
+     * Render the parsed template with rendering context
+     *
+     * @param RenderingContextInterface $renderingContext The rendering context to use
+     * @return string Rendered string
+     */
+    public function render(RenderingContextInterface $renderingContext)
+    {
+        return $this->rootNode->evaluate($renderingContext);
+    }
 
-	/**
-	 * Push a node to the node stack. The node stack holds all currently open
-	 * templating tags.
-	 *
-	 * @param NodeInterface $node Node to push to node stack
-	 * @return void
-	 */
-	public function pushNodeToStack(NodeInterface $node) {
-		array_push($this->nodeStack, $node);
-	}
+    /**
+     * Push a node to the node stack. The node stack holds all currently open
+     * templating tags.
+     *
+     * @param NodeInterface $node Node to push to node stack
+     * @return void
+     */
+    public function pushNodeToStack(NodeInterface $node)
+    {
+        array_push($this->nodeStack, $node);
+    }
 
-	/**
-	 * Get the top stack element, without removing it.
-	 *
-	 * @return NodeInterface the top stack element.
-	 */
-	public function getNodeFromStack() {
-		return $this->nodeStack[count($this->nodeStack) - 1];
-	}
+    /**
+     * Get the top stack element, without removing it.
+     *
+     * @return NodeInterface the top stack element.
+     */
+    public function getNodeFromStack()
+    {
+        return $this->nodeStack[count($this->nodeStack) - 1];
+    }
 
-	/**
-	 * Pop the top stack element (=remove it) and return it back.
-	 *
-	 * @return NodeInterface the top stack element, which was removed.
-	 */
-	public function popNodeFromStack() {
-		return array_pop($this->nodeStack);
-	}
+    /**
+     * Pop the top stack element (=remove it) and return it back.
+     *
+     * @return NodeInterface the top stack element, which was removed.
+     */
+    public function popNodeFromStack()
+    {
+        return array_pop($this->nodeStack);
+    }
 
-	/**
-	 * Count the size of the node stack
-	 *
-	 * @return integer Number of elements on the node stack (i.e. number of currently open Fluid tags)
-	 */
-	public function countNodeStack() {
-		return count($this->nodeStack);
-	}
+    /**
+     * Count the size of the node stack
+     *
+     * @return integer Number of elements on the node stack (i.e. number of currently open Fluid tags)
+     */
+    public function countNodeStack()
+    {
+        return count($this->nodeStack);
+    }
 
-	/**
-	 * Returns a variable container which will be then passed to the postParseFacet.
-	 *
-	 * @return VariableProviderInterface The variable container or NULL if none has been set yet
-	 */
-	public function getVariableContainer() {
-		return $this->variableContainer;
-	}
+    /**
+     * Returns a variable container which will be then passed to the postParseFacet.
+     *
+     * @return VariableProviderInterface The variable container or NULL if none has been set yet
+     */
+    public function getVariableContainer()
+    {
+        return $this->variableContainer;
+    }
 
-	/**
-	 * Returns TRUE if the current template has a template defined via <f:layout name="..." />
-	 *
-	 * @return boolean
-	 */
-	public function hasLayout() {
-		return $this->variableContainer->exists('layoutName');
-	}
+    /**
+     * Returns TRUE if the current template has a template defined via <f:layout name="..." />
+     *
+     * @return boolean
+     */
+    public function hasLayout()
+    {
+        return $this->variableContainer->exists('layoutName');
+    }
 
-	/**
-	 * Returns the name of the layout that is defined within the current template via <f:layout name="..." />
-	 * If no layout is defined, this returns NULL
-	 * This requires the current rendering context in order to be able to evaluate the layout name
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 * @throws View\Exception
-	 */
-	public function getLayoutName(RenderingContextInterface $renderingContext) {
-		$layoutName = $this->variableContainer->get('layoutName');
-		return ($layoutName instanceof RootNode ? $layoutName->evaluate($renderingContext) : $layoutName);
-	}
+    /**
+     * Returns the name of the layout that is defined within the current template via <f:layout name="..." />
+     * If no layout is defined, this returns NULL
+     * This requires the current rendering context in order to be able to evaluate the layout name
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     * @throws View\Exception
+     */
+    public function getLayoutName(RenderingContextInterface $renderingContext)
+    {
+        $layoutName = $this->variableContainer->get('layoutName');
+        return ($layoutName instanceof RootNode ? $layoutName->evaluate($renderingContext) : $layoutName);
+    }
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext)
+    {
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCompilable() {
-		return $this->compilable;
-	}
+    /**
+     * @return boolean
+     */
+    public function isCompilable()
+    {
+        return $this->compilable;
+    }
 
-	/**
-	 * @param boolean $compilable
-	 */
-	public function setCompilable($compilable) {
-		$this->compilable = $compilable;
-	}
+    /**
+     * @param boolean $compilable
+     */
+    public function setCompilable($compilable)
+    {
+        $this->compilable = $compilable;
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCompiled() {
-		return FALSE;
-	}
+    /**
+     * @return boolean
+     */
+    public function isCompiled()
+    {
+        return false;
+    }
 }

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -9,16 +9,17 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
 /**
  * Class Patterns
  */
-abstract class Patterns {
+abstract class Patterns
+{
 
-	const NAMESPACEPREFIX = 'http://typo3.org/ns/';
-	const NAMESPACESUFFIX = '/ViewHelpers';
+    const NAMESPACEPREFIX = 'http://typo3.org/ns/';
+    const NAMESPACESUFFIX = '/ViewHelpers';
 
-	/**
-	 * This regular expression splits the input string at all dynamic tags, AND
-	 * on all <![CDATA[...]]> sections.
-	 */
-	static public $SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS = '/
+    /**
+     * This regular expression splits the input string at all dynamic tags, AND
+     * on all <![CDATA[...]]> sections.
+     */
+    static public $SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS = '/
 		(
 			(?: <\/?                                      # Start dynamic tags
 					(?:(?:[a-zA-Z0-9\\.]*):[a-zA-Z0-9\\.]+)  # A tag consists of the namespace prefix and word characters
@@ -40,10 +41,10 @@ abstract class Patterns {
 			)
 		)/xs';
 
-	/**
-	 * This regular expression scans if the input string is a ViewHelper tag
-	 */
-	static public $SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG = '/
+    /**
+     * This regular expression scans if the input string is a ViewHelper tag
+     */
+    static public $SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG = '/
 		^<                                                # A Tag begins with <
 		(?P<NamespaceIdentifier>[a-zA-Z0-9\\.]*):         # Then comes the Namespace prefix followed by a :
 		(?P<MethodIdentifier>                             # Now comes the Name of the ViewHelper
@@ -67,17 +68,17 @@ abstract class Patterns {
 		(?P<Selfclosing>\/?)                              # A tag might be selfclosing
 		>$/x';
 
-	/**
-	 * This regular expression scans if the input string is a closing ViewHelper
-	 * tag.
-	 */
-	static public $SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG =
-		'/^<\/(?P<NamespaceIdentifier>[a-zA-Z0-9\\.]*):(?P<MethodIdentifier>[a-zA-Z0-9\\.]+)\s*>$/';
+    /**
+     * This regular expression scans if the input string is a closing ViewHelper
+     * tag.
+     */
+    static public $SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG =
+        '/^<\/(?P<NamespaceIdentifier>[a-zA-Z0-9\\.]*):(?P<MethodIdentifier>[a-zA-Z0-9\\.]+)\s*>$/';
 
-	/**
-	 * This regular expression splits the tag arguments into its parts
-	 */
-	static public $SPLIT_PATTERN_TAGARGUMENTS = '/
+    /**
+     * This regular expression splits the tag arguments into its parts
+     */
+    static public $SPLIT_PATTERN_TAGARGUMENTS = '/
 		(?:                                              #
 			\s*                                          #
 			(?P<Argument>                                # The attribute name
@@ -95,22 +96,22 @@ abstract class Patterns {
 		)
 		/xs';
 
-	/**
-	 * This pattern detects the escaping modifier
-	 */
-	static public $SCAN_PATTERN_ESCAPINGMODIFIER = '/{escapingEnabled\s*=\s*(?P<enabled>true|false)\s*}/i';
+    /**
+     * This pattern detects the escaping modifier
+     */
+    static public $SCAN_PATTERN_ESCAPINGMODIFIER = '/{escapingEnabled\s*=\s*(?P<enabled>true|false)\s*}/i';
 
-	/**
-	 * This pattern detects CDATA sections and outputs the text between opening
-	 * and closing CDATA.
-	 */
-	static public $SCAN_PATTERN_CDATA = '/^<!\[CDATA\[(.*?)\]\]>$/s';
+    /**
+     * This pattern detects CDATA sections and outputs the text between opening
+     * and closing CDATA.
+     */
+    static public $SCAN_PATTERN_CDATA = '/^<!\[CDATA\[(.*?)\]\]>$/s';
 
-	/**
-	 * Pattern which splits the shorthand syntax into different tokens. The
-	 * "shorthand syntax" is everything like {...}
-	 */
-	static public $SPLIT_PATTERN_SHORTHANDSYNTAX = '/
+    /**
+     * Pattern which splits the shorthand syntax into different tokens. The
+     * "shorthand syntax" is everything like {...}
+     */
+    static public $SPLIT_PATTERN_SHORTHANDSYNTAX = '/
 		(
 			{                                 # Start of shorthand syntax
 				(?:                           # Shorthand syntax is either composed of...
@@ -123,15 +124,15 @@ abstract class Patterns {
 			}                                 # End of shorthand syntax
 		)/x';
 
-	/**
-	 * Pattern which detects the object accessor syntax:
-	 * {object.some.value}, additionally it detects ViewHelpers like
-	 * {f:for(param1:bla)} and chaining like
-	 * {object.some.value -> f:bla.blubb() -> f:bla.blubb2()}
-	 *
-	 * THIS IS ALMOST THE SAME AS IN $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
-	 */
-	static public $SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS = '/
+    /**
+     * Pattern which detects the object accessor syntax:
+     * {object.some.value}, additionally it detects ViewHelpers like
+     * {f:for(param1:bla)} and chaining like
+     * {object.some.value -> f:bla.blubb() -> f:bla.blubb2()}
+     *
+     * THIS IS ALMOST THE SAME AS IN $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
+     */
+    static public $SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS = '/
 		^{                                                  # Start of shorthand syntax
 			                                                # A shorthand syntax is either...
 			(?P<Object>[a-zA-Z0-9_\-\.\{\}]*)                 # ... an object accessor
@@ -165,11 +166,11 @@ abstract class Patterns {
 			)
 		}$/x';
 
-	/**
-	 * THIS IS ALMOST THE SAME AS $SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS
-	 *
-	 */
-	static public $SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER = '/
+    /**
+     * THIS IS ALMOST THE SAME AS $SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS
+     *
+     */
+    static public $SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER = '/
 
 		(?P<NamespaceIdentifier>[a-zA-Z0-9\\.]+)    # Namespace prefix of ViewHelper (as in $SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG)
 		:
@@ -191,15 +192,15 @@ abstract class Patterns {
 		\)                                          # Closing parameter brackets of ViewHelper
 		/x';
 
-	/**
-	 * Pattern which detects the array/object syntax like in JavaScript, so it
-	 * detects strings like:
-	 * {object: value, object2: {nested: array}, object3: "Some string"}
-	 *
-	 * THIS IS ALMOST THE SAME AS IN SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS
-	 *
-	 */
-	static public $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS = '/^
+    /**
+     * Pattern which detects the array/object syntax like in JavaScript, so it
+     * detects strings like:
+     * {object: value, object2: {nested: array}, object3: "Some string"}
+     *
+     * THIS IS ALMOST THE SAME AS IN SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS
+     *
+     */
+    static public $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS = '/^
 		(?P<Recursion>                                             # Start the recursive part of the regular expression - describing the array syntax
 			{                                                      # Each array needs to start with {
 				(?P<Array>                                         # Start sub-match
@@ -222,12 +223,12 @@ abstract class Patterns {
 			}                                                      # Each array ends with }
 		)$/x';
 
-	/**
-	 * This pattern splits an array into its parts. It is quite similar to the
-	 * pattern above.
-	 *
-	 */
-	static public $SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS = '/
+    /**
+     * This pattern splits an array into its parts. It is quite similar to the
+     * pattern above.
+     *
+     */
+    static public $SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS = '/
 		(?P<ArrayPart>                                             # Start sub-match
 			(?P<Key>                                               # The keys of the array
 				[a-zA-Z0-9\\-_]+                                   # Unquoted
@@ -246,5 +247,4 @@ abstract class Patterns {
 			)                                                      # END possible value options
 		)                                                          # End array part sub-match
 	/x';
-
 }

--- a/src/Core/Parser/SyntaxTree/AbstractNode.php
+++ b/src/Core/Parser/SyntaxTree/AbstractNode.php
@@ -12,72 +12,77 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Abstract node in the syntax tree which has been built.
  */
-abstract class AbstractNode implements NodeInterface {
+abstract class AbstractNode implements NodeInterface
+{
 
-	/**
-	 * List of Child Nodes.
-	 *
-	 * @var NodeInterface[]
-	 */
-	protected $childNodes = array();
+    /**
+     * List of Child Nodes.
+     *
+     * @var NodeInterface[]
+     */
+    protected $childNodes = [];
 
-	/**
-	 * Evaluate all child nodes and return the evaluated results.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed Normally, an object is returned - in case it is concatenated with a string, a string is returned.
-	 * @throws Parser\Exception
-	 */
-	public function evaluateChildNodes(RenderingContextInterface $renderingContext) {
-		$numberOfChildNodes = count($this->childNodes);
-		if ($numberOfChildNodes === 0) {
-			return NULL;
-		}
-		if ($numberOfChildNodes === 1) {
-			return $this->evaluateChildNode($this->childNodes[0], $renderingContext, FALSE);
-		}
-		$output = '';
-		/** @var $subNode NodeInterface */
-		foreach ($this->childNodes as $subNode) {
-			$output .= $this->evaluateChildNode($subNode, $renderingContext, TRUE);
-		}
-		return $output;
-	}
+    /**
+     * Evaluate all child nodes and return the evaluated results.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed Normally, an object is returned - in case it is concatenated with a string, a string is returned.
+     * @throws Parser\Exception
+     */
+    public function evaluateChildNodes(RenderingContextInterface $renderingContext)
+    {
+        $numberOfChildNodes = count($this->childNodes);
+        if ($numberOfChildNodes === 0) {
+            return null;
+        }
+        if ($numberOfChildNodes === 1) {
+            return $this->evaluateChildNode($this->childNodes[0], $renderingContext, false);
+        }
+        $output = '';
+        /** @var $subNode NodeInterface */
+        foreach ($this->childNodes as $subNode) {
+            $output .= $this->evaluateChildNode($subNode, $renderingContext, true);
+        }
+        return $output;
+    }
 
-	/**
-	 * @param NodeInterface $node
-	 * @param RenderingContextInterface $renderingContext
-	 * @param boolean $cast
-	 * @return mixed
-	 */
-	protected function evaluateChildNode(NodeInterface $node, RenderingContextInterface $renderingContext, $cast) {
-		$output = $node->evaluate($renderingContext);
-		if ($cast && is_object($output)) {
-			if (!method_exists($output, '__toString')) {
-				throw new Parser\Exception('Cannot cast object of type "' . get_class($output) . '" to string.', 1273753083);
-			}
-			$output = (string) $output;
-		}
-		return $output;
-	}
+    /**
+     * @param NodeInterface $node
+     * @param RenderingContextInterface $renderingContext
+     * @param boolean $cast
+     * @return mixed
+     */
+    protected function evaluateChildNode(NodeInterface $node, RenderingContextInterface $renderingContext, $cast)
+    {
+        $output = $node->evaluate($renderingContext);
+        if ($cast && is_object($output)) {
+            if (!method_exists($output, '__toString')) {
+                throw new Parser\Exception('Cannot cast object of type "' . get_class($output) . '" to string.', 1273753083);
+            }
+            $output = (string) $output;
+        }
+        return $output;
+    }
 
-	/**
-	 * Returns all child nodes for a given node.
-	 * This is especially needed to implement the boolean expression language.
-	 *
-	 * @return NodeInterface[] A list of nodes
-	 */
-	public function getChildNodes() {
-		return $this->childNodes;
-	}
+    /**
+     * Returns all child nodes for a given node.
+     * This is especially needed to implement the boolean expression language.
+     *
+     * @return NodeInterface[] A list of nodes
+     */
+    public function getChildNodes()
+    {
+        return $this->childNodes;
+    }
 
-	/**
-	 * Appends a sub node to this node. Is used inside the parser to append children
-	 *
-	 * @param NodeInterface $childNode The sub node to add
-	 * @return void
-	 */
-	public function addChildNode(NodeInterface $childNode) {
-		$this->childNodes[] = $childNode;
-	}
+    /**
+     * Appends a sub node to this node. Is used inside the parser to append children
+     *
+     * @param NodeInterface $childNode The sub node to add
+     * @return void
+     */
+    public function addChildNode(NodeInterface $childNode)
+    {
+        $this->childNodes[] = $childNode;
+    }
 }

--- a/src/Core/Parser/SyntaxTree/ArrayNode.php
+++ b/src/Core/Parser/SyntaxTree/ArrayNode.php
@@ -11,44 +11,48 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Array Syntax Tree Node. Handles JSON-like arrays.
  */
-class ArrayNode extends AbstractNode {
+class ArrayNode extends AbstractNode
+{
 
-	/**
-	 * An associative array. Each key is a string. Each value is either a literal, or an AbstractNode.
-	 *
-	 * @var array
-	 */
-	protected $internalArray = array();
+    /**
+     * An associative array. Each key is a string. Each value is either a literal, or an AbstractNode.
+     *
+     * @var array
+     */
+    protected $internalArray = [];
 
-	/**
-	 * Constructor.
-	 *
-	 * @param array $internalArray Array to store
-	 */
-	public function __construct(array $internalArray) {
-		$this->internalArray = $internalArray;
-	}
+    /**
+     * Constructor.
+     *
+     * @param array $internalArray Array to store
+     */
+    public function __construct(array $internalArray)
+    {
+        $this->internalArray = $internalArray;
+    }
 
-	/**
-	 * Evaluate the array and return an evaluated array
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return array An associative array with literal values
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		$arrayToBuild = array();
-		foreach ($this->internalArray as $key => $value) {
-			$arrayToBuild[$key] = $value instanceof NodeInterface ? $value->evaluate($renderingContext) : $value;
-		}
-		return $arrayToBuild;
-	}
+    /**
+     * Evaluate the array and return an evaluated array
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return array An associative array with literal values
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        $arrayToBuild = [];
+        foreach ($this->internalArray as $key => $value) {
+            $arrayToBuild[$key] = $value instanceof NodeInterface ? $value->evaluate($renderingContext) : $value;
+        }
+        return $arrayToBuild;
+    }
 
-	/**
-	 * INTERNAL; DO NOT CALL DIRECTLY!
-	 *
-	 * @return array
-	 */
-	public function getInternalArray() {
-		return $this->internalArray;
-	}
+    /**
+     * INTERNAL; DO NOT CALL DIRECTLY!
+     *
+     * @return array
+     */
+    public function getInternalArray()
+    {
+        return $this->internalArray;
+    }
 }

--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -15,152 +15,161 @@ use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 /**
  * A node which is used inside boolean arguments
  */
-class BooleanNode extends AbstractNode {
+class BooleanNode extends AbstractNode
+{
 
-	/**
-	 * Stack of expression nodes to be evaluated
-	 *
-	 * @var NodeInterface[]
-	 */
-	protected $childNodes = array();
+    /**
+     * Stack of expression nodes to be evaluated
+     *
+     * @var NodeInterface[]
+     */
+    protected $childNodes = [];
 
-	/**
-	 * @var NodeInterface
-	 */
-	protected $node;
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
 
-	/**
-	 * @var array
-	 */
-	protected $stack = array();
+    /**
+     * @var array
+     */
+    protected $stack = [];
 
-	/**
-	 * @param mixed $input NodeInterface, array (of nodes or expression parts) or a simple type that can be evaluated to boolean
-	 */
-	public function __construct($input) {
-		// First, evaluate everything that is not an ObjectAccessorNode, ArrayNode
-		// or ViewHelperNode so we get all text, numbers, comparators and
-		// groupers from the text parts of the expression. All other nodes
-		// we leave intact for later processing
-		if ($input instanceof RootNode) {
-			$this->stack = $input->getChildNodes();
-		} elseif (is_array($input)) {
-			$this->stack = $input;
-		} else {
-			$this->stack = array(is_string($input) ? trim($input) : $input);
-		}
-	}
+    /**
+     * @param mixed $input NodeInterface, array (of nodes or expression parts) or a simple type that can be evaluated to boolean
+     */
+    public function __construct($input)
+    {
+        // First, evaluate everything that is not an ObjectAccessorNode, ArrayNode
+        // or ViewHelperNode so we get all text, numbers, comparators and
+        // groupers from the text parts of the expression. All other nodes
+        // we leave intact for later processing
+        if ($input instanceof RootNode) {
+            $this->stack = $input->getChildNodes();
+        } elseif (is_array($input)) {
+            $this->stack = $input;
+        } else {
+            $this->stack = [is_string($input) ? trim($input) : $input];
+        }
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getStack() {
-		return $this->stack;
-	}
+    /**
+     * @return array
+     */
+    public function getStack()
+    {
+        return $this->stack;
+    }
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return boolean the boolean value
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return self::evaluateStack($renderingContext, $this->stack);
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return boolean the boolean value
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return self::evaluateStack($renderingContext, $this->stack);
+    }
 
-	/**
-	 * @param NodeInterface $node
-	 * @param RenderingContextInterface $renderingContext
-	 * @return boolean
-	 */
-	public static function createFromNodeAndEvaluate(NodeInterface $node, RenderingContextInterface $renderingContext) {
-		$booleanNode = new BooleanNode($node);
-		return $booleanNode->evaluate($renderingContext);
-	}
+    /**
+     * @param NodeInterface $node
+     * @param RenderingContextInterface $renderingContext
+     * @return boolean
+     */
+    public static function createFromNodeAndEvaluate(NodeInterface $node, RenderingContextInterface $renderingContext)
+    {
+        $booleanNode = new BooleanNode($node);
+        return $booleanNode->evaluate($renderingContext);
+    }
 
-	/**
-	 * Takes a stack of nodes evaluates it with the end result
-	 * being a single boolean value. Creates new BooleanNodes
-	 * recursively to process braced expressions as single units.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @param array $expressionParts
-	 * @return boolean the boolean value
-	 */
-	public static function evaluateStack(RenderingContextInterface $renderingContext, array $expressionParts) {
-		$expression = static::reconcatenateExpression($expressionParts);
-		$context = static::gatherContext($renderingContext, $expressionParts);
+    /**
+     * Takes a stack of nodes evaluates it with the end result
+     * being a single boolean value. Creates new BooleanNodes
+     * recursively to process braced expressions as single units.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @param array $expressionParts
+     * @return boolean the boolean value
+     */
+    public static function evaluateStack(RenderingContextInterface $renderingContext, array $expressionParts)
+    {
+        $expression = static::reconcatenateExpression($expressionParts);
+        $context = static::gatherContext($renderingContext, $expressionParts);
 
-		$parser = new BooleanParser();
-		return static::convertToBoolean($parser->evaluate($expression, $context), $renderingContext);
-	}
+        $parser = new BooleanParser();
+        return static::convertToBoolean($parser->evaluate($expression, $context), $renderingContext);
+    }
 
-	/**
-	 * Walk all expressionParts and concatenate an expression string
-	 *
-	 * @param array $expressionParts
-	 * @return string
-	 */
-	public static function reconcatenateExpression($expressionParts) {
-		$merged = array();
-		foreach ($expressionParts as $key => $expressionPart) {
-			if ($expressionPart instanceof TextNode || is_string($expressionPart)) {
-				$merged[] = $expressionPart instanceof TextNode ? $expressionPart->getText() : $expressionPart;
-			} else if ($expressionPart instanceof NodeInterface) {
-				$merged[] = '{node' . $key . '}';
-			} else {
-				$merged[] = '{node' . $key . '}';
-			}
-		}
-		return implode('', $merged);
-	}
+    /**
+     * Walk all expressionParts and concatenate an expression string
+     *
+     * @param array $expressionParts
+     * @return string
+     */
+    public static function reconcatenateExpression($expressionParts)
+    {
+        $merged = [];
+        foreach ($expressionParts as $key => $expressionPart) {
+            if ($expressionPart instanceof TextNode || is_string($expressionPart)) {
+                $merged[] = $expressionPart instanceof TextNode ? $expressionPart->getText() : $expressionPart;
+            } elseif ($expressionPart instanceof NodeInterface) {
+                $merged[] = '{node' . $key . '}';
+            } else {
+                $merged[] = '{node' . $key . '}';
+            }
+        }
+        return implode('', $merged);
+    }
 
-	/**
-	 * Walk all expressionParts and gather a context array of all non textNode parts
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @param array $expressionParts
-	 * @return array
-	 */
-	public static function gatherContext($renderingContext, $expressionParts) {
-		$context = array();
-		foreach ($expressionParts as $key => $expressionPart) {
-			if ($expressionPart instanceof NodeInterface) {
-				$context['node' . $key] = $expressionPart->evaluate($renderingContext);
-			} else {
-				$context['node' . $key] = $expressionPart;
-			}
-		}
-		return $context;
-	}
+    /**
+     * Walk all expressionParts and gather a context array of all non textNode parts
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @param array $expressionParts
+     * @return array
+     */
+    public static function gatherContext($renderingContext, $expressionParts)
+    {
+        $context = [];
+        foreach ($expressionParts as $key => $expressionPart) {
+            if ($expressionPart instanceof NodeInterface) {
+                $context['node' . $key] = $expressionPart->evaluate($renderingContext);
+            } else {
+                $context['node' . $key] = $expressionPart;
+            }
+        }
+        return $context;
+    }
 
-	/**
-	 * Convert argument strings to their equivalents. Needed to handle strings with a boolean meaning.
-	 *
-	 * Must be public and static as it is used from inside cached templates.
-	 *
-	 * @param boolean $value Value to be converted to boolean
-	 * @param RenderingContextInterface $renderingContext
-	 * @return boolean
-	 */
-	public static function convertToBoolean($value, $renderingContext) {
-		if (is_bool($value)) {
-			return $value;
-		}
-		if (is_numeric($value)) {
-			return (boolean) ((float) $value > 0);
-		}
-		if (is_string($value)) {
-			if (strlen($value) === 0) {
-				return FALSE;
-			}
-			$value = $renderingContext->getTemplateParser()->unquoteString($value);
-			return (strtolower($value) !== 'false' && !empty($value));
-		}
-		if (is_array($value) || (is_object($value) && $value instanceof \Countable)) {
-			return count($value) > 0;
-		}
-		if (is_object($value)) {
-			return TRUE;
-		}
-		return FALSE;
-	}
+    /**
+     * Convert argument strings to their equivalents. Needed to handle strings with a boolean meaning.
+     *
+     * Must be public and static as it is used from inside cached templates.
+     *
+     * @param boolean $value Value to be converted to boolean
+     * @param RenderingContextInterface $renderingContext
+     * @return boolean
+     */
+    public static function convertToBoolean($value, $renderingContext)
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return (boolean) ((float) $value > 0);
+        }
+        if (is_string($value)) {
+            if (strlen($value) === 0) {
+                return false;
+            }
+            $value = $renderingContext->getTemplateParser()->unquoteString($value);
+            return (strtolower($value) !== 'false' && !empty($value));
+        }
+        if (is_array($value) || (is_object($value) && $value instanceof \Countable)) {
+            return count($value) > 0;
+        }
+        if (is_object($value)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -13,49 +13,54 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 /**
  * Escaping Node - wraps all content that must be escaped before output.
  */
-class EscapingNode extends AbstractNode {
+class EscapingNode extends AbstractNode
+{
 
-	/**
-	 * Node to be escaped
-	 *
-	 * @var NodeInterface
-	 */
-	protected $node;
+    /**
+     * Node to be escaped
+     *
+     * @var NodeInterface
+     */
+    protected $node;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param NodeInterface $node
-	 */
-	public function __construct(NodeInterface $node) {
-		$this->node = $node;
-	}
+    /**
+     * Constructor.
+     *
+     * @param NodeInterface $node
+     */
+    public function __construct(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
 
-	/**
-	 * Return the value associated to the syntax tree.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return number the value stored in this node/subtree.
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES);
-	}
+    /**
+     * Return the value associated to the syntax tree.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return number the value stored in this node/subtree.
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return htmlspecialchars($this->node->evaluate($renderingContext), ENT_QUOTES);
+    }
 
-	/**
-	 * @return NodeInterface
-	 */
-	public function getNode() {
-		return $this->node;
-	}
+    /**
+     * @return NodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
 
-	/**
-	 * NumericNode does not allow adding child nodes, so this will always throw an exception.
-	 *
-	 * @param NodeInterface $childNode The sub node to add
-	 * @throws Parser\Exception
-	 * @return void
-	 */
-	public function addChildNode(NodeInterface $childNode) {
-		$this->node = $childNode;
-	}
+    /**
+     * NumericNode does not allow adding child nodes, so this will always throw an exception.
+     *
+     * @param NodeInterface $childNode The sub node to add
+     * @throws Parser\Exception
+     * @return void
+     */
+    public function addChildNode(NodeInterface $childNode)
+    {
+        $this->node = $childNode;
+    }
 }

--- a/src/Core/Parser/SyntaxTree/Expression/AbstractExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/AbstractExpressionNode.php
@@ -15,111 +15,118 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 /**
  * Base class for nodes based on (shorthand) expressions.
  */
-abstract class AbstractExpressionNode extends AbstractNode implements ExpressionNodeInterface {
+abstract class AbstractExpressionNode extends AbstractNode implements ExpressionNodeInterface
+{
 
-	/**
-	 * Contents of the text node
-	 *
-	 * @var string
-	 */
-	protected $expression;
+    /**
+     * Contents of the text node
+     *
+     * @var string
+     */
+    protected $expression;
 
-	/**
-	 * @var array
-	 */
-	protected $matches = array();
+    /**
+     * @var array
+     */
+    protected $matches = [];
 
-	/**
-	 * Constructor.
-	 *
-	 * @param string $expression The original expression that created this node.
-	 * @param array $matches Matches extracted from expression
-	 * @throws Parser\Exception
-	 */
-	public function __construct($expression, array $matches) {
-		$this->expression = trim($expression, " \t\n\r\0\x0b");
-		$this->matches = $matches;
-	}
+    /**
+     * Constructor.
+     *
+     * @param string $expression The original expression that created this node.
+     * @param array $matches Matches extracted from expression
+     * @throws Parser\Exception
+     */
+    public function __construct($expression, array $matches)
+    {
+        $this->expression = trim($expression, " \t\n\r\0\x0b");
+        $this->matches = $matches;
+    }
 
-	/**
-	 * Evaluates the expression stored in this node, in the context of $renderingcontext.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string the text stored in this node/subtree.
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return static::evaluateExpression($renderingContext, $this->expression, $this->matches);
-	}
+    /**
+     * Evaluates the expression stored in this node, in the context of $renderingcontext.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return string the text stored in this node/subtree.
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return static::evaluateExpression($renderingContext, $this->expression, $this->matches);
+    }
 
-	/**
-	 * Compiles the ExpressionNode, returning an array with
-	 * exactly two keys which contain strings:
-	 *
-	 * - "initialization" which contains variable initializations
-	 * - "execution" which contains the execution (that uses the variables)
-	 *
-	 * The expression and matches can be read from the local
-	 * instance - and the RenderingContext and other APIs
-	 * can be accessed via the TemplateCompiler.
-	 *
-	 * @param TemplateCompiler $templateCompiler
-	 * @return array
-	 */
-	public function compile(TemplateCompiler $templateCompiler) {
-		$handlerClass = get_class($this);
-		$expressionVariable = $templateCompiler->variableName('string');
-		$matchesVariable = $templateCompiler->variableName('array');
-		$initializationPhpCode = sprintf('// Rendering %s node' . chr(10), $handlerClass);
-		$initializationPhpCode .= sprintf('%s = \'%s\';', $expressionVariable, $this->getExpression()) . chr(10);
-		$initializationPhpCode .= sprintf('%s = %s;', $matchesVariable, var_export($this->getMatches(), TRUE)) . chr(10);
-		return array(
-			'initialization' => $initializationPhpCode,
-			'execution' => sprintf(
-				'\%s::evaluateExpression($renderingContext, %s, %s)',
-				$handlerClass,
-				$expressionVariable,
-				$matchesVariable
-			)
-		);
-	}
+    /**
+     * Compiles the ExpressionNode, returning an array with
+     * exactly two keys which contain strings:
+     *
+     * - "initialization" which contains variable initializations
+     * - "execution" which contains the execution (that uses the variables)
+     *
+     * The expression and matches can be read from the local
+     * instance - and the RenderingContext and other APIs
+     * can be accessed via the TemplateCompiler.
+     *
+     * @param TemplateCompiler $templateCompiler
+     * @return array
+     */
+    public function compile(TemplateCompiler $templateCompiler)
+    {
+        $handlerClass = get_class($this);
+        $expressionVariable = $templateCompiler->variableName('string');
+        $matchesVariable = $templateCompiler->variableName('array');
+        $initializationPhpCode = sprintf('// Rendering %s node' . chr(10), $handlerClass);
+        $initializationPhpCode .= sprintf('%s = \'%s\';', $expressionVariable, $this->getExpression()) . chr(10);
+        $initializationPhpCode .= sprintf('%s = %s;', $matchesVariable, var_export($this->getMatches(), true)) . chr(10);
+        return [
+            'initialization' => $initializationPhpCode,
+            'execution' => sprintf(
+                '\%s::evaluateExpression($renderingContext, %s, %s)',
+                $handlerClass,
+                $expressionVariable,
+                $matchesVariable
+            )
+        ];
+    }
 
-	/**
-	 * Getter for returning the expression before parsing.
-	 *
-	 * @return string
-	 */
-	public function getExpression() {
-		return $this->expression;
-	}
+    /**
+     * Getter for returning the expression before parsing.
+     *
+     * @return string
+     */
+    public function getExpression()
+    {
+        return $this->expression;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getMatches() {
-		return $this->matches;
-	}
+    /**
+     * @return array
+     */
+    public function getMatches()
+    {
+        return $this->matches;
+    }
 
-	/**
-	 * @param string $part
-	 * @return string
-	 */
-	protected static function trimPart($part) {
-		return trim($part, " \t\n\r\0\x0b{}");
-	}
+    /**
+     * @param string $part
+     * @return string
+     */
+    protected static function trimPart($part)
+    {
+        return trim($part, " \t\n\r\0\x0b{}");
+    }
 
-	/**
-	 * @param mixed $candidate
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	protected static function getTemplateVariableOrValueItself($candidate, RenderingContextInterface $renderingContext) {
-		$variables = $renderingContext->getVariableProvider()->getAll();
-		$extractor = new VariableExtractor();
-		$suspect = $extractor->getByPath($variables, $candidate);
-		if (NULL === $suspect) {
-			return $candidate;
-		}
-		return $suspect;
-	}
-
+    /**
+     * @param mixed $candidate
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    protected static function getTemplateVariableOrValueItself($candidate, RenderingContextInterface $renderingContext)
+    {
+        $variables = $renderingContext->getVariableProvider()->getAll();
+        $extractor = new VariableExtractor();
+        $suspect = $extractor->getByPath($variables, $candidate);
+        if (null === $suspect) {
+            return $candidate;
+        }
+        return $suspect;
+    }
 }

--- a/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
@@ -14,22 +14,23 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;
  * Type Casting Node - allows the shorthand version
  * of a condition to be written as `{var ? thenvar : elsevar}`
  */
-class CastingExpressionNode extends AbstractExpressionNode {
+class CastingExpressionNode extends AbstractExpressionNode
+{
 
-	/**
-	 * @var array
-	 */
-	protected static $validTypes = array(
-		'integer', 'boolean', 'string', 'float', 'array', 'DateTime'
-	);
+    /**
+     * @var array
+     */
+    protected static $validTypes = [
+        'integer', 'boolean', 'string', 'float', 'array', 'DateTime'
+    ];
 
-	/**
-	 * Pattern which detects ternary conditions written in shorthand
-	 * syntax, e.g. {some.variable as integer}. The right-hand side
-	 * of the expression can also be a variable containing the type
-	 * of the variable.
-	 */
-	public static $detectionExpression = '/
+    /**
+     * Pattern which detects ternary conditions written in shorthand
+     * syntax, e.g. {some.variable as integer}. The right-hand side
+     * of the expression can also be a variable containing the type
+     * of the variable.
+     */
+    public static $detectionExpression = '/
 		(
 			{                                # Start of shorthand syntax
 				(?:                          # Math expression is composed of...
@@ -40,86 +41,89 @@ class CastingExpressionNode extends AbstractExpressionNode {
 			}                                # End of shorthand syntax
 		)/x';
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @param string $expression
-	 * @param array $matches
-	 * @return integer|float
-	 */
-	public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches) {
-		$expression = trim($expression, '{}');
-		list ($variable, $type) = explode(' as ', $expression);
-		$variable = static::getTemplateVariableOrValueItself($variable, $renderingContext);
-		if (!in_array($type, self::$validTypes)) {
-			$type = static::getTemplateVariableOrValueItself($type, $renderingContext);
-		}
-		if (!in_array($type, self::$validTypes)) {
-			throw new ExpressionException(
-			    sprintf(
-			        'Invalid target conversion type "%s" specified in casting expression',
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @param string $expression
+     * @param array $matches
+     * @return integer|float
+     */
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches)
+    {
+        $expression = trim($expression, '{}');
+        list ($variable, $type) = explode(' as ', $expression);
+        $variable = static::getTemplateVariableOrValueItself($variable, $renderingContext);
+        if (!in_array($type, self::$validTypes)) {
+            $type = static::getTemplateVariableOrValueItself($type, $renderingContext);
+        }
+        if (!in_array($type, self::$validTypes)) {
+            throw new ExpressionException(
+                sprintf(
+                    'Invalid target conversion type "%s" specified in casting expression',
                     $type
                 )
             );
-		}
-		return self::convert($variable, $type);
-	}
+        }
+        return self::convert($variable, $type);
+    }
 
-	/**
-	 * @param mixed $variable
-	 * @param string $type
-	 * @return mixed
-	 */
-	protected static function convert($variable, $type) {
-		$value = NULL;
-		if ($type === 'integer') {
-			$value = (integer) $variable;
-		} elseif ($type === 'boolean') {
-			$value = (boolean) $variable;
-		} elseif ($type === 'string') {
-			$value = (string) $variable;
-		} elseif ($type === 'float') {
-			$value = (float) $variable;
-		} elseif ($type === 'DateTime') {
-			$value = self::convertToDateTime($variable);
-		} elseif ($type === 'array') {
-			$value = (array) self::convertToArray($variable);
-		}
-		return $value;
-	}
+    /**
+     * @param mixed $variable
+     * @param string $type
+     * @return mixed
+     */
+    protected static function convert($variable, $type)
+    {
+        $value = null;
+        if ($type === 'integer') {
+            $value = (integer) $variable;
+        } elseif ($type === 'boolean') {
+            $value = (boolean) $variable;
+        } elseif ($type === 'string') {
+            $value = (string) $variable;
+        } elseif ($type === 'float') {
+            $value = (float) $variable;
+        } elseif ($type === 'DateTime') {
+            $value = self::convertToDateTime($variable);
+        } elseif ($type === 'array') {
+            $value = (array) self::convertToArray($variable);
+        }
+        return $value;
+    }
 
-	/**
-	 * @param mixed $variable
-	 * @return \DateTime|false
-	 */
-	protected static function convertToDateTime($variable) {
-		if (preg_match_all('/[a-z]+/i', $variable)) {
-			return new \DateTime($variable);
-		}
-		return \DateTime::createFromFormat('U', (integer) $variable);
-	}
+    /**
+     * @param mixed $variable
+     * @return \DateTime|false
+     */
+    protected static function convertToDateTime($variable)
+    {
+        if (preg_match_all('/[a-z]+/i', $variable)) {
+            return new \DateTime($variable);
+        }
+        return \DateTime::createFromFormat('U', (integer) $variable);
+    }
 
-	/**
-	 * @param mixed $variable
-	 * @return array
-	 */
-	protected static function convertToArray($variable) {
-		if (is_array($variable)) {
-			return $variable;
-		} elseif (is_string($variable) && strpos($variable, ',')) {
-			return array_map('trim', explode(',', $variable));
-		} elseif (is_object($variable) && $variable instanceof \Iterator) {
-			$array = array();
-			foreach ($variable as $key => $value) {
-				$array[$key] = $value;
-			}
-			return $array;
-		} elseif (is_object($variable) && method_exists($variable, 'toArray')) {
-			return $variable->toArray();
-		} elseif (is_bool($variable)) {
-			return array();
-		} else {
-			return array($variable);
-		}
-	}
-
+    /**
+     * @param mixed $variable
+     * @return array
+     */
+    protected static function convertToArray($variable)
+    {
+        if (is_array($variable)) {
+            return $variable;
+        } elseif (is_string($variable) && strpos($variable, ',')) {
+            return array_map('trim', explode(',', $variable));
+        } elseif (is_object($variable) && $variable instanceof \Iterator) {
+            $array = [];
+            foreach ($variable as $key => $value) {
+                $array[$key] = $value;
+            }
+            return $array;
+        } elseif (is_object($variable) && method_exists($variable, 'toArray')) {
+            return $variable->toArray();
+        } elseif (is_bool($variable)) {
+            return [];
+        } else {
+            return [$variable];
+        }
+    }
 }

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
@@ -11,5 +11,6 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
  *
  * @api
  */
-class ExpressionException extends \TYPO3Fluid\Fluid\Core\Exception {
+class ExpressionException extends \TYPO3Fluid\Fluid\Core\Exception
+{
 }

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
@@ -13,55 +13,55 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Interface for shorthand expression node types
  */
-interface ExpressionNodeInterface extends NodeInterface {
+interface ExpressionNodeInterface extends NodeInterface
+{
 
-	/**
-	 * Evaluates the expression by delegating it to the
-	 * resolved ExpressionNode type.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext);
+    /**
+     * Evaluates the expression by delegating it to the
+     * resolved ExpressionNode type.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public function evaluate(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Evaluate expression, static version. Should return
-	 * the exact same value as evaluate() but should be
-	 * able to do so in a statically called context.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @param string $expression
-	 * @param array $matches
-	 * @return mixed
-	 */
-	public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches);
+    /**
+     * Evaluate expression, static version. Should return
+     * the exact same value as evaluate() but should be
+     * able to do so in a statically called context.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @param string $expression
+     * @param array $matches
+     * @return mixed
+     */
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches);
 
-	/**
-	 * Compiles the ExpressionNode, returning an array with
-	 * exactly two keys which contain strings:
-	 *
-	 * - "initialization" which contains variable initializations
-	 * - "execution" which contains the execution (that uses the variables)
-	 *
-	 * The expression and matches can be read from the local
-	 * instance - and the RenderingContext and other APIs
-	 * can be accessed via the TemplateCompiler.
-	 *
-	 * @param TemplateCompiler $templateCompiler
-	 * @return array
-	 */
-	public function compile(TemplateCompiler $templateCompiler);
+    /**
+     * Compiles the ExpressionNode, returning an array with
+     * exactly two keys which contain strings:
+     *
+     * - "initialization" which contains variable initializations
+     * - "execution" which contains the execution (that uses the variables)
+     *
+     * The expression and matches can be read from the local
+     * instance - and the RenderingContext and other APIs
+     * can be accessed via the TemplateCompiler.
+     *
+     * @param TemplateCompiler $templateCompiler
+     * @return array
+     */
+    public function compile(TemplateCompiler $templateCompiler);
 
-	/**
-	 * Getter for returning the expression before parsing.
-	 *
-	 * @return string
-	 */
-	public function getExpression();
+    /**
+     * Getter for returning the expression before parsing.
+     *
+     * @return string
+     */
+    public function getExpression();
 
-	/**
-	 * @return array
-	 */
-	public function getMatches();
-
+    /**
+     * @return array
+     */
+    public function getMatches();
 }

--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -12,16 +12,17 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Math Expression Syntax Node - is a container for numeric values.
  */
-class MathExpressionNode extends AbstractExpressionNode {
+class MathExpressionNode extends AbstractExpressionNode
+{
 
-	/**
-	 * Pattern which detects the mathematical expressions with either
-	 * object accessor expressions or numbers on left and right hand
-	 * side of a mathematical operator inside curly braces, e.g.:
-	 *
-	 * {variable * 10}, {100 / variable}, {variable + variable2} etc.
-	 */
-	public static $detectionExpression = '/
+    /**
+     * Pattern which detects the mathematical expressions with either
+     * object accessor expressions or numbers on left and right hand
+     * side of a mathematical operator inside curly braces, e.g.:
+     *
+     * {variable * 10}, {100 / variable}, {variable + variable2} etc.
+     */
+    public static $detectionExpression = '/
 		(
 			{                                # Start of shorthand syntax
 				(?:                          # Math expression is composed of...
@@ -31,56 +32,57 @@ class MathExpressionNode extends AbstractExpressionNode {
 			}                                # End of shorthand syntax
 		)/x';
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @param string $expression
-	 * @param array $matches
-	 * @return integer|float
-	 */
-	public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches) {
-		// Split the expression on all recognized operators
-		$matches = array();
-		preg_match_all('/([+\-*\^\/\%]|[a-z0-9\.]+)/s', $expression, $matches);
-		$matches[0] = array_map('trim', $matches[0]);
-		// Like the BooleanNode, we dumb down the processing logic to not apply
-		// any special precedence on the priority of operators. We simply process
-		// them in order.
-		$result = array_shift($matches[0]);
-		$result = static::getTemplateVariableOrValueItself($result, $renderingContext);
-		$operator = NULL;
-		$operators = array('*', '^', '-', '+', '/', '%');
-		foreach ($matches[0] as $part) {
-			if (in_array($part, $operators)) {
-				$operator = $part;
-			} else {
-				$part = static::getTemplateVariableOrValueItself($part, $renderingContext);
-				$result = self::evaluateOperation($result, $operator, $part);
-			}
-		}
-		return $result;
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @param string $expression
+     * @param array $matches
+     * @return integer|float
+     */
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches)
+    {
+        // Split the expression on all recognized operators
+        $matches = [];
+        preg_match_all('/([+\-*\^\/\%]|[a-z0-9\.]+)/s', $expression, $matches);
+        $matches[0] = array_map('trim', $matches[0]);
+        // Like the BooleanNode, we dumb down the processing logic to not apply
+        // any special precedence on the priority of operators. We simply process
+        // them in order.
+        $result = array_shift($matches[0]);
+        $result = static::getTemplateVariableOrValueItself($result, $renderingContext);
+        $operator = null;
+        $operators = ['*', '^', '-', '+', '/', '%'];
+        foreach ($matches[0] as $part) {
+            if (in_array($part, $operators)) {
+                $operator = $part;
+            } else {
+                $part = static::getTemplateVariableOrValueItself($part, $renderingContext);
+                $result = self::evaluateOperation($result, $operator, $part);
+            }
+        }
+        return $result;
+    }
 
-	/**
-	 * @param integer|float $left
-	 * @param string $operator
-	 * @param integer|float $right
-	 * @return integer|float
-	 */
-	protected static function evaluateOperation($left, $operator, $right) {
-		if ($operator === '%') {
-			return $left % $right;
-		} elseif ($operator === '-') {
-			return $left - $right;
-		} elseif ($operator === '+') {
-			return $left + $right;
-		} elseif ($operator === '*') {
-			return $left * $right;
-		} elseif ($operator === '/') {
-			return (integer) $right !== 0 ? $left / $right : 0;
-		} elseif ($operator === '^') {
-			return pow($left, $right);
-		}
-		return 0;
-	}
-
+    /**
+     * @param integer|float $left
+     * @param string $operator
+     * @param integer|float $right
+     * @return integer|float
+     */
+    protected static function evaluateOperation($left, $operator, $right)
+    {
+        if ($operator === '%') {
+            return $left % $right;
+        } elseif ($operator === '-') {
+            return $left - $right;
+        } elseif ($operator === '+') {
+            return $left + $right;
+        } elseif ($operator === '*') {
+            return $left * $right;
+        } elseif ($operator === '/') {
+            return (integer) $right !== 0 ? $left / $right : 0;
+        } elseif ($operator === '^') {
+            return pow($left, $right);
+        }
+        return 0;
+    }
 }

--- a/src/Core/Parser/SyntaxTree/NodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/NodeInterface.php
@@ -11,36 +11,37 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Node in the syntax tree.
  */
-interface NodeInterface {
+interface NodeInterface
+{
 
-	/**
-	 * Evaluate all child nodes and return the evaluated results.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed Normally, an object is returned - in case it is concatenated with a string, a string is returned.
-	 */
-	public function evaluateChildNodes(RenderingContextInterface $renderingContext);
+    /**
+     * Evaluate all child nodes and return the evaluated results.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed Normally, an object is returned - in case it is concatenated with a string, a string is returned.
+     */
+    public function evaluateChildNodes(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Returns all child nodes for a given node.
-	 *
-	 * @return array<\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface> A list of nodes
-	 */
-	public function getChildNodes();
+    /**
+     * Returns all child nodes for a given node.
+     *
+     * @return array<\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface> A list of nodes
+     */
+    public function getChildNodes();
 
-	/**
-	 * Appends a sub node to this node. Is used inside the parser to append children
-	 *
-	 * @param NodeInterface $childNode The sub node to add
-	 * @return void
-	 */
-	public function addChildNode(NodeInterface $childNode);
+    /**
+     * Appends a sub node to this node. Is used inside the parser to append children
+     *
+     * @param NodeInterface $childNode The sub node to add
+     * @return void
+     */
+    public function addChildNode(NodeInterface $childNode);
 
-	/**
-	 * Evaluates the node - can return not only strings, but arbitary objects.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed Evaluated node
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext);
+    /**
+     * Evaluates the node - can return not only strings, but arbitary objects.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed Evaluated node
+     */
+    public function evaluate(RenderingContextInterface $renderingContext);
 }

--- a/src/Core/Parser/SyntaxTree/NumericNode.php
+++ b/src/Core/Parser/SyntaxTree/NumericNode.php
@@ -12,54 +12,59 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Numeric Syntax Tree Node - is a container for numeric values.
  */
-class NumericNode extends AbstractNode {
+class NumericNode extends AbstractNode
+{
 
-	/**
-	 * Contents of the numeric node
-	 * @var number
-	 */
-	protected $value;
+    /**
+     * Contents of the numeric node
+     * @var number
+     */
+    protected $value;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param string|number $value value to store in this numericNode
-	 * @throws Parser\Exception
-	 */
-	public function __construct($value) {
-		if (!is_numeric($value)) {
-			throw new Parser\Exception('Numeric node requires an argument of type number, "' . gettype($value) . '" given.');
-		}
-		$this->value = $value + 0;
-	}
+    /**
+     * Constructor.
+     *
+     * @param string|number $value value to store in this numericNode
+     * @throws Parser\Exception
+     */
+    public function __construct($value)
+    {
+        if (!is_numeric($value)) {
+            throw new Parser\Exception('Numeric node requires an argument of type number, "' . gettype($value) . '" given.');
+        }
+        $this->value = $value + 0;
+    }
 
-	/**
-	 * Return the value associated to the syntax tree.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return number the value stored in this node/subtree.
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return $this->value;
-	}
+    /**
+     * Return the value associated to the syntax tree.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return number the value stored in this node/subtree.
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return $this->value;
+    }
 
-	/**
-	 * Getter for value
-	 *
-	 * @return number The value of this node
-	 */
-	public function getValue() {
-		return $this->value;
-	}
+    /**
+     * Getter for value
+     *
+     * @return number The value of this node
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
 
-	/**
-	 * NumericNode does not allow adding child nodes, so this will always throw an exception.
-	 *
-	 * @param NodeInterface $childNode The sub node to add
-	 * @throws Parser\Exception
-	 * @return void
-	 */
-	public function addChildNode(NodeInterface $childNode) {
-		throw new Parser\Exception('Numeric nodes may not contain child nodes, tried to add "' . get_class($childNode) . '".');
-	}
+    /**
+     * NumericNode does not allow adding child nodes, so this will always throw an exception.
+     *
+     * @param NodeInterface $childNode The sub node to add
+     * @throws Parser\Exception
+     * @return void
+     */
+    public function addChildNode(NodeInterface $childNode)
+    {
+        throw new Parser\Exception('Numeric nodes may not contain child nodes, tried to add "' . get_class($childNode) . '".');
+    }
 }

--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -12,74 +12,78 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 /**
  * A node which handles object access. This means it handles structures like {object.accessor.bla}
  */
-class ObjectAccessorNode extends AbstractNode {
+class ObjectAccessorNode extends AbstractNode
+{
 
-	/**
-	 * Object path which will be called. Is a list like "post.name.email"
-	 *
-	 * @var string
-	 */
-	protected $objectPath;
+    /**
+     * Object path which will be called. Is a list like "post.name.email"
+     *
+     * @var string
+     */
+    protected $objectPath;
 
-	/**
-	 * Accessor names, one per segment in the object path. Use constants from VariableExtractor
-	 *
-	 * @var array
-	 */
-	protected $accessors = array();
+    /**
+     * Accessor names, one per segment in the object path. Use constants from VariableExtractor
+     *
+     * @var array
+     */
+    protected $accessors = [];
 
-	/**
-	 * Constructor. Takes an object path as input.
-	 *
-	 * The first part of the object path has to be a variable in the
-	 * VariableProvider.
-	 *
-	 * @param string $objectPath An Object Path, like object1.object2.object3
-	 * @param array $accessors Optional list of accessor strategies; starting from beginning of dotted path. Incomplete allowed.
-	 */
-	public function __construct($objectPath, array $accessors = array()) {
-		$this->objectPath = $objectPath;
-		$this->accessors = $accessors;
-	}
+    /**
+     * Constructor. Takes an object path as input.
+     *
+     * The first part of the object path has to be a variable in the
+     * VariableProvider.
+     *
+     * @param string $objectPath An Object Path, like object1.object2.object3
+     * @param array $accessors Optional list of accessor strategies; starting from beginning of dotted path. Incomplete allowed.
+     */
+    public function __construct($objectPath, array $accessors = [])
+    {
+        $this->objectPath = $objectPath;
+        $this->accessors = $accessors;
+    }
 
 
-	/**
-	 * Internally used for building up cached templates; do not use directly!
-	 *
-	 * @return string
-	 */
-	public function getObjectPath() {
-		return $this->objectPath;
-	}
+    /**
+     * Internally used for building up cached templates; do not use directly!
+     *
+     * @return string
+     */
+    public function getObjectPath()
+    {
+        return $this->objectPath;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAccessors() {
-		return $this->accessors;
-	}
+    /**
+     * @return array
+     */
+    public function getAccessors()
+    {
+        return $this->accessors;
+    }
 
-	/**
-	 * Evaluate this node and return the correct object.
-	 *
-	 * Handles each part (denoted by .) in $this->objectPath in the following order:
-	 * - call appropriate getter
-	 * - call public property, if exists
-	 * - fail
-	 *
-	 * The first part of the object path has to be a variable in the
-	 * VariableProvider.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return object The evaluated object, can be any object type.
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
+    /**
+     * Evaluate this node and return the correct object.
+     *
+     * Handles each part (denoted by .) in $this->objectPath in the following order:
+     * - call appropriate getter
+     * - call public property, if exists
+     * - fail
+     *
+     * The first part of the object path has to be a variable in the
+     * VariableProvider.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return object The evaluated object, can be any object type.
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
         $objectPath = strtolower($this->objectPath);
         $variableProvider = $renderingContext->getVariableProvider();
         if ($objectPath === '_all') {
             return $variableProvider->getAll();
         }
         return VariableExtractor::extract($variableProvider, $this->objectPath, $this->accessors);
-	}
-
+    }
 }

--- a/src/Core/Parser/SyntaxTree/RootNode.php
+++ b/src/Core/Parser/SyntaxTree/RootNode.php
@@ -11,15 +11,17 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Root node of every syntax tree.
  */
-class RootNode extends AbstractNode {
+class RootNode extends AbstractNode
+{
 
-	/**
-	 * Evaluate the root node, by evaluating the subtree.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed Evaluated subtree
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return $this->evaluateChildNodes($renderingContext);
-	}
+    /**
+     * Evaluate the root node, by evaluating the subtree.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed Evaluated subtree
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return $this->evaluateChildNodes($renderingContext);
+    }
 }

--- a/src/Core/Parser/SyntaxTree/TextNode.php
+++ b/src/Core/Parser/SyntaxTree/TextNode.php
@@ -12,53 +12,57 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Text Syntax Tree Node - is a container for strings.
  */
-class TextNode extends AbstractNode {
+class TextNode extends AbstractNode
+{
 
-	/**
-	 * Contents of the text node
-	 *
-	 * @var string
-	 */
-	protected $text;
+    /**
+     * Contents of the text node
+     *
+     * @var string
+     */
+    protected $text;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param string $text text to store in this textNode
-	 * @throws Parser\Exception
-	 */
-	public function __construct($text) {
-		if (!is_string($text)) {
-			throw new Parser\Exception('Text node requires an argument of type string, "' . gettype($text) . '" given.');
-		}
-		$this->text = $text;
-	}
+    /**
+     * Constructor.
+     *
+     * @param string $text text to store in this textNode
+     * @throws Parser\Exception
+     */
+    public function __construct($text)
+    {
+        if (!is_string($text)) {
+            throw new Parser\Exception('Text node requires an argument of type string, "' . gettype($text) . '" given.');
+        }
+        $this->text = $text;
+    }
 
-	/**
-	 * Return the text associated to the syntax tree. Text from child nodes is
-	 * appended to the text in the node's own text.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string the text stored in this node/subtree.
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return $this->text;
-	}
+    /**
+     * Return the text associated to the syntax tree. Text from child nodes is
+     * appended to the text in the node's own text.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return string the text stored in this node/subtree.
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return $this->text;
+    }
 
-	/**
-	 * Getter for text
-	 *
-	 * @return string The text of this node
-	 */
-	public function getText() {
-		return $this->text;
-	}
+    /**
+     * Getter for text
+     *
+     * @return string The text of this node
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function __toString() {
-		return $this->getText();
-	}
-
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getText();
+    }
 }

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -15,188 +15,200 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 /**
  * Node which will call a ViewHelper associated with this node.
  */
-class ViewHelperNode extends AbstractNode {
+class ViewHelperNode extends AbstractNode
+{
 
-	/**
-	 * @var string
-	 */
-	protected $viewHelperClassName;
+    /**
+     * @var string
+     */
+    protected $viewHelperClassName;
 
-	/**
-	 * @var NodeInterface[]
-	 */
-	protected $arguments = array();
+    /**
+     * @var NodeInterface[]
+     */
+    protected $arguments = [];
 
-	/**
-	 * @var ViewHelperInterface
-	 */
-	protected $uninitializedViewHelper = NULL;
+    /**
+     * @var ViewHelperInterface
+     */
+    protected $uninitializedViewHelper = null;
 
-	/**
-	 * @var ArgumentDefinition[]
-	 */
-	protected $argumentDefinitions = array();
+    /**
+     * @var ArgumentDefinition[]
+     */
+    protected $argumentDefinitions = [];
 
-	/**
-	 * @var string
-	 */
-	protected $pointerTemplateCode = NULL;
+    /**
+     * @var string
+     */
+    protected $pointerTemplateCode = null;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param RenderingContextInterface $renderingContext a RenderingContext, provided by invoker
-	 * @param string $namespace the namespace identifier of the ViewHelper.
-	 * @param string $identifier the name of the ViewHelper to render, inside the namespace provided.
-	 * @param NodeInterface[] $arguments Arguments of view helper - each value is a RootNode.
-	 * @param ParsingState $state
-	 */
-	public function __construct(RenderingContextInterface $renderingContext, $namespace, $identifier, array $arguments, ParsingState $state) {
-		$resolver = $renderingContext->getViewHelperResolver();
-		$this->arguments = $arguments;
-		$this->viewHelperClassName = $resolver->resolveViewHelperClassName($namespace, $identifier);
-		$this->uninitializedViewHelper = $resolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
-		$this->uninitializedViewHelper->setViewHelperNode($this);
-		// Note: RenderingContext required here though replaced later. See https://github.com/TYPO3Fluid/Fluid/pull/93
-		$this->uninitializedViewHelper->setRenderingContext($renderingContext);
-		$this->argumentDefinitions = $resolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
-		$this->rewriteBooleanNodesInArgumentsObjectTree($this->argumentDefinitions, $this->arguments);
-		$this->validateArguments($this->argumentDefinitions, $this->arguments);
-	}
+    /**
+     * Constructor.
+     *
+     * @param RenderingContextInterface $renderingContext a RenderingContext, provided by invoker
+     * @param string $namespace the namespace identifier of the ViewHelper.
+     * @param string $identifier the name of the ViewHelper to render, inside the namespace provided.
+     * @param NodeInterface[] $arguments Arguments of view helper - each value is a RootNode.
+     * @param ParsingState $state
+     */
+    public function __construct(RenderingContextInterface $renderingContext, $namespace, $identifier, array $arguments, ParsingState $state)
+    {
+        $resolver = $renderingContext->getViewHelperResolver();
+        $this->arguments = $arguments;
+        $this->viewHelperClassName = $resolver->resolveViewHelperClassName($namespace, $identifier);
+        $this->uninitializedViewHelper = $resolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
+        $this->uninitializedViewHelper->setViewHelperNode($this);
+        // Note: RenderingContext required here though replaced later. See https://github.com/TYPO3Fluid/Fluid/pull/93
+        $this->uninitializedViewHelper->setRenderingContext($renderingContext);
+        $this->argumentDefinitions = $resolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
+        $this->rewriteBooleanNodesInArgumentsObjectTree($this->argumentDefinitions, $this->arguments);
+        $this->validateArguments($this->argumentDefinitions, $this->arguments);
+    }
 
-	/**
-	 * @return ArgumentDefinition[]
-	 */
-	public function getArgumentDefinitions() {
-		return $this->argumentDefinitions;
-	}
+    /**
+     * @return ArgumentDefinition[]
+     */
+    public function getArgumentDefinitions()
+    {
+        return $this->argumentDefinitions;
+    }
 
-	/**
-	 * Returns the attached (but still uninitialized) ViewHelper for this ViewHelperNode.
-	 * We need this method because sometimes Interceptors need to ask some information from the ViewHelper.
-	 *
-	 * @return ViewHelperInterface
-	 */
-	public function getUninitializedViewHelper() {
-		return $this->uninitializedViewHelper;
-	}
+    /**
+     * Returns the attached (but still uninitialized) ViewHelper for this ViewHelperNode.
+     * We need this method because sometimes Interceptors need to ask some information from the ViewHelper.
+     *
+     * @return ViewHelperInterface
+     */
+    public function getUninitializedViewHelper()
+    {
+        return $this->uninitializedViewHelper;
+    }
 
-	/**
-	 * Get class name of view helper
-	 *
-	 * @return string Class Name of associated view helper
-	 */
-	public function getViewHelperClassName() {
-		return $this->viewHelperClassName;
-	}
+    /**
+     * Get class name of view helper
+     *
+     * @return string Class Name of associated view helper
+     */
+    public function getViewHelperClassName()
+    {
+        return $this->viewHelperClassName;
+    }
 
-	/**
-	 * INTERNAL - only needed for compiling templates
-	 *
-	 * @return NodeInterface[]
-	 */
-	public function getArguments() {
-		return $this->arguments;
-	}
+    /**
+     * INTERNAL - only needed for compiling templates
+     *
+     * @return NodeInterface[]
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
 
-	/**
-	 * INTERNAL - only needed for compiling templates
-	 *
-	 * @param string $argumentName
-	 * @return ArgumentDefinition
-	 */
-	public function getArgumentDefinition($argumentName) {
-		return $this->argumentDefinitions[$argumentName];
-	}
+    /**
+     * INTERNAL - only needed for compiling templates
+     *
+     * @param string $argumentName
+     * @return ArgumentDefinition
+     */
+    public function getArgumentDefinition($argumentName)
+    {
+        return $this->argumentDefinitions[$argumentName];
+    }
 
-	/**
-	 * @param NodeInterface $childNode
-	 * @return void
-	 */
-	public function addChildNode(NodeInterface $childNode) {
-		parent::addChildNode($childNode);
-		$this->uninitializedViewHelper->setChildNodes($this->childNodes);
-	}
+    /**
+     * @param NodeInterface $childNode
+     * @return void
+     */
+    public function addChildNode(NodeInterface $childNode)
+    {
+        parent::addChildNode($childNode);
+        $this->uninitializedViewHelper->setChildNodes($this->childNodes);
+    }
 
-	/**
-	 * @param string $pointerTemplateCode
-	 * @return void
-	 */
-	public function setPointerTemplateCode($pointerTemplateCode) {
-		$this->pointerTemplateCode = $pointerTemplateCode;
-	}
+    /**
+     * @param string $pointerTemplateCode
+     * @return void
+     */
+    public function setPointerTemplateCode($pointerTemplateCode)
+    {
+        $this->pointerTemplateCode = $pointerTemplateCode;
+    }
 
-	/**
-	 * Call the view helper associated with this object.
-	 *
-	 * First, it evaluates the arguments of the view helper.
-	 *
-	 * If the view helper implements \TYPO3Fluid\Fluid\Core\ViewHelper\ChildNodeAccessInterface,
-	 * it calls setChildNodes(array childNodes) on the view helper.
-	 *
-	 * Afterwards, checks that the view helper did not leave a variable lying around.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string evaluated node after the view helper has been called.
-	 */
-	public function evaluate(RenderingContextInterface $renderingContext) {
-		return $renderingContext->getViewHelperInvoker()->invoke($this->uninitializedViewHelper, $this->arguments, $renderingContext);
-	}
+    /**
+     * Call the view helper associated with this object.
+     *
+     * First, it evaluates the arguments of the view helper.
+     *
+     * If the view helper implements \TYPO3Fluid\Fluid\Core\ViewHelper\ChildNodeAccessInterface,
+     * it calls setChildNodes(array childNodes) on the view helper.
+     *
+     * Afterwards, checks that the view helper did not leave a variable lying around.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return string evaluated node after the view helper has been called.
+     */
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        return $renderingContext->getViewHelperInvoker()->invoke($this->uninitializedViewHelper, $this->arguments, $renderingContext);
+    }
 
-	/**
-	 * Wraps the argument tree, if a node is boolean, into a Boolean syntax tree node
-	 *
-	 * @param ArgumentDefinition[] $argumentDefinitions the argument definitions, key is the argument name, value is the ArgumentDefinition object
-	 * @param NodeInterface[] $argumentsObjectTree the arguments syntax tree, key is the argument name, value is an AbstractNode
-	 * @return void
-	 */
-	protected function rewriteBooleanNodesInArgumentsObjectTree($argumentDefinitions, &$argumentsObjectTree) {
-		/** @var $argumentDefinition ArgumentDefinition */
-		foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
-			if ($argumentDefinition->getType() === 'boolean' && isset($argumentsObjectTree[$argumentName])) {
-				$argumentsObjectTree[$argumentName] = new BooleanNode($argumentsObjectTree[$argumentName]);
-			}
-		}
-	}
+    /**
+     * Wraps the argument tree, if a node is boolean, into a Boolean syntax tree node
+     *
+     * @param ArgumentDefinition[] $argumentDefinitions the argument definitions, key is the argument name, value is the ArgumentDefinition object
+     * @param NodeInterface[] $argumentsObjectTree the arguments syntax tree, key is the argument name, value is an AbstractNode
+     * @return void
+     */
+    protected function rewriteBooleanNodesInArgumentsObjectTree($argumentDefinitions, &$argumentsObjectTree)
+    {
+        /** @var $argumentDefinition ArgumentDefinition */
+        foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
+            if ($argumentDefinition->getType() === 'boolean' && isset($argumentsObjectTree[$argumentName])) {
+                $argumentsObjectTree[$argumentName] = new BooleanNode($argumentsObjectTree[$argumentName]);
+            }
+        }
+    }
 
-	/**
-	 * @param ArgumentDefinition[] $argumentDefinitions
-	 * @param NodeInterface[] $argumentsObjectTree
-	 * @throws Exception
-	 */
-	protected function validateArguments(array $argumentDefinitions, array $argumentsObjectTree) {
-		$additionalArguments = array();
-		foreach ($argumentsObjectTree as $argumentName => $value) {
-			if (!array_key_exists($argumentName, $argumentDefinitions)) {
-				$additionalArguments[$argumentName] = $value;
-			}
-		}
-		foreach ($argumentDefinitions as $argumentDefinition) {
-			if ($argumentDefinition->isRequired() && $argumentDefinition->getDefaultValue() === NULL) {
-				$name = $argumentDefinition->getName();
-				if (!array_key_exists($name, $argumentsObjectTree)) {
-					throw new Exception(sprintf('Required argument %s for ViewHelper %s was not provided', $name, $this->viewHelperClassName));
-				}
-			}
-		}
-		$this->abortIfRequiredArgumentsAreMissing($argumentDefinitions, $argumentsObjectTree);
-		$this->uninitializedViewHelper->validateAdditionalArguments($additionalArguments);
-	}
+    /**
+     * @param ArgumentDefinition[] $argumentDefinitions
+     * @param NodeInterface[] $argumentsObjectTree
+     * @throws Exception
+     */
+    protected function validateArguments(array $argumentDefinitions, array $argumentsObjectTree)
+    {
+        $additionalArguments = [];
+        foreach ($argumentsObjectTree as $argumentName => $value) {
+            if (!array_key_exists($argumentName, $argumentDefinitions)) {
+                $additionalArguments[$argumentName] = $value;
+            }
+        }
+        foreach ($argumentDefinitions as $argumentDefinition) {
+            if ($argumentDefinition->isRequired() && $argumentDefinition->getDefaultValue() === null) {
+                $name = $argumentDefinition->getName();
+                if (!array_key_exists($name, $argumentsObjectTree)) {
+                    throw new Exception(sprintf('Required argument %s for ViewHelper %s was not provided', $name, $this->viewHelperClassName));
+                }
+            }
+        }
+        $this->abortIfRequiredArgumentsAreMissing($argumentDefinitions, $argumentsObjectTree);
+        $this->uninitializedViewHelper->validateAdditionalArguments($additionalArguments);
+    }
 
-	/**
-	 * Throw an exception if required arguments are missing
-	 *
-	 * @param ArgumentDefinition[] $expectedArguments Array of all expected arguments
-	 * @param NodeInterface[] $actualArguments Actual arguments
-	 * @throws Exception
-	 */
-	protected function abortIfRequiredArgumentsAreMissing($expectedArguments, $actualArguments) {
-		$actualArgumentNames = array_keys($actualArguments);
-		foreach ($expectedArguments as $expectedArgument) {
-			if ($expectedArgument->isRequired() && !in_array($expectedArgument->getName(), $actualArgumentNames)) {
-				throw new Exception('Required argument "' . $expectedArgument->getName() . '" was not supplied.', 1237823699);
-			}
-		}
-	}
-
+    /**
+     * Throw an exception if required arguments are missing
+     *
+     * @param ArgumentDefinition[] $expectedArguments Array of all expected arguments
+     * @param NodeInterface[] $actualArguments Actual arguments
+     * @throws Exception
+     */
+    protected function abortIfRequiredArgumentsAreMissing($expectedArguments, $actualArguments)
+    {
+        $actualArgumentNames = array_keys($actualArguments);
+        foreach ($expectedArguments as $expectedArgument) {
+            if ($expectedArgument->isRequired() && !in_array($expectedArgument->getName(), $actualArgumentNames)) {
+                throw new Exception('Required argument "' . $expectedArgument->getName() . '" was not supplied.', 1237823699);
+            }
+        }
+    }
 }

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -25,659 +25,681 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 /**
  * Template parser building up an object syntax tree
  */
-class TemplateParser {
+class TemplateParser
+{
 
-	/**
-	 * The following two constants are used for tracking whether we are currently
-	 * parsing ViewHelper arguments or not. This is used to parse arrays only as
-	 * ViewHelper argument.
-	 */
-	const CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS = 1;
-	const CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS = 2;
+    /**
+     * The following two constants are used for tracking whether we are currently
+     * parsing ViewHelper arguments or not. This is used to parse arrays only as
+     * ViewHelper argument.
+     */
+    const CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS = 1;
+    const CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS = 2;
 
-	/**
-	 * Whether or not the escaping interceptors are active
-	 *
-	 * @var boolean
-	 */
-	protected $escapingEnabled = TRUE;
+    /**
+     * Whether or not the escaping interceptors are active
+     *
+     * @var boolean
+     */
+    protected $escapingEnabled = true;
 
-	/**
-	 * @var Configuration
-	 */
-	protected $configuration;
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
 
-	/**
-	 * @var array
-	 */
-	protected $settings;
+    /**
+     * @var array
+     */
+    protected $settings;
 
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
 
-	/**
-	 * @var integer
-	 */
-	protected $pointerLineNumber = 1;
+    /**
+     * @var integer
+     */
+    protected $pointerLineNumber = 1;
 
-	/**
-	 * @var integer
-	 */
-	protected $pointerLineCharacter = 1;
+    /**
+     * @var integer
+     */
+    protected $pointerLineCharacter = 1;
 
-	/**
-	 * @var string
-	 */
-	protected $pointerTemplateCode = NULL;
+    /**
+     * @var string
+     */
+    protected $pointerTemplateCode = null;
 
-	/**
-	 * @var ParsedTemplateInterface[]
-	 */
-	protected $parsedTemplates = array();
+    /**
+     * @var ParsedTemplateInterface[]
+     */
+    protected $parsedTemplates = [];
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext) {
-		$this->renderingContext = $renderingContext;
-		$this->configuration = $renderingContext->buildParserConfiguration();
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        $this->renderingContext = $renderingContext;
+        $this->configuration = $renderingContext->buildParserConfiguration();
+    }
 
-	/**
-	 * Returns an array of current line number, character in line and reference template code;
-	 * for extraction when catching parser-related Exceptions during parsing.
-	 *
-	 * @return array
-	 */
-	public function getCurrentParsingPointers() {
-		return array($this->pointerLineNumber, $this->pointerLineCharacter, $this->pointerTemplateCode);
-	}
+    /**
+     * Returns an array of current line number, character in line and reference template code;
+     * for extraction when catching parser-related Exceptions during parsing.
+     *
+     * @return array
+     */
+    public function getCurrentParsingPointers()
+    {
+        return [$this->pointerLineNumber, $this->pointerLineCharacter, $this->pointerTemplateCode];
+    }
 
-	/**
-	 * Parses a given template string and returns a parsed template object.
-	 *
-	 * The resulting ParsedTemplate can then be rendered by calling evaluate() on it.
-	 *
-	 * Normally, you should use a subclass of AbstractTemplateView instead of calling the
-	 * TemplateParser directly.
-	 *
-	 * @param string $templateString The template to parse as a string
-	 * @param string|null $templateIdentifier If the template has an identifying string it can be passed here to improve error reporting.
-	 * @return ParsedTemplateInterface Parsed template
-	 * @throws Exception
-	 */
-	public function parse($templateString, $templateIdentifier = NULL) {
-		if (!is_string($templateString)) {
-			throw new Exception('Parse requires a template string as argument, ' . gettype($templateString) . ' given.', 1224237899);
-		}
-		try {
-			$this->reset();
+    /**
+     * Parses a given template string and returns a parsed template object.
+     *
+     * The resulting ParsedTemplate can then be rendered by calling evaluate() on it.
+     *
+     * Normally, you should use a subclass of AbstractTemplateView instead of calling the
+     * TemplateParser directly.
+     *
+     * @param string $templateString The template to parse as a string
+     * @param string|null $templateIdentifier If the template has an identifying string it can be passed here to improve error reporting.
+     * @return ParsedTemplateInterface Parsed template
+     * @throws Exception
+     */
+    public function parse($templateString, $templateIdentifier = null)
+    {
+        if (!is_string($templateString)) {
+            throw new Exception('Parse requires a template string as argument, ' . gettype($templateString) . ' given.', 1224237899);
+        }
+        try {
+            $this->reset();
 
-			$templateString = $this->extractEscapingModifier($templateString);
-			$templateString = $this->preProcessTemplateSource($templateString);
+            $templateString = $this->extractEscapingModifier($templateString);
+            $templateString = $this->preProcessTemplateSource($templateString);
 
-			$splitTemplate = $this->splitTemplateAtDynamicTags($templateString);
-			$parsingState = $this->buildObjectTree($splitTemplate, self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
-		} catch (Exception $error) {
-			throw $this->createParsingRelatedExceptionWithContext($error, $templateIdentifier);
-		}
-		$this->parsedTemplates[$templateIdentifier] = $parsingState;
-		return $parsingState;
-	}
+            $splitTemplate = $this->splitTemplateAtDynamicTags($templateString);
+            $parsingState = $this->buildObjectTree($splitTemplate, self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
+        } catch (Exception $error) {
+            throw $this->createParsingRelatedExceptionWithContext($error, $templateIdentifier);
+        }
+        $this->parsedTemplates[$templateIdentifier] = $parsingState;
+        return $parsingState;
+    }
 
-	/**
-	 * @param \Exception $error
-	 * @param string $templateIdentifier
-	 * @throws \Exception
-	 */
-	public function createParsingRelatedExceptionWithContext(\Exception $error, $templateIdentifier) {
-		list ($line, $character, $templateCode) = $this->getCurrentParsingPointers();
-		$exceptionClass = get_class($error);
-		return new $exceptionClass(
-			sprintf(
-				'Fluid parse error in template %s, line %d at character %d. Error: %s (error code %d). Template source chunk: %s',
-				$templateIdentifier,
-				$line,
-				$character,
-				$error->getMessage(),
-				$error->getCode(),
-				$templateCode
-			),
-			$error->getCode(),
-			$error
-		);
-	}
+    /**
+     * @param \Exception $error
+     * @param string $templateIdentifier
+     * @throws \Exception
+     */
+    public function createParsingRelatedExceptionWithContext(\Exception $error, $templateIdentifier)
+    {
+        list ($line, $character, $templateCode) = $this->getCurrentParsingPointers();
+        $exceptionClass = get_class($error);
+        return new $exceptionClass(
+            sprintf(
+                'Fluid parse error in template %s, line %d at character %d. Error: %s (error code %d). Template source chunk: %s',
+                $templateIdentifier,
+                $line,
+                $character,
+                $error->getMessage(),
+                $error->getCode(),
+                $templateCode
+            ),
+            $error->getCode(),
+            $error
+        );
+    }
 
-	/**
-	 * @param string $templateIdentifier
-	 * @param \Closure $templateSourceClosure Closure which returns the template source if needed
-	 * @return ParsedTemplateInterface
-	 */
-	public function getOrParseAndStoreTemplate($templateIdentifier, $templateSourceClosure) {
-		$compiler = $this->renderingContext->getTemplateCompiler();
-		if (isset($this->parsedTemplates[$templateIdentifier])) {
-			$parsedTemplate = $this->parsedTemplates[$templateIdentifier];
-		} elseif ($compiler->has($templateIdentifier)) {
-			$parsedTemplate = $compiler->get($templateIdentifier);
-		} else {
-			$parsedTemplate = $this->parse(
-				$templateSourceClosure($this, $this->renderingContext->getTemplatePaths()),
-				$templateIdentifier
-			);
-			$parsedTemplate->setIdentifier($templateIdentifier);
-			$this->parsedTemplates[$templateIdentifier] = $parsedTemplate;
-			if ($parsedTemplate->isCompilable()) {
-				try {
-					$compiler->store($templateIdentifier, $parsedTemplate);
-				} catch (StopCompilingException $stop) {
-					$parsedTemplate->setCompilable(FALSE);
-					return $parsedTemplate;
-				}
-			}
-		}
-		return $parsedTemplate;
-	}
+    /**
+     * @param string $templateIdentifier
+     * @param \Closure $templateSourceClosure Closure which returns the template source if needed
+     * @return ParsedTemplateInterface
+     */
+    public function getOrParseAndStoreTemplate($templateIdentifier, $templateSourceClosure)
+    {
+        $compiler = $this->renderingContext->getTemplateCompiler();
+        if (isset($this->parsedTemplates[$templateIdentifier])) {
+            $parsedTemplate = $this->parsedTemplates[$templateIdentifier];
+        } elseif ($compiler->has($templateIdentifier)) {
+            $parsedTemplate = $compiler->get($templateIdentifier);
+        } else {
+            $parsedTemplate = $this->parse(
+                $templateSourceClosure($this, $this->renderingContext->getTemplatePaths()),
+                $templateIdentifier
+            );
+            $parsedTemplate->setIdentifier($templateIdentifier);
+            $this->parsedTemplates[$templateIdentifier] = $parsedTemplate;
+            if ($parsedTemplate->isCompilable()) {
+                try {
+                    $compiler->store($templateIdentifier, $parsedTemplate);
+                } catch (StopCompilingException $stop) {
+                    $parsedTemplate->setCompilable(false);
+                    return $parsedTemplate;
+                }
+            }
+        }
+        return $parsedTemplate;
+    }
 
-	/**
-	 * Pre-process the template source, making all registered TemplateProcessors
-	 * do what they need to do with the template source before it is parsed.
-	 *
-	 * @param string $templateSource
-	 * @return string
-	 */
-	protected function preProcessTemplateSource($templateSource) {
-		foreach ($this->renderingContext->getTemplateProcessors() as $templateProcessor) {
-			$templateSource = $templateProcessor->preProcessSource($templateSource);
-		}
-		return $templateSource;
-	}
+    /**
+     * Pre-process the template source, making all registered TemplateProcessors
+     * do what they need to do with the template source before it is parsed.
+     *
+     * @param string $templateSource
+     * @return string
+     */
+    protected function preProcessTemplateSource($templateSource)
+    {
+        foreach ($this->renderingContext->getTemplateProcessors() as $templateProcessor) {
+            $templateSource = $templateProcessor->preProcessSource($templateSource);
+        }
+        return $templateSource;
+    }
 
-	/**
-	 * Resets the parser to its default values.
-	 *
-	 * @return void
-	 */
-	protected function reset() {
-		$this->escapingEnabled = TRUE;
-		$this->pointerLineNumber = 1;
-		$this->pointerLineCharacter = 1;
-	}
+    /**
+     * Resets the parser to its default values.
+     *
+     * @return void
+     */
+    protected function reset()
+    {
+        $this->escapingEnabled = true;
+        $this->pointerLineNumber = 1;
+        $this->pointerLineCharacter = 1;
+    }
 
-	/**
-	 * Extracts escaping modifiers ({escapingEnabled=true/false}) out of the given template and sets $this->escapingEnabled accordingly
-	 *
-	 * @param string $templateString Template string to extract the {escaping = ..} definitions from
-	 * @return string The updated template string without escaping declarations inside
-	 * @throws Exception if there is more than one modifier
-	 */
-	protected function extractEscapingModifier($templateString) {
-		$matches = array();
-		preg_match_all(Patterns::$SCAN_PATTERN_ESCAPINGMODIFIER, $templateString, $matches, PREG_SET_ORDER);
-		if ($matches === array()) {
-			return $templateString;
-		}
-		if (count($matches) > 1) {
-			throw new Exception('There is more than one escaping modifier defined. There can only be one {escapingEnabled=...} per template.', 1461009874);
-		}
-		if (strtolower($matches[0]['enabled']) === 'false') {
-			$this->escapingEnabled = FALSE;
-		}
-		$templateString = preg_replace(Patterns::$SCAN_PATTERN_ESCAPINGMODIFIER, '', $templateString);
+    /**
+     * Extracts escaping modifiers ({escapingEnabled=true/false}) out of the given template and sets $this->escapingEnabled accordingly
+     *
+     * @param string $templateString Template string to extract the {escaping = ..} definitions from
+     * @return string The updated template string without escaping declarations inside
+     * @throws Exception if there is more than one modifier
+     */
+    protected function extractEscapingModifier($templateString)
+    {
+        $matches = [];
+        preg_match_all(Patterns::$SCAN_PATTERN_ESCAPINGMODIFIER, $templateString, $matches, PREG_SET_ORDER);
+        if ($matches === []) {
+            return $templateString;
+        }
+        if (count($matches) > 1) {
+            throw new Exception('There is more than one escaping modifier defined. There can only be one {escapingEnabled=...} per template.', 1461009874);
+        }
+        if (strtolower($matches[0]['enabled']) === 'false') {
+            $this->escapingEnabled = false;
+        }
+        $templateString = preg_replace(Patterns::$SCAN_PATTERN_ESCAPINGMODIFIER, '', $templateString);
 
-		return $templateString;
-	}
+        return $templateString;
+    }
 
-	/**
-	 * Splits the template string on all dynamic tags found.
-	 *
-	 * @param string $templateString Template string to split.
-	 * @return array Splitted template
-	 */
-	protected function splitTemplateAtDynamicTags($templateString) {
-		return preg_split(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, $templateString, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-	}
+    /**
+     * Splits the template string on all dynamic tags found.
+     *
+     * @param string $templateString Template string to split.
+     * @return array Splitted template
+     */
+    protected function splitTemplateAtDynamicTags($templateString)
+    {
+        return preg_split(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, $templateString, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+    }
 
-	/**
-	 * Build object tree from the split template
-	 *
-	 * @param array $splitTemplate The split template, so that every tag with a namespace declaration is already a seperate array element.
-	 * @param integer $context one of the CONTEXT_* constants, defining whether we are inside or outside of ViewHelper arguments currently.
-	 * @return ParsingState
-	 * @throws Exception
-	 */
-	protected function buildObjectTree(array $splitTemplate, $context) {
-		$state = $this->getParsingState();
-		$previousBlock = '';
+    /**
+     * Build object tree from the split template
+     *
+     * @param array $splitTemplate The split template, so that every tag with a namespace declaration is already a seperate array element.
+     * @param integer $context one of the CONTEXT_* constants, defining whether we are inside or outside of ViewHelper arguments currently.
+     * @return ParsingState
+     * @throws Exception
+     */
+    protected function buildObjectTree(array $splitTemplate, $context)
+    {
+        $state = $this->getParsingState();
+        $previousBlock = '';
 
-		foreach ($splitTemplate as $templateElement) {
-			if ($context === self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS) {
-				// Store a neat reference to the outermost chunk of Fluid template code.
-				// Don't store the reference if parsing ViewHelper arguments object tree;
-				// we want the reference code to contain *all* of the ViewHelper call.
-				$this->pointerTemplateCode = $templateElement;
-			}
-			$this->pointerLineNumber += substr_count($templateElement, PHP_EOL);
-			$this->pointerLineCharacter = strlen(substr($previousBlock, strrpos($previousBlock, PHP_EOL))) + 1;
-			$previousBlock = $templateElement;
-			$matchedVariables = array();
+        foreach ($splitTemplate as $templateElement) {
+            if ($context === self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS) {
+                // Store a neat reference to the outermost chunk of Fluid template code.
+                // Don't store the reference if parsing ViewHelper arguments object tree;
+                // we want the reference code to contain *all* of the ViewHelper call.
+                $this->pointerTemplateCode = $templateElement;
+            }
+            $this->pointerLineNumber += substr_count($templateElement, PHP_EOL);
+            $this->pointerLineCharacter = strlen(substr($previousBlock, strrpos($previousBlock, PHP_EOL))) + 1;
+            $previousBlock = $templateElement;
+            $matchedVariables = [];
 
-			if (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
-				if ($this->openingViewHelperTagHandler(
-					$state,
-					$matchedVariables['NamespaceIdentifier'],
-					$matchedVariables['MethodIdentifier'],
-					$matchedVariables['Attributes'],
-					($matchedVariables['Selfclosing'] === '' ? FALSE : TRUE),
-					$templateElement
-				)) {
-					continue;
-				}
-			} elseif (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
-				if ($this->closingViewHelperTagHandler(
-					$state,
-					$matchedVariables['NamespaceIdentifier'],
-					$matchedVariables['MethodIdentifier']
-				)) {
-					continue;
-				}
-			}
-			$this->textAndShorthandSyntaxHandler($state, $templateElement, $context);
-		}
+            if (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
+                if ($this->openingViewHelperTagHandler(
+                    $state,
+                    $matchedVariables['NamespaceIdentifier'],
+                    $matchedVariables['MethodIdentifier'],
+                    $matchedVariables['Attributes'],
+                    ($matchedVariables['Selfclosing'] === '' ? false : true),
+                    $templateElement
+                )) {
+                    continue;
+                }
+            } elseif (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
+                if ($this->closingViewHelperTagHandler(
+                    $state,
+                    $matchedVariables['NamespaceIdentifier'],
+                    $matchedVariables['MethodIdentifier']
+                )) {
+                    continue;
+                }
+            }
+            $this->textAndShorthandSyntaxHandler($state, $templateElement, $context);
+        }
 
-		if ($state->countNodeStack() !== 1) {
-			throw new Exception('Not all tags were closed!', 1238169398);
-		}
-		return $state;
-	}
-	/**
-	 * Handles an opening or self-closing view helper tag.
-	 *
-	 * @param ParsingState $state Current parsing state
-	 * @param string $namespaceIdentifier Namespace identifier - being looked up in $this->namespaces
-	 * @param string $methodIdentifier Method identifier
-	 * @param string $arguments Arguments string, not yet parsed
-	 * @param boolean $selfclosing true, if the tag is a self-closing tag.
-	 * @param string $templateElement The template code containing the ViewHelper call
-	 * @return ViewHelperNode|NULL
-	 */
-	protected function openingViewHelperTagHandler(ParsingState $state, $namespaceIdentifier, $methodIdentifier, $arguments, $selfclosing, $templateElement) {
-		$viewHelperNode = $this->initializeViewHelperAndAddItToStack(
-			$state,
-			$namespaceIdentifier,
-			$methodIdentifier,
-			$this->parseArguments($arguments)
-		);
+        if ($state->countNodeStack() !== 1) {
+            throw new Exception('Not all tags were closed!', 1238169398);
+        }
+        return $state;
+    }
+    /**
+     * Handles an opening or self-closing view helper tag.
+     *
+     * @param ParsingState $state Current parsing state
+     * @param string $namespaceIdentifier Namespace identifier - being looked up in $this->namespaces
+     * @param string $methodIdentifier Method identifier
+     * @param string $arguments Arguments string, not yet parsed
+     * @param boolean $selfclosing true, if the tag is a self-closing tag.
+     * @param string $templateElement The template code containing the ViewHelper call
+     * @return ViewHelperNode|NULL
+     */
+    protected function openingViewHelperTagHandler(ParsingState $state, $namespaceIdentifier, $methodIdentifier, $arguments, $selfclosing, $templateElement)
+    {
+        $viewHelperNode = $this->initializeViewHelperAndAddItToStack(
+            $state,
+            $namespaceIdentifier,
+            $methodIdentifier,
+            $this->parseArguments($arguments)
+        );
 
-		if ($viewHelperNode) {
-			$viewHelperNode->setPointerTemplateCode($templateElement);
-			if ($selfclosing === TRUE) {
-				$state->popNodeFromStack();
-				$this->callInterceptor($viewHelperNode, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
-				// This needs to be called here because closingViewHelperTagHandler() is not triggered for self-closing tags
-				$state->getNodeFromStack()->addChildNode($viewHelperNode);
-			}
-		}
+        if ($viewHelperNode) {
+            $viewHelperNode->setPointerTemplateCode($templateElement);
+            if ($selfclosing === true) {
+                $state->popNodeFromStack();
+                $this->callInterceptor($viewHelperNode, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
+                // This needs to be called here because closingViewHelperTagHandler() is not triggered for self-closing tags
+                $state->getNodeFromStack()->addChildNode($viewHelperNode);
+            }
+        }
 
-		return $viewHelperNode;
-	}
+        return $viewHelperNode;
+    }
 
-	/**
-	 * Initialize the given ViewHelper and adds it to the current node and to
-	 * the stack.
-	 *
-	 * @param ParsingState $state Current parsing state
-	 * @param string $namespaceIdentifier Namespace identifier - being looked up in $this->namespaces
-	 * @param string $methodIdentifier Method identifier
-	 * @param array $argumentsObjectTree Arguments object tree
-	 * @return ViewHelperNode|NULL An instance of ViewHelperNode if identity was valid - NULL if the namespace/identity was not registered
-	 * @throws Exception
-	 */
-	protected function initializeViewHelperAndAddItToStack(ParsingState $state, $namespaceIdentifier, $methodIdentifier, $argumentsObjectTree) {
-		$viewHelperResolver = $this->renderingContext->getViewHelperResolver();
-		if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
-			return NULL;
-		}
-		$currentViewHelperNode = new ViewHelperNode(
-			$this->renderingContext,
-			$namespaceIdentifier,
-			$methodIdentifier,
-			$argumentsObjectTree,
-			$state
-		);
+    /**
+     * Initialize the given ViewHelper and adds it to the current node and to
+     * the stack.
+     *
+     * @param ParsingState $state Current parsing state
+     * @param string $namespaceIdentifier Namespace identifier - being looked up in $this->namespaces
+     * @param string $methodIdentifier Method identifier
+     * @param array $argumentsObjectTree Arguments object tree
+     * @return ViewHelperNode|NULL An instance of ViewHelperNode if identity was valid - NULL if the namespace/identity was not registered
+     * @throws Exception
+     */
+    protected function initializeViewHelperAndAddItToStack(ParsingState $state, $namespaceIdentifier, $methodIdentifier, $argumentsObjectTree)
+    {
+        $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
+        if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
+            return null;
+        }
+        $currentViewHelperNode = new ViewHelperNode(
+            $this->renderingContext,
+            $namespaceIdentifier,
+            $methodIdentifier,
+            $argumentsObjectTree,
+            $state
+        );
 
-		$this->callInterceptor($currentViewHelperNode, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, $state);
-		$viewHelper = $currentViewHelperNode->getUninitializedViewHelper();
-		$viewHelper::postParseEvent($currentViewHelperNode, $argumentsObjectTree, $state->getVariableContainer());
-		$state->pushNodeToStack($currentViewHelperNode);
+        $this->callInterceptor($currentViewHelperNode, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, $state);
+        $viewHelper = $currentViewHelperNode->getUninitializedViewHelper();
+        $viewHelper::postParseEvent($currentViewHelperNode, $argumentsObjectTree, $state->getVariableContainer());
+        $state->pushNodeToStack($currentViewHelperNode);
 
-		return $currentViewHelperNode;
-	}
+        return $currentViewHelperNode;
+    }
 
-	/**
-	 * Handles a closing view helper tag
-	 *
-	 * @param ParsingState $state The current parsing state
-	 * @param string $namespaceIdentifier Namespace identifier for the closing tag.
-	 * @param string $methodIdentifier Method identifier.
-	 * @return boolean whether the viewHelper was found and added to the stack or not
-	 * @throws Exception
-	 */
-	protected function closingViewHelperTagHandler(ParsingState $state, $namespaceIdentifier, $methodIdentifier) {
-		$viewHelperResolver = $this->renderingContext->getViewHelperResolver();
-		if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
-			return FALSE;
-		}
-		$lastStackElement = $state->popNodeFromStack();
-		if (!($lastStackElement instanceof ViewHelperNode)) {
-			throw new Exception('You closed a templating tag which you never opened!', 1224485838);
-		}
-		$actualViewHelperClassName = $viewHelperResolver->resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier);
-		$expectedViewHelperClassName = $lastStackElement->getViewHelperClassName();
-		if ($actualViewHelperClassName !== $expectedViewHelperClassName) {
-			throw new Exception(
-				'Templating tags not properly nested. Expected: ' . $expectedViewHelperClassName . '; Actual: ' .
-				$actualViewHelperClassName,
-				1224485398
-			);
-		}
-		$this->callInterceptor($lastStackElement, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
-		$state->getNodeFromStack()->addChildNode($lastStackElement);
+    /**
+     * Handles a closing view helper tag
+     *
+     * @param ParsingState $state The current parsing state
+     * @param string $namespaceIdentifier Namespace identifier for the closing tag.
+     * @param string $methodIdentifier Method identifier.
+     * @return boolean whether the viewHelper was found and added to the stack or not
+     * @throws Exception
+     */
+    protected function closingViewHelperTagHandler(ParsingState $state, $namespaceIdentifier, $methodIdentifier)
+    {
+        $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
+        if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
+            return false;
+        }
+        $lastStackElement = $state->popNodeFromStack();
+        if (!($lastStackElement instanceof ViewHelperNode)) {
+            throw new Exception('You closed a templating tag which you never opened!', 1224485838);
+        }
+        $actualViewHelperClassName = $viewHelperResolver->resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier);
+        $expectedViewHelperClassName = $lastStackElement->getViewHelperClassName();
+        if ($actualViewHelperClassName !== $expectedViewHelperClassName) {
+            throw new Exception(
+                'Templating tags not properly nested. Expected: ' . $expectedViewHelperClassName . '; Actual: ' .
+                $actualViewHelperClassName,
+                1224485398
+            );
+        }
+        $this->callInterceptor($lastStackElement, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
+        $state->getNodeFromStack()->addChildNode($lastStackElement);
 
-		return TRUE;
-	}
+        return true;
+    }
 
-	/**
-	 * Handles the appearance of an object accessor (like {posts.author.email}).
-	 * Creates a new instance of \TYPO3Fluid\Fluid\ObjectAccessorNode.
-	 *
-	 * Handles ViewHelpers as well which are in the shorthand syntax.
-	 *
-	 * @param ParsingState $state The current parsing state
-	 * @param string $objectAccessorString String which identifies which objects to fetch
-	 * @param string $delimiter
-	 * @param string $viewHelperString
-	 * @param string $additionalViewHelpersString
-	 * @return void
-	 */
-	protected function objectAccessorHandler(ParsingState $state, $objectAccessorString, $delimiter, $viewHelperString, $additionalViewHelpersString) {
-		$viewHelperString .= $additionalViewHelpersString;
-		$numberOfViewHelpers = 0;
+    /**
+     * Handles the appearance of an object accessor (like {posts.author.email}).
+     * Creates a new instance of \TYPO3Fluid\Fluid\ObjectAccessorNode.
+     *
+     * Handles ViewHelpers as well which are in the shorthand syntax.
+     *
+     * @param ParsingState $state The current parsing state
+     * @param string $objectAccessorString String which identifies which objects to fetch
+     * @param string $delimiter
+     * @param string $viewHelperString
+     * @param string $additionalViewHelpersString
+     * @return void
+     */
+    protected function objectAccessorHandler(ParsingState $state, $objectAccessorString, $delimiter, $viewHelperString, $additionalViewHelpersString)
+    {
+        $viewHelperString .= $additionalViewHelpersString;
+        $numberOfViewHelpers = 0;
 
-		// The following post-processing handles a case when there is only a ViewHelper, and no Object Accessor.
-		// Resolves bug #5107.
-		if (strlen($delimiter) === 0 && strlen($viewHelperString) > 0) {
-			$viewHelperString = $objectAccessorString . $viewHelperString;
-			$objectAccessorString = '';
-		}
+        // The following post-processing handles a case when there is only a ViewHelper, and no Object Accessor.
+        // Resolves bug #5107.
+        if (strlen($delimiter) === 0 && strlen($viewHelperString) > 0) {
+            $viewHelperString = $objectAccessorString . $viewHelperString;
+            $objectAccessorString = '';
+        }
 
-		// ViewHelpers
-		$matches = array();
-		if (strlen($viewHelperString) > 0 && preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER, $viewHelperString, $matches, PREG_SET_ORDER) > 0) {
-			// The last ViewHelper has to be added first for correct chaining.
-			foreach (array_reverse($matches) as $singleMatch) {
-				if (strlen($singleMatch['ViewHelperArguments']) > 0) {
-					$arguments = $this->recursiveArrayHandler($singleMatch['ViewHelperArguments']);
-				} else {
-					$arguments = array();
-				}
-				$viewHelperNode = $this->initializeViewHelperAndAddItToStack($state, $singleMatch['NamespaceIdentifier'], $singleMatch['MethodIdentifier'], $arguments);
-				if ($viewHelperNode) {
-					$numberOfViewHelpers++;
-				}
-			}
-		}
+        // ViewHelpers
+        $matches = [];
+        if (strlen($viewHelperString) > 0 && preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER, $viewHelperString, $matches, PREG_SET_ORDER) > 0) {
+            // The last ViewHelper has to be added first for correct chaining.
+            foreach (array_reverse($matches) as $singleMatch) {
+                if (strlen($singleMatch['ViewHelperArguments']) > 0) {
+                    $arguments = $this->recursiveArrayHandler($singleMatch['ViewHelperArguments']);
+                } else {
+                    $arguments = [];
+                }
+                $viewHelperNode = $this->initializeViewHelperAndAddItToStack($state, $singleMatch['NamespaceIdentifier'], $singleMatch['MethodIdentifier'], $arguments);
+                if ($viewHelperNode) {
+                    $numberOfViewHelpers++;
+                }
+            }
+        }
 
-		// Object Accessor
-		if (strlen($objectAccessorString) > 0) {
-			if ($state->isCompilable() && !$state->isCompiled()) {
-				$accessors = VariableExtractor::extractAccessors($state->getVariableContainer(), $objectAccessorString);
-			} else {
-				$accessors = array();
-			}
-			$node = new ObjectAccessorNode($objectAccessorString, $accessors);
-			$this->callInterceptor($node, InterceptorInterface::INTERCEPT_OBJECTACCESSOR, $state);
-			$state->getNodeFromStack()->addChildNode($node);
-		}
+        // Object Accessor
+        if (strlen($objectAccessorString) > 0) {
+            if ($state->isCompilable() && !$state->isCompiled()) {
+                $accessors = VariableExtractor::extractAccessors($state->getVariableContainer(), $objectAccessorString);
+            } else {
+                $accessors = [];
+            }
+            $node = new ObjectAccessorNode($objectAccessorString, $accessors);
+            $this->callInterceptor($node, InterceptorInterface::INTERCEPT_OBJECTACCESSOR, $state);
+            $state->getNodeFromStack()->addChildNode($node);
+        }
 
-		// Close ViewHelper Tags if needed.
-		for ($i = 0; $i < $numberOfViewHelpers; $i++) {
-			$node = $state->popNodeFromStack();
-			$this->callInterceptor($node, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
-			$state->getNodeFromStack()->addChildNode($node);
-		}
-	}
+        // Close ViewHelper Tags if needed.
+        for ($i = 0; $i < $numberOfViewHelpers; $i++) {
+            $node = $state->popNodeFromStack();
+            $this->callInterceptor($node, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, $state);
+            $state->getNodeFromStack()->addChildNode($node);
+        }
+    }
 
-	/**
-	 * Call all interceptors registered for a given interception point.
-	 *
-	 * @param NodeInterface $node The syntax tree node which can be modified by the interceptors.
-	 * @param integer $interceptionPoint the interception point. One of the \TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface::INTERCEPT_* constants.
-	 * @param ParsingState $state the parsing state
-	 * @return void
-	 */
-	protected function callInterceptor(NodeInterface &$node, $interceptionPoint, ParsingState $state) {
-		if ($this->configuration === NULL) {
-			return;
-		}
-		if ($this->escapingEnabled) {
-			/** @var $interceptor InterceptorInterface */
-			foreach ($this->configuration->getEscapingInterceptors($interceptionPoint) as $interceptor) {
-				$node = $interceptor->process($node, $interceptionPoint, $state);
-			}
-		}
+    /**
+     * Call all interceptors registered for a given interception point.
+     *
+     * @param NodeInterface $node The syntax tree node which can be modified by the interceptors.
+     * @param integer $interceptionPoint the interception point. One of the \TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface::INTERCEPT_* constants.
+     * @param ParsingState $state the parsing state
+     * @return void
+     */
+    protected function callInterceptor(NodeInterface &$node, $interceptionPoint, ParsingState $state)
+    {
+        if ($this->configuration === null) {
+            return;
+        }
+        if ($this->escapingEnabled) {
+            /** @var $interceptor InterceptorInterface */
+            foreach ($this->configuration->getEscapingInterceptors($interceptionPoint) as $interceptor) {
+                $node = $interceptor->process($node, $interceptionPoint, $state);
+            }
+        }
 
-		/** @var $interceptor InterceptorInterface */
-		foreach ($this->configuration->getInterceptors($interceptionPoint) as $interceptor) {
-			$node = $interceptor->process($node, $interceptionPoint, $state);
-		}
-	}
+        /** @var $interceptor InterceptorInterface */
+        foreach ($this->configuration->getInterceptors($interceptionPoint) as $interceptor) {
+            $node = $interceptor->process($node, $interceptionPoint, $state);
+        }
+    }
 
-	/**
-	 * Parse arguments of a given tag, and build up the Arguments Object Tree
-	 * for each argument.
-	 * Returns an associative array, where the key is the name of the argument,
-	 * and the value is a single Argument Object Tree.
-	 *
-	 * @param string $argumentsString All arguments as string
-	 * @return array An associative array of objects, where the key is the argument name.
-	 */
-	protected function parseArguments($argumentsString) {
-		$argumentsObjectTree = array();
-		$matches = array();
-		if (preg_match_all(Patterns::$SPLIT_PATTERN_TAGARGUMENTS, $argumentsString, $matches, PREG_SET_ORDER) > 0) {
-			$escapingEnabledBackup = $this->escapingEnabled;
-			$this->escapingEnabled = FALSE;
-			foreach ($matches as $singleMatch) {
-				$argument = $singleMatch['Argument'];
-				$value = $this->unquoteString($singleMatch['ValueQuoted']);
-				$argumentsObjectTree[$argument] = $this->buildArgumentObjectTree($value);
-			}
-			$this->escapingEnabled = $escapingEnabledBackup;
-		}
-		return $argumentsObjectTree;
-	}
+    /**
+     * Parse arguments of a given tag, and build up the Arguments Object Tree
+     * for each argument.
+     * Returns an associative array, where the key is the name of the argument,
+     * and the value is a single Argument Object Tree.
+     *
+     * @param string $argumentsString All arguments as string
+     * @return array An associative array of objects, where the key is the argument name.
+     */
+    protected function parseArguments($argumentsString)
+    {
+        $argumentsObjectTree = [];
+        $matches = [];
+        if (preg_match_all(Patterns::$SPLIT_PATTERN_TAGARGUMENTS, $argumentsString, $matches, PREG_SET_ORDER) > 0) {
+            $escapingEnabledBackup = $this->escapingEnabled;
+            $this->escapingEnabled = false;
+            foreach ($matches as $singleMatch) {
+                $argument = $singleMatch['Argument'];
+                $value = $this->unquoteString($singleMatch['ValueQuoted']);
+                $argumentsObjectTree[$argument] = $this->buildArgumentObjectTree($value);
+            }
+            $this->escapingEnabled = $escapingEnabledBackup;
+        }
+        return $argumentsObjectTree;
+    }
 
-	/**
-	 * Build up an argument object tree for the string in $argumentString.
-	 * This builds up the tree for a single argument value.
-	 *
-	 * This method also does some performance optimizations, so in case
-	 * no { or < is found, then we just return a TextNode.
-	 *
-	 * @param string $argumentString
-	 * @return SyntaxTree\NodeInterface the corresponding argument object tree.
-	 */
-	protected function buildArgumentObjectTree($argumentString) {
-		if (strpos($argumentString, '{') === FALSE && strpos($argumentString, '<') === FALSE) {
-			if (is_numeric($argumentString)) {
-				return new NumericNode($argumentString);
-			}
-			return new TextNode($argumentString);
-		}
-		$splitArgument = $this->splitTemplateAtDynamicTags($argumentString);
-		$rootNode = $this->buildObjectTree($splitArgument, self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS)->getRootNode();
-		return $rootNode;
-	}
+    /**
+     * Build up an argument object tree for the string in $argumentString.
+     * This builds up the tree for a single argument value.
+     *
+     * This method also does some performance optimizations, so in case
+     * no { or < is found, then we just return a TextNode.
+     *
+     * @param string $argumentString
+     * @return SyntaxTree\NodeInterface the corresponding argument object tree.
+     */
+    protected function buildArgumentObjectTree($argumentString)
+    {
+        if (strpos($argumentString, '{') === false && strpos($argumentString, '<') === false) {
+            if (is_numeric($argumentString)) {
+                return new NumericNode($argumentString);
+            }
+            return new TextNode($argumentString);
+        }
+        $splitArgument = $this->splitTemplateAtDynamicTags($argumentString);
+        $rootNode = $this->buildObjectTree($splitArgument, self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS)->getRootNode();
+        return $rootNode;
+    }
 
-	/**
-	 * Removes escapings from a given argument string and trims the outermost
-	 * quotes.
-	 *
-	 * This method is meant as a helper for regular expression results.
-	 *
-	 * @param string $quotedValue Value to unquote
-	 * @return string Unquoted value
-	 */
-	public function unquoteString($quotedValue) {
-		$value = $quotedValue;
-		if ($quotedValue{0} === '"') {
-			$value = str_replace('\\"', '"', preg_replace('/(^"|"$)/', '', $quotedValue));
-		} elseif ($quotedValue{0} === '\'') {
-			$value = str_replace("\\'", "'", preg_replace('/(^\'|\'$)/', '', $quotedValue));
-		}
-		return str_replace('\\\\', '\\', $value);
-	}
+    /**
+     * Removes escapings from a given argument string and trims the outermost
+     * quotes.
+     *
+     * This method is meant as a helper for regular expression results.
+     *
+     * @param string $quotedValue Value to unquote
+     * @return string Unquoted value
+     */
+    public function unquoteString($quotedValue)
+    {
+        $value = $quotedValue;
+        if ($quotedValue{0} === '"') {
+            $value = str_replace('\\"', '"', preg_replace('/(^"|"$)/', '', $quotedValue));
+        } elseif ($quotedValue{0} === '\'') {
+            $value = str_replace("\\'", "'", preg_replace('/(^\'|\'$)/', '', $quotedValue));
+        }
+        return str_replace('\\\\', '\\', $value);
+    }
 
-	/**
-	 * Handler for everything which is not a ViewHelperNode.
-	 *
-	 * This includes Text, array syntax, and object accessor syntax.
-	 *
-	 * @param ParsingState $state Current parsing state
-	 * @param string $text Text to process
-	 * @param integer $context one of the CONTEXT_* constants, defining whether we are inside or outside of ViewHelper arguments currently.
-	 * @return void
-	 */
-	protected function textAndShorthandSyntaxHandler(ParsingState $state, $text, $context) {
-		$sections = preg_split(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX, $text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-		foreach ($sections as $section) {
-			$matchedVariables = array();
-			$expressionNode = NULL;
-			if (preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS, $section, $matchedVariables) > 0) {
-				$this->objectAccessorHandler(
-					$state,
-					$matchedVariables['Object'],
-					$matchedVariables['Delimiter'],
-					(isset($matchedVariables['ViewHelper']) ? $matchedVariables['ViewHelper'] : ''),
-					(isset($matchedVariables['AdditionalViewHelpers']) ? $matchedVariables['AdditionalViewHelpers'] : '')
-				);
-			} elseif (
-				$context === self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS
-				&& preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $section, $matchedVariables) > 0
-			) {
-				// We only match arrays if we are INSIDE viewhelper arguments
-				$this->arrayHandler($state, $this->recursiveArrayHandler($matchedVariables['Array']));
-			} else {
-				// We ask custom ExpressionNode instances from ViewHelperResolver
-				// if any match our expression:
-				foreach ($this->renderingContext->getExpressionNodeTypes() as $expressionNodeTypeClassName) {
-					$detectionExpression = $expressionNodeTypeClassName::$detectionExpression;
-					$matchedVariables = array();
-					preg_match_all($detectionExpression, $section, $matchedVariables, PREG_SET_ORDER);
-					if (is_array($matchedVariables) === TRUE) {
-						foreach ($matchedVariables as $matchedVariableSet) {
-							$expressionStartPosition = strpos($section, $matchedVariableSet[0]);
-							/** @var ExpressionNodeInterface $expressionNode */
-							$expressionNode = new $expressionNodeTypeClassName($matchedVariableSet[0], $matchedVariableSet, $state);
-							if ($expressionStartPosition > 0) {
-								$state->getNodeFromStack()->addChildNode(new TextNode(substr($section, 0, $expressionStartPosition)));
-							}
-							$state->getNodeFromStack()->addChildNode($expressionNode);
-							$expressionEndPosition = $expressionStartPosition + strlen($matchedVariableSet[0]);
-							if ($expressionEndPosition < strlen($section)) {
-								$this->textAndShorthandSyntaxHandler($state, substr($section, $expressionEndPosition), $context);
-								break;
-							}
-						}
-					}
-				}
+    /**
+     * Handler for everything which is not a ViewHelperNode.
+     *
+     * This includes Text, array syntax, and object accessor syntax.
+     *
+     * @param ParsingState $state Current parsing state
+     * @param string $text Text to process
+     * @param integer $context one of the CONTEXT_* constants, defining whether we are inside or outside of ViewHelper arguments currently.
+     * @return void
+     */
+    protected function textAndShorthandSyntaxHandler(ParsingState $state, $text, $context)
+    {
+        $sections = preg_split(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX, $text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        foreach ($sections as $section) {
+            $matchedVariables = [];
+            $expressionNode = null;
+            if (preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS, $section, $matchedVariables) > 0) {
+                $this->objectAccessorHandler(
+                    $state,
+                    $matchedVariables['Object'],
+                    $matchedVariables['Delimiter'],
+                    (isset($matchedVariables['ViewHelper']) ? $matchedVariables['ViewHelper'] : ''),
+                    (isset($matchedVariables['AdditionalViewHelpers']) ? $matchedVariables['AdditionalViewHelpers'] : '')
+                );
+            } elseif ($context === self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS
+                && preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $section, $matchedVariables) > 0
+            ) {
+                // We only match arrays if we are INSIDE viewhelper arguments
+                $this->arrayHandler($state, $this->recursiveArrayHandler($matchedVariables['Array']));
+            } else {
+                // We ask custom ExpressionNode instances from ViewHelperResolver
+                // if any match our expression:
+                foreach ($this->renderingContext->getExpressionNodeTypes() as $expressionNodeTypeClassName) {
+                    $detectionExpression = $expressionNodeTypeClassName::$detectionExpression;
+                    $matchedVariables = [];
+                    preg_match_all($detectionExpression, $section, $matchedVariables, PREG_SET_ORDER);
+                    if (is_array($matchedVariables) === true) {
+                        foreach ($matchedVariables as $matchedVariableSet) {
+                            $expressionStartPosition = strpos($section, $matchedVariableSet[0]);
+                            /** @var ExpressionNodeInterface $expressionNode */
+                            $expressionNode = new $expressionNodeTypeClassName($matchedVariableSet[0], $matchedVariableSet, $state);
+                            if ($expressionStartPosition > 0) {
+                                $state->getNodeFromStack()->addChildNode(new TextNode(substr($section, 0, $expressionStartPosition)));
+                            }
+                            $state->getNodeFromStack()->addChildNode($expressionNode);
+                            $expressionEndPosition = $expressionStartPosition + strlen($matchedVariableSet[0]);
+                            if ($expressionEndPosition < strlen($section)) {
+                                $this->textAndShorthandSyntaxHandler($state, substr($section, $expressionEndPosition), $context);
+                                break;
+                            }
+                        }
+                    }
+                }
 
-				if ($expressionNode) {
-					// Trigger initial parse-time evaluation to allow the node to manipulate the rendering context.
-					$expressionNode->evaluate($this->renderingContext);
-				} else {
-					// As fallback we simply render the expression back as template content.
-					$this->textHandler($state, $section);
-				}
-			}
-		}
-	}
+                if ($expressionNode) {
+                    // Trigger initial parse-time evaluation to allow the node to manipulate the rendering context.
+                    $expressionNode->evaluate($this->renderingContext);
+                } else {
+                    // As fallback we simply render the expression back as template content.
+                    $this->textHandler($state, $section);
+                }
+            }
+        }
+    }
 
-	/**
-	 * Handler for array syntax. This creates the array object recursively and
-	 * adds it to the current node.
-	 *
-	 * @param ParsingState $state The current parsing state
-	 * @param array $arrayText The array as string.
-	 * @return void
-	 */
-	protected function arrayHandler(ParsingState $state, $arrayText) {
-		$arrayNode = new ArrayNode($arrayText);
-		$state->getNodeFromStack()->addChildNode($arrayNode);
-	}
+    /**
+     * Handler for array syntax. This creates the array object recursively and
+     * adds it to the current node.
+     *
+     * @param ParsingState $state The current parsing state
+     * @param array $arrayText The array as string.
+     * @return void
+     */
+    protected function arrayHandler(ParsingState $state, $arrayText)
+    {
+        $arrayNode = new ArrayNode($arrayText);
+        $state->getNodeFromStack()->addChildNode($arrayNode);
+    }
 
-	/**
-	 * Recursive function which takes the string representation of an array and
-	 * builds an object tree from it.
-	 *
-	 * Deals with the following value types:
-	 * - Numbers (Integers and Floats)
-	 * - Strings
-	 * - Variables
-	 * - sub-arrays
-	 *
-	 * @param string $arrayText Array text
-	 * @return NodeInterface[] the array node built up
-	 * @throws Exception
-	 */
-	protected function recursiveArrayHandler($arrayText) {
-		$matches = array();
-		$arrayToBuild = array();
-		if (preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS, $arrayText, $matches, PREG_SET_ORDER)) {
-			foreach ($matches as $singleMatch) {
-				$arrayKey = $this->unquoteString($singleMatch['Key']);
-				if (!empty($singleMatch['VariableIdentifier'])) {
-					$arrayToBuild[$arrayKey] = new ObjectAccessorNode($singleMatch['VariableIdentifier']);
-				} elseif (array_key_exists('Number', $singleMatch) && (!empty($singleMatch['Number']) || $singleMatch['Number'] === '0' )) {
-					$arrayToBuild[$arrayKey] = floatval($singleMatch['Number']);
-				} elseif ((array_key_exists('QuotedString', $singleMatch) && !empty($singleMatch['QuotedString']))) {
-					$argumentString = $this->unquoteString($singleMatch['QuotedString']);
-					$arrayToBuild[$arrayKey] = $this->buildArgumentObjectTree($argumentString);
-				} elseif (array_key_exists('Subarray', $singleMatch) && !empty($singleMatch['Subarray'])) {
-					$arrayToBuild[$arrayKey] = new ArrayNode($this->recursiveArrayHandler($singleMatch['Subarray']));
-				}
-			}
-		}
-		return $arrayToBuild;
-	}
+    /**
+     * Recursive function which takes the string representation of an array and
+     * builds an object tree from it.
+     *
+     * Deals with the following value types:
+     * - Numbers (Integers and Floats)
+     * - Strings
+     * - Variables
+     * - sub-arrays
+     *
+     * @param string $arrayText Array text
+     * @return NodeInterface[] the array node built up
+     * @throws Exception
+     */
+    protected function recursiveArrayHandler($arrayText)
+    {
+        $matches = [];
+        $arrayToBuild = [];
+        if (preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS, $arrayText, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $singleMatch) {
+                $arrayKey = $this->unquoteString($singleMatch['Key']);
+                if (!empty($singleMatch['VariableIdentifier'])) {
+                    $arrayToBuild[$arrayKey] = new ObjectAccessorNode($singleMatch['VariableIdentifier']);
+                } elseif (array_key_exists('Number', $singleMatch) && (!empty($singleMatch['Number']) || $singleMatch['Number'] === '0' )) {
+                    $arrayToBuild[$arrayKey] = floatval($singleMatch['Number']);
+                } elseif ((array_key_exists('QuotedString', $singleMatch) && !empty($singleMatch['QuotedString']))) {
+                    $argumentString = $this->unquoteString($singleMatch['QuotedString']);
+                    $arrayToBuild[$arrayKey] = $this->buildArgumentObjectTree($argumentString);
+                } elseif (array_key_exists('Subarray', $singleMatch) && !empty($singleMatch['Subarray'])) {
+                    $arrayToBuild[$arrayKey] = new ArrayNode($this->recursiveArrayHandler($singleMatch['Subarray']));
+                }
+            }
+        }
+        return $arrayToBuild;
+    }
 
-	/**
-	 * Text node handler
-	 *
-	 * @param ParsingState $state
-	 * @param string $text
-	 * @return void
-	 */
-	protected function textHandler(ParsingState $state, $text) {
-		$node = new TextNode($text);
-		$this->callInterceptor($node, InterceptorInterface::INTERCEPT_TEXT, $state);
-		$state->getNodeFromStack()->addChildNode($node);
-	}
+    /**
+     * Text node handler
+     *
+     * @param ParsingState $state
+     * @param string $text
+     * @return void
+     */
+    protected function textHandler(ParsingState $state, $text)
+    {
+        $node = new TextNode($text);
+        $this->callInterceptor($node, InterceptorInterface::INTERCEPT_TEXT, $state);
+        $state->getNodeFromStack()->addChildNode($node);
+    }
 
-	/**
-	 * @return ParsingState
-	 */
-	protected function getParsingState() {
-		$rootNode = new RootNode();
-		$variableProvider = $this->renderingContext->getVariableProvider();
-		$state = new ParsingState();
-		$state->setRootNode($rootNode);
-		$state->pushNodeToStack($rootNode);
-		$state->setVariableProvider($variableProvider->getScopeCopy($variableProvider->getAll()));
-		return $state;
-	}
-
+    /**
+     * @return ParsingState
+     */
+    protected function getParsingState()
+    {
+        $rootNode = new RootNode();
+        $variableProvider = $this->renderingContext->getVariableProvider();
+        $state = new ParsingState();
+        $state->setRootNode($rootNode);
+        $state->pushNodeToStack($rootNode);
+        $state->setVariableProvider($variableProvider->getScopeCopy($variableProvider->getAll()));
+        return $state;
+    }
 }

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -20,134 +20,139 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *   - report any unregistered/unignored namespaces through exception
  *
  */
-class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface {
+class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
+{
 
-	const NAMESPACE_DECLARATION = '/(?<!\\\\){namespace\s*(?P<identifier>[a-zA-Z\*]+[a-zA-Z0-9\.\*]*)\s*(=\s*(?P<phpNamespace>(?:[A-Za-z0-9\.]+|Tx)(?:\\\\\w+)+)\s*)?}/m';
+    const NAMESPACE_DECLARATION = '/(?<!\\\\){namespace\s*(?P<identifier>[a-zA-Z\*]+[a-zA-Z0-9\.\*]*)\s*(=\s*(?P<phpNamespace>(?:[A-Za-z0-9\.]+|Tx)(?:\\\\\w+)+)\s*)?}/m';
 
-	const SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG = '/xmlns:([a-z0-9\.]+)=("[^"]+"|\'[^\']+\')*/xi';
+    const SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG = '/xmlns:([a-z0-9\.]+)=("[^"]+"|\'[^\']+\')*/xi';
 
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
 
-	/**
-	 * @var array()
-	 */
-	protected $localNamespaces = array();
+    /**
+     * @var array()
+     */
+    protected $localNamespaces = [];
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext) {
-		$this->renderingContext = $renderingContext;
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        $this->renderingContext = $renderingContext;
+    }
 
-	/**
-	 * Pre-process the template source before it is
-	 * returned to the TemplateParser or passed to
-	 * the next TemplateProcessorInterface instance.
-	 *
-	 * @param string $templateSource
-	 * @return string
-	 */
-	public function preProcessSource($templateSource) {
-		$templateSource = $this->replaceCdataSectionsByEmptyLines($templateSource);
-		$this->registerNamespacesFromTemplateSource($templateSource);
-		$this->throwExceptionsForUnhandledNamespaces($templateSource);
-		return $templateSource;
-	}
+    /**
+     * Pre-process the template source before it is
+     * returned to the TemplateParser or passed to
+     * the next TemplateProcessorInterface instance.
+     *
+     * @param string $templateSource
+     * @return string
+     */
+    public function preProcessSource($templateSource)
+    {
+        $templateSource = $this->replaceCdataSectionsByEmptyLines($templateSource);
+        $this->registerNamespacesFromTemplateSource($templateSource);
+        $this->throwExceptionsForUnhandledNamespaces($templateSource);
+        return $templateSource;
+    }
 
-	/**
-	 * Replaces all cdata sections with empty lines to exclude it from further
-	 * processing in the templateParser while maintaining the line-count
-	 * of the template string for the exception handler to reference to.
-	 *
-	 * @param string $templateSource
-	 * @return string
-	 */
-	public function replaceCdataSectionsByEmptyLines($templateSource) {
-		$parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
+    /**
+     * Replaces all cdata sections with empty lines to exclude it from further
+     * processing in the templateParser while maintaining the line-count
+     * of the template string for the exception handler to reference to.
+     *
+     * @param string $templateSource
+     * @return string
+     */
+    public function replaceCdataSectionsByEmptyLines($templateSource)
+    {
+        $parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
 
-		$balance = 0;
-		foreach ($parts as $index => $part) {
-			if ($part === '<![CDATA[') {
-				$balance++;
-			}
-			if ($balance > 0) {
-				$parts[$index] = str_repeat(PHP_EOL, substr_count($part, PHP_EOL));
-			}
-			if ($part === ']]>') {
-				$balance--;
-			}
-		}
+        $balance = 0;
+        foreach ($parts as $index => $part) {
+            if ($part === '<![CDATA[') {
+                $balance++;
+            }
+            if ($balance > 0) {
+                $parts[$index] = str_repeat(PHP_EOL, substr_count($part, PHP_EOL));
+            }
+            if ($part === ']]>') {
+                $balance--;
+            }
+        }
 
-		return implode('', $parts);
-	}
+        return implode('', $parts);
+    }
 
-	/**
-	 * Register all namespaces that are declared inside the template string
-	 *
-	 * @param string $templateSource
-	 * @return void
-	 */
-	public function registerNamespacesFromTemplateSource($templateSource) {
-		$viewHelperResolver = $this->renderingContext->getViewHelperResolver();
-		if (preg_match_all(static::SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG, $templateSource, $matchedVariables, PREG_SET_ORDER) > 0) {
-			foreach ($matchedVariables as $namespaceMatch) {
-				$viewHelperNamespace = $this->renderingContext->getTemplateParser()->unquoteString($namespaceMatch[2]);
-				$phpNamespace = $viewHelperResolver->resolvePhpNamespaceFromFluidNamespace($viewHelperNamespace);
-				if (strpos($phpNamespace, '/') === FALSE) {
-					$viewHelperResolver->addNamespace($namespaceMatch[1], $phpNamespace);
-				}
-			}
-		}
+    /**
+     * Register all namespaces that are declared inside the template string
+     *
+     * @param string $templateSource
+     * @return void
+     */
+    public function registerNamespacesFromTemplateSource($templateSource)
+    {
+        $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
+        if (preg_match_all(static::SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG, $templateSource, $matchedVariables, PREG_SET_ORDER) > 0) {
+            foreach ($matchedVariables as $namespaceMatch) {
+                $viewHelperNamespace = $this->renderingContext->getTemplateParser()->unquoteString($namespaceMatch[2]);
+                $phpNamespace = $viewHelperResolver->resolvePhpNamespaceFromFluidNamespace($viewHelperNamespace);
+                if (strpos($phpNamespace, '/') === false) {
+                    $viewHelperResolver->addNamespace($namespaceMatch[1], $phpNamespace);
+                }
+            }
+        }
 
-		preg_match_all(static::NAMESPACE_DECLARATION, $templateSource, $namespaces);
-		foreach ($namespaces['identifier'] as $key => $identifier) {
-			$namespace = $namespaces['phpNamespace'][$key];
-			if (strlen($namespace) === 0) {
-				$namespace = NULL;
-			}
-			$viewHelperResolver->addNamespace($identifier, $namespace);
-		}
-	}
+        preg_match_all(static::NAMESPACE_DECLARATION, $templateSource, $namespaces);
+        foreach ($namespaces['identifier'] as $key => $identifier) {
+            $namespace = $namespaces['phpNamespace'][$key];
+            if (strlen($namespace) === 0) {
+                $namespace = null;
+            }
+            $viewHelperResolver->addNamespace($identifier, $namespace);
+        }
+    }
 
-	/**
-	 * Throw an UnknownNamespaceException for any unknown and not ignored
-	 * namespace inside the template string
-	 *
-	 * @param string $templateSource
-	 * @return void
-	 */
-	public function throwExceptionsForUnhandledNamespaces($templateSource) {
-		$viewHelperResolver = $this->renderingContext->getViewHelperResolver();
-		$splitTemplate = preg_split(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-		foreach ($splitTemplate as $templateElement) {
-			if (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
-				if (!$viewHelperResolver->isNamespaceValidOrIgnored($matchedVariables['NamespaceIdentifier'])) {
-					throw new UnknownNamespaceException('Unkown Namespace: ' . htmlspecialchars($matchedVariables[0]));
-				}
-				continue;
-			} elseif (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
-				continue;
-			}
+    /**
+     * Throw an UnknownNamespaceException for any unknown and not ignored
+     * namespace inside the template string
+     *
+     * @param string $templateSource
+     * @return void
+     */
+    public function throwExceptionsForUnhandledNamespaces($templateSource)
+    {
+        $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
+        $splitTemplate = preg_split(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        foreach ($splitTemplate as $templateElement) {
+            if (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
+                if (!$viewHelperResolver->isNamespaceValidOrIgnored($matchedVariables['NamespaceIdentifier'])) {
+                    throw new UnknownNamespaceException('Unkown Namespace: ' . htmlspecialchars($matchedVariables[0]));
+                }
+                continue;
+            } elseif (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
+                continue;
+            }
 
-			$sections = preg_split(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX, $templateElement, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-			foreach ($sections as $section) {
-				if (preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS, $section, $matchedVariables) > 0) {
-					preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER, $section, $shorthandViewHelpers, PREG_SET_ORDER);
-					if (is_array($shorthandViewHelpers) === TRUE) {
-						foreach ($shorthandViewHelpers as $shorthandViewHelper) {
-							if (!$viewHelperResolver->isNamespaceValidOrIgnored($shorthandViewHelper['NamespaceIdentifier'])) {
-								throw new UnknownNamespaceException('Unkown Namespace: ' . $shorthandViewHelper['NamespaceIdentifier']);
-							}
-						}	
-					}
-				}
-			}
-		}
-	}
-
+            $sections = preg_split(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX, $templateElement, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+            foreach ($sections as $section) {
+                if (preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS, $section, $matchedVariables) > 0) {
+                    preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER, $section, $shorthandViewHelpers, PREG_SET_ORDER);
+                    if (is_array($shorthandViewHelpers) === true) {
+                        foreach ($shorthandViewHelpers as $shorthandViewHelper) {
+                            if (!$viewHelperResolver->isNamespaceValidOrIgnored($shorthandViewHelper['NamespaceIdentifier'])) {
+                                throw new UnknownNamespaceException('Unkown Namespace: ' . $shorthandViewHelper['NamespaceIdentifier']);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/Core/Parser/TemplateProcessorInterface.php
+++ b/src/Core/Parser/TemplateProcessorInterface.php
@@ -22,22 +22,22 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
  * custom instructions from the template which are
  * then used to manipulate how ViewHelpers resolve.
  */
-interface TemplateProcessorInterface {
+interface TemplateProcessorInterface
+{
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext);
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Pre-process the template source before it is
-	 * returned to the TemplateParser or passed to
-	 * the next TemplateProcessorInterface instance.
-	 *
-	 * @param string $templateSource
-	 * @return string
-	 */
-	public function preProcessSource($templateSource);
-
+    /**
+     * Pre-process the template source before it is
+     * returned to the TemplateParser or passed to
+     * the next TemplateProcessorInterface instance.
+     *
+     * @param string $templateSource
+     * @return string
+     */
+    public function preProcessSource($templateSource);
 }

--- a/src/Core/Parser/UnknownNamespaceException.php
+++ b/src/Core/Parser/UnknownNamespaceException.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  *
  * @api
  */
-class UnknownNamespaceException extends \TYPO3Fluid\Fluid\Core\Parser\Exception {
+class UnknownNamespaceException extends \TYPO3Fluid\Fluid\Core\Parser\Exception
+{
 
 }

--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -27,325 +27,352 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
 /**
  * The rendering context that contains useful information during rendering time of a Fluid template
  */
-class RenderingContext implements RenderingContextInterface {
+class RenderingContext implements RenderingContextInterface
+{
 
-	/**
-	 * Template Variable Container. Contains all variables available through object accessors in the template
-	 *
-	 * @var VariableProviderInterface
-	 */
-	protected $variableProvider;
+    /**
+     * Template Variable Container. Contains all variables available through object accessors in the template
+     *
+     * @var VariableProviderInterface
+     */
+    protected $variableProvider;
 
-	/**
-	 * ViewHelper Variable Container
-	 *
-	 * @var ViewHelperVariableContainer
-	 */
-	protected $viewHelperVariableContainer;
+    /**
+     * ViewHelper Variable Container
+     *
+     * @var ViewHelperVariableContainer
+     */
+    protected $viewHelperVariableContainer;
 
-	/**
-	 * @var ViewHelperResolver
-	 */
-	protected $viewHelperResolver;
+    /**
+     * @var ViewHelperResolver
+     */
+    protected $viewHelperResolver;
 
-	/**
-	 * @var ViewHelperInvoker
-	 */
-	protected $viewHelperInvoker;
+    /**
+     * @var ViewHelperInvoker
+     */
+    protected $viewHelperInvoker;
 
-	/**
-	 * @var TemplatePaths
-	 */
-	protected $templatePaths;
+    /**
+     * @var TemplatePaths
+     */
+    protected $templatePaths;
 
-	/**
-	 * @var string
-	 */
-	protected $controllerName;
+    /**
+     * @var string
+     */
+    protected $controllerName;
 
-	/**
-	 * @var string
-	 */
-	protected $controllerAction;
+    /**
+     * @var string
+     */
+    protected $controllerAction;
 
-	/**
-	 * @var ViewInterface
-	 */
-	protected $view;
+    /**
+     * @var ViewInterface
+     */
+    protected $view;
 
-	/**
-	 * @var TemplateParser
-	 */
-	protected $templateParser;
+    /**
+     * @var TemplateParser
+     */
+    protected $templateParser;
 
-	/**
-	 * @var TemplateCompiler
-	 */
-	protected $templateCompiler;
+    /**
+     * @var TemplateCompiler
+     */
+    protected $templateCompiler;
 
-	/**
-	 * @var FluidCacheInterface
-	 */
-	protected $cache;
+    /**
+     * @var FluidCacheInterface
+     */
+    protected $cache;
 
-	/**
-	 * @var TemplateProcessorInterface[]
-	 */
-	protected $templateProcessors = array();
+    /**
+     * @var TemplateProcessorInterface[]
+     */
+    protected $templateProcessors = [];
 
-	/**
-	 * List of class names implementing ExpressionNodeInterface
-	 * which will be consulted when an expression does not match
-	 * any built-in parser expression types.
-	 *
-	 * @var array
-	 */
-	protected $expressionNodeTypes = array(
-		CastingExpressionNode::class,
-		MathExpressionNode::class,
-		TernaryExpressionNode::class,
-	);
+    /**
+     * List of class names implementing ExpressionNodeInterface
+     * which will be consulted when an expression does not match
+     * any built-in parser expression types.
+     *
+     * @var array
+     */
+    protected $expressionNodeTypes = [
+        CastingExpressionNode::class,
+        MathExpressionNode::class,
+        TernaryExpressionNode::class,
+    ];
 
-	/**
-	 * Constructor
-	 *
-	 * Constructing a RenderingContext should result in an object containing instances
-	 * in all properties of the object. Subclassing RenderingContext allows changing the
-	 * types of instances that are created.
-	 *
-	 * Setters are used to fill the object instances. Some setters will call the
-	 * setRenderingContext() method (convention name) to provide the instance that is
-	 * created with an instance of the "parent" RenderingContext.
-	 */
-	public function __construct(ViewInterface $view) {
-		$this->view = $view;
-		$this->setTemplateParser(new TemplateParser());
-		$this->setTemplateCompiler(new TemplateCompiler());
-		$this->setTemplatePaths(new TemplatePaths());
-		$this->setTemplateProcessors(array(new NamespaceDetectionTemplateProcessor()));
-		$this->setViewHelperResolver(new ViewHelperResolver());
-		$this->setViewHelperInvoker(new ViewHelperInvoker());
-		$this->setViewHelperVariableContainer(new ViewHelperVariableContainer());
-		$this->setVariableProvider(new StandardVariableProvider());
-	}
+    /**
+     * Constructor
+     *
+     * Constructing a RenderingContext should result in an object containing instances
+     * in all properties of the object. Subclassing RenderingContext allows changing the
+     * types of instances that are created.
+     *
+     * Setters are used to fill the object instances. Some setters will call the
+     * setRenderingContext() method (convention name) to provide the instance that is
+     * created with an instance of the "parent" RenderingContext.
+     */
+    public function __construct(ViewInterface $view)
+    {
+        $this->view = $view;
+        $this->setTemplateParser(new TemplateParser());
+        $this->setTemplateCompiler(new TemplateCompiler());
+        $this->setTemplatePaths(new TemplatePaths());
+        $this->setTemplateProcessors([new NamespaceDetectionTemplateProcessor()]);
+        $this->setViewHelperResolver(new ViewHelperResolver());
+        $this->setViewHelperInvoker(new ViewHelperInvoker());
+        $this->setViewHelperVariableContainer(new ViewHelperVariableContainer());
+        $this->setVariableProvider(new StandardVariableProvider());
+    }
 
-	/**
-	 * Injects the template variable container containing all variables available through ObjectAccessors
-	 * in the template
-	 *
-	 * @param VariableProviderInterface $variableProvider The template variable container to set
-	 */
-	public function setVariableProvider(VariableProviderInterface $variableProvider) {
-		$this->variableProvider = $variableProvider;
-	}
+    /**
+     * Injects the template variable container containing all variables available through ObjectAccessors
+     * in the template
+     *
+     * @param VariableProviderInterface $variableProvider The template variable container to set
+     */
+    public function setVariableProvider(VariableProviderInterface $variableProvider)
+    {
+        $this->variableProvider = $variableProvider;
+    }
 
-	/**
-	 * Get the template variable container
-	 *
-	 * @return VariableProviderInterface The Template Variable Container
-	 */
-	public function getVariableProvider() {
-		return $this->variableProvider;
-	}
+    /**
+     * Get the template variable container
+     *
+     * @return VariableProviderInterface The Template Variable Container
+     */
+    public function getVariableProvider()
+    {
+        return $this->variableProvider;
+    }
 
-	/**
-	 * @return ViewHelperResolver
-	 */
-	public function getViewHelperResolver() {
-		return $this->viewHelperResolver;
-	}
+    /**
+     * @return ViewHelperResolver
+     */
+    public function getViewHelperResolver()
+    {
+        return $this->viewHelperResolver;
+    }
 
-	/**
-	 * @param ViewHelperResolver $viewHelperResolver
-	 * @return void
-	 */
-	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver) {
-		$this->viewHelperResolver = $viewHelperResolver;
-	}
+    /**
+     * @param ViewHelperResolver $viewHelperResolver
+     * @return void
+     */
+    public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver)
+    {
+        $this->viewHelperResolver = $viewHelperResolver;
+    }
 
-	/**
-	 * @return ViewHelperInvoker
-	 */
-	public function getViewHelperInvoker() {
-		return $this->viewHelperInvoker;
-	}
+    /**
+     * @return ViewHelperInvoker
+     */
+    public function getViewHelperInvoker()
+    {
+        return $this->viewHelperInvoker;
+    }
 
-	/**
-	 * @param ViewHelperInvoker $viewHelperInvoker
-	 * @return void
-	 */
-	public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker) {
-		$this->viewHelperInvoker = $viewHelperInvoker;
-	}
+    /**
+     * @param ViewHelperInvoker $viewHelperInvoker
+     * @return void
+     */
+    public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker)
+    {
+        $this->viewHelperInvoker = $viewHelperInvoker;
+    }
 
-	/**
-	 * @return TemplatePaths
-	 */
-	public function getTemplatePaths() {
-		return $this->templatePaths;
-	}
+    /**
+     * @return TemplatePaths
+     */
+    public function getTemplatePaths()
+    {
+        return $this->templatePaths;
+    }
 
-	/**
-	 * @param TemplatePaths $templatePaths
-	 * @return void
-	 */
-	public function setTemplatePaths(TemplatePaths $templatePaths) {
-		$this->templatePaths = $templatePaths;
-	}
+    /**
+     * @param TemplatePaths $templatePaths
+     * @return void
+     */
+    public function setTemplatePaths(TemplatePaths $templatePaths)
+    {
+        $this->templatePaths = $templatePaths;
+    }
 
-	/**
-	 * Set the ViewHelperVariableContainer
-	 *
-	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
-	 * @return void
-	 */
-	public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer) {
-		$this->viewHelperVariableContainer = $viewHelperVariableContainer;
-	}
+    /**
+     * Set the ViewHelperVariableContainer
+     *
+     * @param ViewHelperVariableContainer $viewHelperVariableContainer
+     * @return void
+     */
+    public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer)
+    {
+        $this->viewHelperVariableContainer = $viewHelperVariableContainer;
+    }
 
-	/**
-	 * Get the ViewHelperVariableContainer
-	 *
-	 * @return ViewHelperVariableContainer
-	 */
-	public function getViewHelperVariableContainer() {
-		return $this->viewHelperVariableContainer;
-	}
+    /**
+     * Get the ViewHelperVariableContainer
+     *
+     * @return ViewHelperVariableContainer
+     */
+    public function getViewHelperVariableContainer()
+    {
+        return $this->viewHelperVariableContainer;
+    }
 
-	/**
-	 * Inject the Template Parser
-	 *
-	 * @param TemplateParser $templateParser The template parser
-	 * @return void
-	 */
-	public function setTemplateParser(TemplateParser $templateParser) {
-		$this->templateParser = $templateParser;
-		$this->templateParser->setRenderingContext($this);
-	}
+    /**
+     * Inject the Template Parser
+     *
+     * @param TemplateParser $templateParser The template parser
+     * @return void
+     */
+    public function setTemplateParser(TemplateParser $templateParser)
+    {
+        $this->templateParser = $templateParser;
+        $this->templateParser->setRenderingContext($this);
+    }
 
-	/**
-	 * @return TemplateParser
-	 */
-	public function getTemplateParser() {
-		return $this->templateParser;
-	}
+    /**
+     * @return TemplateParser
+     */
+    public function getTemplateParser()
+    {
+        return $this->templateParser;
+    }
 
-	/**
-	 * @param TemplateCompiler $templateCompiler
-	 * @return void
-	 */
-	public function setTemplateCompiler(TemplateCompiler $templateCompiler) {
-		$this->templateCompiler = $templateCompiler;
-		$this->templateCompiler->setRenderingContext($this);
-	}
+    /**
+     * @param TemplateCompiler $templateCompiler
+     * @return void
+     */
+    public function setTemplateCompiler(TemplateCompiler $templateCompiler)
+    {
+        $this->templateCompiler = $templateCompiler;
+        $this->templateCompiler->setRenderingContext($this);
+    }
 
-	/**
-	 * @return TemplateCompiler
-	 */
-	public function getTemplateCompiler() {
-		return $this->templateCompiler;
-	}
+    /**
+     * @return TemplateCompiler
+     */
+    public function getTemplateCompiler()
+    {
+        return $this->templateCompiler;
+    }
 
-	/**
-	 * Delegation: Set the cache used by this View's compiler
-	 *
-	 * @param FluidCacheInterface $cache
-	 * @return void
-	 */
-	public function setCache(FluidCacheInterface $cache) {
-		$this->cache = $cache;
-	}
+    /**
+     * Delegation: Set the cache used by this View's compiler
+     *
+     * @param FluidCacheInterface $cache
+     * @return void
+     */
+    public function setCache(FluidCacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
 
-	/**
-	 * @return FluidCacheInterface
-	 */
-	public function getCache() {
-		return $this->cache;
-	}
+    /**
+     * @return FluidCacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCacheEnabled() {
-		return $this->cache instanceof FluidCacheInterface;
-	}
+    /**
+     * @return boolean
+     */
+    public function isCacheEnabled()
+    {
+        return $this->cache instanceof FluidCacheInterface;
+    }
 
-	/**
-	 * Delegation: Set TemplateProcessor instances in the parser
-	 * through a public API.
-	 *
-	 * @param TemplateProcessorInterface[] $templateProcessors
-	 * @return void
-	 */
-	public function setTemplateProcessors(array $templateProcessors) {
-		$this->templateProcessors = $templateProcessors;
-		foreach ($this->templateProcessors as $templateProcessor) {
-			$templateProcessor->setRenderingContext($this);
-		}
-	}
+    /**
+     * Delegation: Set TemplateProcessor instances in the parser
+     * through a public API.
+     *
+     * @param TemplateProcessorInterface[] $templateProcessors
+     * @return void
+     */
+    public function setTemplateProcessors(array $templateProcessors)
+    {
+        $this->templateProcessors = $templateProcessors;
+        foreach ($this->templateProcessors as $templateProcessor) {
+            $templateProcessor->setRenderingContext($this);
+        }
+    }
 
-	/**
-	 * @return TemplateProcessorInterface[]
-	 */
-	public function getTemplateProcessors() {
-		return $this->templateProcessors;
-	}
+    /**
+     * @return TemplateProcessorInterface[]
+     */
+    public function getTemplateProcessors()
+    {
+        return $this->templateProcessors;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getExpressionNodeTypes() {
-		return $this->expressionNodeTypes;
-	}
+    /**
+     * @return string
+     */
+    public function getExpressionNodeTypes()
+    {
+        return $this->expressionNodeTypes;
+    }
 
-	/**
-	 * @param array $expressionNodeTypes
-	 * @return void
-	 */
-	public function setExpressionNodeTypes(array $expressionNodeTypes) {
-		$this->expressionNodeTypes = $expressionNodeTypes;
-	}
+    /**
+     * @param array $expressionNodeTypes
+     * @return void
+     */
+    public function setExpressionNodeTypes(array $expressionNodeTypes)
+    {
+        $this->expressionNodeTypes = $expressionNodeTypes;
+    }
 
-	/**
-	 * Build parser configuration
-	 *
-	 * @return Configuration
-	 */
-	public function buildParserConfiguration() {
-		$parserConfiguration = new Configuration();
-		$escapeInterceptor = new Escape();
-		$parserConfiguration->addEscapingInterceptor($escapeInterceptor);
-		return $parserConfiguration;
-	}
+    /**
+     * Build parser configuration
+     *
+     * @return Configuration
+     */
+    public function buildParserConfiguration()
+    {
+        $parserConfiguration = new Configuration();
+        $escapeInterceptor = new Escape();
+        $parserConfiguration->addEscapingInterceptor($escapeInterceptor);
+        return $parserConfiguration;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getControllerName() {
-		return $this->controllerName;
-	}
+    /**
+     * @return string
+     */
+    public function getControllerName()
+    {
+        return $this->controllerName;
+    }
 
-	/**
-	 * @param string $controllerName
-	 * @return void
-	 */
-	public function setControllerName($controllerName) {
-		$this->controllerName = $controllerName;
-	}
+    /**
+     * @param string $controllerName
+     * @return void
+     */
+    public function setControllerName($controllerName)
+    {
+        $this->controllerName = $controllerName;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getControllerAction() {
-		return $this->controllerAction;
-	}
+    /**
+     * @return string
+     */
+    public function getControllerAction()
+    {
+        return $this->controllerAction;
+    }
 
-	/**
-	 * @param string $action
-	 * @return void
-	 */
-	public function setControllerAction($action) {
-		$this->controllerAction = $action;
-	}
-
+    /**
+     * @param string $action
+     * @return void
+     */
+    public function setControllerAction($action)
+    {
+        $this->controllerAction = $action;
+    }
 }

--- a/src/Core/Rendering/RenderingContextInterface.php
+++ b/src/Core/Rendering/RenderingContextInterface.php
@@ -20,162 +20,162 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 /**
  * Contract for the rendering context
  */
-interface RenderingContextInterface {
+interface RenderingContextInterface
+{
 
-	/**
-	 * Injects the template variable container containing all variables available through ObjectAccessors
-	 * in the template
-	 *
-	 * @param VariableProviderInterface $variableProvider The template variable container to set
-	 */
-	public function setVariableProvider(VariableProviderInterface $variableProvider);
+    /**
+     * Injects the template variable container containing all variables available through ObjectAccessors
+     * in the template
+     *
+     * @param VariableProviderInterface $variableProvider The template variable container to set
+     */
+    public function setVariableProvider(VariableProviderInterface $variableProvider);
 
-	/**
-	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
-	 */
-	public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer);
+    /**
+     * @param ViewHelperVariableContainer $viewHelperVariableContainer
+     */
+    public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer);
 
-	/**
-	 * Get the template variable container
-	 *
-	 * @return VariableProviderInterface The Template Variable Container
-	 */
-	public function getVariableProvider();
+    /**
+     * Get the template variable container
+     *
+     * @return VariableProviderInterface The Template Variable Container
+     */
+    public function getVariableProvider();
 
-	/**
-	 * Get the ViewHelperVariableContainer
-	 *
-	 * @return ViewHelperVariableContainer
-	 */
-	public function getViewHelperVariableContainer();
+    /**
+     * Get the ViewHelperVariableContainer
+     *
+     * @return ViewHelperVariableContainer
+     */
+    public function getViewHelperVariableContainer();
 
-	/**
-	 * @return ViewHelperResolver
-	 */
-	public function getViewHelperResolver();
+    /**
+     * @return ViewHelperResolver
+     */
+    public function getViewHelperResolver();
 
-	/**
-	 * @param ViewHelperResolver $viewHelperResolver
-	 * @return void
-	 */
-	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver);
+    /**
+     * @param ViewHelperResolver $viewHelperResolver
+     * @return void
+     */
+    public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver);
 
-	/**
-	 * @return ViewHelperInvoker
-	 */
-	public function getViewHelperInvoker();
+    /**
+     * @return ViewHelperInvoker
+     */
+    public function getViewHelperInvoker();
 
-	/**
-	 * @param ViewHelperInvoker $viewHelperInvoker
-	 * @return void
-	 */
-	public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker);
+    /**
+     * @param ViewHelperInvoker $viewHelperInvoker
+     * @return void
+     */
+    public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker);
 
-	/**
-	 * Inject the Template Parser
-	 *
-	 * @param TemplateParser $templateParser The template parser
-	 * @return void
-	 */
-	public function setTemplateParser(TemplateParser $templateParser);
+    /**
+     * Inject the Template Parser
+     *
+     * @param TemplateParser $templateParser The template parser
+     * @return void
+     */
+    public function setTemplateParser(TemplateParser $templateParser);
 
-	/**
-	 * @return TemplateParser
-	 */
-	public function getTemplateParser();
+    /**
+     * @return TemplateParser
+     */
+    public function getTemplateParser();
 
-	/**
-	 * @param TemplateCompiler $templateCompiler
-	 * @return void
-	 */
-	public function setTemplateCompiler(TemplateCompiler $templateCompiler);
+    /**
+     * @param TemplateCompiler $templateCompiler
+     * @return void
+     */
+    public function setTemplateCompiler(TemplateCompiler $templateCompiler);
 
-	/**
-	 * @return TemplateCompiler
-	 */
-	public function getTemplateCompiler();
+    /**
+     * @return TemplateCompiler
+     */
+    public function getTemplateCompiler();
 
-	/**
-	 * @return TemplatePaths
-	 */
-	public function getTemplatePaths();
+    /**
+     * @return TemplatePaths
+     */
+    public function getTemplatePaths();
 
-	/**
-	 * @param TemplatePaths $templatePaths
-	 * @return void
-	 */
-	public function setTemplatePaths(TemplatePaths $templatePaths);
+    /**
+     * @param TemplatePaths $templatePaths
+     * @return void
+     */
+    public function setTemplatePaths(TemplatePaths $templatePaths);
 
-	/**
-	 * Delegation: Set the cache used by this View's compiler
-	 *
-	 * @param FluidCacheInterface $cache
-	 * @return void
-	 */
-	public function setCache(FluidCacheInterface $cache);
+    /**
+     * Delegation: Set the cache used by this View's compiler
+     *
+     * @param FluidCacheInterface $cache
+     * @return void
+     */
+    public function setCache(FluidCacheInterface $cache);
 
-	/**
-	 * @return FluidCacheInterface
-	 */
-	public function getCache();
+    /**
+     * @return FluidCacheInterface
+     */
+    public function getCache();
 
-	/**
-	 * @return boolean
-	 */
-	public function isCacheEnabled();
+    /**
+     * @return boolean
+     */
+    public function isCacheEnabled();
 
-	/**
-	 * Delegation: Set TemplateProcessor instances in the parser
-	 * through a public API.
-	 *
-	 * @param TemplateProcessorInterface[] $templateProcessors
-	 * @return void
-	 */
-	public function setTemplateProcessors(array $templateProcessors);
+    /**
+     * Delegation: Set TemplateProcessor instances in the parser
+     * through a public API.
+     *
+     * @param TemplateProcessorInterface[] $templateProcessors
+     * @return void
+     */
+    public function setTemplateProcessors(array $templateProcessors);
 
-	/**
-	 * @return TemplateProcessorInterface[]
-	 */
-	public function getTemplateProcessors();
+    /**
+     * @return TemplateProcessorInterface[]
+     */
+    public function getTemplateProcessors();
 
-	/**
-	 * @return array
-	 */
-	public function getExpressionNodeTypes();
+    /**
+     * @return array
+     */
+    public function getExpressionNodeTypes();
 
-	/**
-	 * @param array $expressionNodeTypes
-	 * @return void
-	 */
-	public function setExpressionNodeTypes(array $expressionNodeTypes);
+    /**
+     * @param array $expressionNodeTypes
+     * @return void
+     */
+    public function setExpressionNodeTypes(array $expressionNodeTypes);
 
-	/**
-	 * Build parser configuration
-	 *
-	 * @return Configuration
-	 */
-	public function buildParserConfiguration();
+    /**
+     * Build parser configuration
+     *
+     * @return Configuration
+     */
+    public function buildParserConfiguration();
 
-	/**
-	 * @return string
-	 */
-	public function getControllerName();
+    /**
+     * @return string
+     */
+    public function getControllerName();
 
-	/**
-	 * @param string $controllerName
-	 * @return void
-	 */
-	public function setControllerName($controllerName);
+    /**
+     * @param string $controllerName
+     * @return void
+     */
+    public function setControllerName($controllerName);
 
-	/**
-	 * @return string
-	 */
-	public function getControllerAction();
+    /**
+     * @return string
+     */
+    public function getControllerAction();
 
-	/**
-	 * @param string $action
-	 * @return void
-	 */
-	public function setControllerAction($action);
-
+    /**
+     * @param string $action
+     * @return void
+     */
+    public function setControllerAction($action);
 }

--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -13,86 +13,92 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  * to be consulted whenever a variable is requested. First
  * VariableProvider to return a value "wins".
  */
-class ChainedVariableProvider extends StandardVariableProvider implements VariableProviderInterface {
+class ChainedVariableProvider extends StandardVariableProvider implements VariableProviderInterface
+{
 
-	/**
-	 * @var VariableProviderInterface[]
-	 */
-	protected $variableProviders = array();
+    /**
+     * @var VariableProviderInterface[]
+     */
+    protected $variableProviders = [];
 
-	/**
-	 * @param array $variableProviders
-	 */
-	public function __construct(array $variableProviders = array()) {
-		$this->variableProviders = $variableProviders;
-	}
+    /**
+     * @param array $variableProviders
+     */
+    public function __construct(array $variableProviders = [])
+    {
+        $this->variableProviders = $variableProviders;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAll() {
-		$merged = array();
-		foreach (array_reverse($this->variableProviders) as $provider) {
-			$merged = array_replace_recursive($merged, $provider->getAll());
-		}
-		return array_merge($merged, $this->variables);
-	}
+    /**
+     * @return array
+     */
+    public function getAll()
+    {
+        $merged = [];
+        foreach (array_reverse($this->variableProviders) as $provider) {
+            $merged = array_replace_recursive($merged, $provider->getAll());
+        }
+        return array_merge($merged, $this->variables);
+    }
 
-	/**
-	 * @param string $identifier
-	 * @return mixed
-	 */
-	public function get($identifier) {
-		if (array_key_exists($identifier, $this->variables)) {
-			return $this->variables[$identifier];
-		}
-		foreach ($this->variableProviders as $provider) {
-			$value = $provider->get($identifier);
-			if ($value !== NULL) {
-				return $value;
-			}
-		}
-		return NULL;
-	}
+    /**
+     * @param string $identifier
+     * @return mixed
+     */
+    public function get($identifier)
+    {
+        if (array_key_exists($identifier, $this->variables)) {
+            return $this->variables[$identifier];
+        }
+        foreach ($this->variableProviders as $provider) {
+            $value = $provider->get($identifier);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+        return null;
+    }
 
-	/**
-	 * @param string $path
-	 * @param array $accessors
-	 * @return mixed|null
-	 */
-	public function getByPath($path, array $accessors = array()) {
-		$value = VariableExtractor::extract($this->variables, $path, $accessors);
-		if ($value !== NULL) {
-			return $value;
-		}
-		foreach ($this->variableProviders as $provider) {
-			$value = $provider->getByPath($path, $accessors);
-			if ($value !== NULL) {
-				return $value;
-			}
-		}
-		return NULL;
-	}
+    /**
+     * @param string $path
+     * @param array $accessors
+     * @return mixed|null
+     */
+    public function getByPath($path, array $accessors = [])
+    {
+        $value = VariableExtractor::extract($this->variables, $path, $accessors);
+        if ($value !== null) {
+            return $value;
+        }
+        foreach ($this->variableProviders as $provider) {
+            $value = $provider->getByPath($path, $accessors);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+        return null;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAllIdentifiers() {
-		$merged = parent::getAllIdentifiers();
-		foreach ($this->variableProviders as $provider) {
-			$merged = array_replace_recursive($merged, $provider->getAllIdentifiers());
-		}
-		return array_values(array_unique($merged));
-	}
+    /**
+     * @return array
+     */
+    public function getAllIdentifiers()
+    {
+        $merged = parent::getAllIdentifiers();
+        foreach ($this->variableProviders as $provider) {
+            $merged = array_replace_recursive($merged, $provider->getAllIdentifiers());
+        }
+        return array_values(array_unique($merged));
+    }
 
-	/**
-	 * @param array|\ArrayAccess $variables
-	 * @return ChainedVariableProvider
-	 */
-	public function getScopeCopy($variables) {
-		$clone = clone $this;
-		$clone->setSource($variables);
-		return $clone;
-	}
-
+    /**
+     * @param array|\ArrayAccess $variables
+     * @return ChainedVariableProvider
+     */
+    public function getScopeCopy($variables)
+    {
+        $clone = clone $this;
+        $clone->setSource($variables);
+        return $clone;
+    }
 }

--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -12,94 +12,101 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  * VariableProvider capable of using JSON files
  * and streams as data source.
  */
-class JSONVariableProvider extends StandardVariableProvider implements VariableProviderInterface {
+class JSONVariableProvider extends StandardVariableProvider implements VariableProviderInterface
+{
 
-	/**
-	 * @var integer
-	 */
-	protected $lastLoaded = 0;
+    /**
+     * @var integer
+     */
+    protected $lastLoaded = 0;
 
-	/**
-	 * Lifetime of fetched JSON sources before refetch. Using
-	 * a hard value avoids the need to re-query using HEAD and
-	 * should allow any HTTPD process to finish in time but make
-	 * any CLI/infinite running scripts re-fetch JSON after this
-	 * time has passed.
-	 *
-	 * @var integer
-	 */
-	protected $ttl = 15;
+    /**
+     * Lifetime of fetched JSON sources before refetch. Using
+     * a hard value avoids the need to re-query using HEAD and
+     * should allow any HTTPD process to finish in time but make
+     * any CLI/infinite running scripts re-fetch JSON after this
+     * time has passed.
+     *
+     * @var integer
+     */
+    protected $ttl = 15;
 
-	/**
-	 * JSON source. Either a complete JSON string with an object
-	 * inside, or a reference to a JSON file either local or
-	 * remote (supporting any stream types PHP supports).
-	 *
-	 * @var string
-	 */
-	protected $source = NULL;
+    /**
+     * JSON source. Either a complete JSON string with an object
+     * inside, or a reference to a JSON file either local or
+     * remote (supporting any stream types PHP supports).
+     *
+     * @var string
+     */
+    protected $source = null;
 
-	/**
-	 * @return string
-	 */
-	public function getSource() {
-		return $this->source;
-	}
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
 
-	/**
-	 * @param string $source
-	 * @return void
-	 */
-	public function setSource($source) {
-		$this->source = $source;
-	}
+    /**
+     * @param string $source
+     * @return void
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAll() {
-		$this->load();
-		return parent::getAll();
-	}
+    /**
+     * @return array
+     */
+    public function getAll()
+    {
+        $this->load();
+        return parent::getAll();
+    }
 
-	/**
-	 * @param string $identifier
-	 * @return mixed
-	 */
-	public function get($identifier) {
-		$this->load();
-		return parent::get($identifier);
-	}
+    /**
+     * @param string $identifier
+     * @return mixed
+     */
+    public function get($identifier)
+    {
+        $this->load();
+        return parent::get($identifier);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAllIdentifiers() {
-		$this->load();
-		return parent::getAllIdentifiers();
-	}
+    /**
+     * @return array
+     */
+    public function getAllIdentifiers()
+    {
+        $this->load();
+        return parent::getAllIdentifiers();
+    }
 
-	/**
-	 * @return void
-	 */
-	protected function load() {
-		if ($this->source !== NULL && time() > ($this->lastLoaded + $this->ttl)) {
-			if (!$this->isJSON($this->source)) {
-				$source = file_get_contents($this->source);
-			} else {
-				$source = $this->source;
-			}
-			$this->variables = json_decode($source, defined('JSON_OBJECT_AS_ARRAY') ? JSON_OBJECT_AS_ARRAY : 1);
-			$this->lastLoaded = time();
-		}
-	}
+    /**
+     * @return void
+     */
+    protected function load()
+    {
+        if ($this->source !== null && time() > ($this->lastLoaded + $this->ttl)) {
+            if (!$this->isJSON($this->source)) {
+                $source = file_get_contents($this->source);
+            } else {
+                $source = $this->source;
+            }
+            $this->variables = json_decode($source, defined('JSON_OBJECT_AS_ARRAY') ? JSON_OBJECT_AS_ARRAY : 1);
+            $this->lastLoaded = time();
+        }
+    }
 
-	/**
-	 * @param string $string
-	 */
-	protected function isJSON($string) {
-		$string = trim($string);
-		return ($string{0} === '{' && substr($string, -1) === '}');
-	}
-
+    /**
+     * @param string $string
+     */
+    protected function isJSON($string)
+    {
+        $string = trim($string);
+        return ($string{0} === '{' && substr($string, -1) === '}');
+    }
 }

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -9,189 +9,205 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
 /**
  * Class StandardVariableProvider
  */
-class StandardVariableProvider implements VariableProviderInterface {
+class StandardVariableProvider implements VariableProviderInterface
+{
 
-	/**
-	 * Variables stored in context
-	 *
-	 * @var mixed
-	 */
-	protected $variables = array();
+    /**
+     * Variables stored in context
+     *
+     * @var mixed
+     */
+    protected $variables = [];
 
-	/**
-	 * Variables, if any, with which to initialize this
-	 * VariableProvider.
-	 *
-	 * @param array $variables
-	 */
-	public function __construct(array $variables = array()) {
-		$this->variables = $variables;
-	}
+    /**
+     * Variables, if any, with which to initialize this
+     * VariableProvider.
+     *
+     * @param array $variables
+     */
+    public function __construct(array $variables = [])
+    {
+        $this->variables = $variables;
+    }
 
-	/**
-	 * @param array|\ArrayAccess $variables
-	 * @return VariableProviderInterface
-	 */
-	public function getScopeCopy($variables) {
-		if (!array_key_exists('settings', $variables) && array_key_exists('settings', $this->variables)) {
-			$variables['settings'] = $this->variables['settings'];
-		}
-		$className = get_class($this);
-		return new $className($variables);
-	}
+    /**
+     * @param array|\ArrayAccess $variables
+     * @return VariableProviderInterface
+     */
+    public function getScopeCopy($variables)
+    {
+        if (!array_key_exists('settings', $variables) && array_key_exists('settings', $this->variables)) {
+            $variables['settings'] = $this->variables['settings'];
+        }
+        $className = get_class($this);
+        return new $className($variables);
+    }
 
-	/**
-	 * Set the source data used by this VariableProvider. The
-	 * source can be any type, but the type must of course be
-	 * supported by the VariableProvider itself.
-	 *
-	 * @param mixed $source
-	 * @return void
-	 */
-	public function setSource($source) {
-		$this->variables = $source;
-	}
+    /**
+     * Set the source data used by this VariableProvider. The
+     * source can be any type, but the type must of course be
+     * supported by the VariableProvider itself.
+     *
+     * @param mixed $source
+     * @return void
+     */
+    public function setSource($source)
+    {
+        $this->variables = $source;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getSource() {
-		return $this->variables;
-	}
+    /**
+     * @return array
+     */
+    public function getSource()
+    {
+        return $this->variables;
+    }
 
-	/**
-	 * Get every variable provisioned by the VariableProvider
-	 * implementing the interface. Must return an array or
-	 * ArrayAccess instance!
-	 *
-	 * @return array|\ArrayAccess
-	 */
-	public function getAll() {
-		return $this->variables;
-	}
+    /**
+     * Get every variable provisioned by the VariableProvider
+     * implementing the interface. Must return an array or
+     * ArrayAccess instance!
+     *
+     * @return array|\ArrayAccess
+     */
+    public function getAll()
+    {
+        return $this->variables;
+    }
 
-	/**
-	 * Add a variable to the context
-	 *
-	 * @param string $identifier Identifier of the variable to add
-	 * @param mixed $value The variable's value
-	 * @return void
-	 * @api
-	 */
-	public function add($identifier, $value) {
-		$this->variables[$identifier] = $value;
-	}
+    /**
+     * Add a variable to the context
+     *
+     * @param string $identifier Identifier of the variable to add
+     * @param mixed $value The variable's value
+     * @return void
+     * @api
+     */
+    public function add($identifier, $value)
+    {
+        $this->variables[$identifier] = $value;
+    }
 
-	/**
-	 * Get a variable from the context. Throws exception if variable is not found in context.
-	 *
-	 * If "_all" is given as identifier, all variables are returned in an array,
-	 * if one of the other reserved variables are given, their appropriate value
-	 * they're representing is returned.
-	 *
-	 * @param string $identifier
-	 * @return mixed The variable value identified by $identifier
-	 * @api
-	 */
-	public function get($identifier) {
-		return $this->getByPath($identifier);
-	}
+    /**
+     * Get a variable from the context. Throws exception if variable is not found in context.
+     *
+     * If "_all" is given as identifier, all variables are returned in an array,
+     * if one of the other reserved variables are given, their appropriate value
+     * they're representing is returned.
+     *
+     * @param string $identifier
+     * @return mixed The variable value identified by $identifier
+     * @api
+     */
+    public function get($identifier)
+    {
+        return $this->getByPath($identifier);
+    }
 
-	/**
-	 * Get a variable by dotted path expression, retrieving the
-	 * variable from nested arrays/objects one segment at a time.
-	 * If the second variable is passed, it is expected to contain
-	 * extraction method names (constants from VariableExtractor)
-	 * which indicate how each value is extracted.
-	 *
-	 * @param string $path
-	 * @return mixed
-	 */
-	public function getByPath($path, array $accessors = array()) {
-		return VariableExtractor::extract($this->variables, $path, $accessors);
-	}
+    /**
+     * Get a variable by dotted path expression, retrieving the
+     * variable from nested arrays/objects one segment at a time.
+     * If the second variable is passed, it is expected to contain
+     * extraction method names (constants from VariableExtractor)
+     * which indicate how each value is extracted.
+     *
+     * @param string $path
+     * @return mixed
+     */
+    public function getByPath($path, array $accessors = [])
+    {
+        return VariableExtractor::extract($this->variables, $path, $accessors);
+    }
 
-	/**
-	 * Remove a variable from context. Throws exception if variable is not found in context.
-	 *
-	 * @param string $identifier The identifier to remove
-	 * @return void
-	 * @api
-	 */
-	public function remove($identifier) {
-		if (array_key_exists($identifier, $this->variables)) {
-			unset($this->variables[$identifier]);
-		}
-	}
+    /**
+     * Remove a variable from context. Throws exception if variable is not found in context.
+     *
+     * @param string $identifier The identifier to remove
+     * @return void
+     * @api
+     */
+    public function remove($identifier)
+    {
+        if (array_key_exists($identifier, $this->variables)) {
+            unset($this->variables[$identifier]);
+        }
+    }
 
-	/**
-	 * Returns an array of all identifiers available in the context.
-	 *
-	 * @return array Array of identifier strings
-	 */
-	public function getAllIdentifiers() {
-		return array_keys($this->variables);
-	}
+    /**
+     * Returns an array of all identifiers available in the context.
+     *
+     * @return array Array of identifier strings
+     */
+    public function getAllIdentifiers()
+    {
+        return array_keys($this->variables);
+    }
 
-	/**
-	 * Checks if this property exists in the VariableContainer.
-	 *
-	 * @param string $identifier
-	 * @return boolean TRUE if $identifier exists, FALSE otherwise
-	 * @api
-	 */
-	public function exists($identifier) {
-		return array_key_exists($identifier, $this->variables);
-	}
+    /**
+     * Checks if this property exists in the VariableContainer.
+     *
+     * @param string $identifier
+     * @return boolean TRUE if $identifier exists, FALSE otherwise
+     * @api
+     */
+    public function exists($identifier)
+    {
+        return array_key_exists($identifier, $this->variables);
+    }
 
-	/**
-	 * Clean up for serializing.
-	 *
-	 * @return string[]
-	 */
-	public function __sleep() {
-		return array('variables');
-	}
+    /**
+     * Clean up for serializing.
+     *
+     * @return string[]
+     */
+    public function __sleep()
+    {
+        return ['variables'];
+    }
 
-	/**
-	 * Adds a variable to the context.
-	 *
-	 * @param string $identifier Identifier of the variable to add
-	 * @param mixed $value The variable's value
-	 * @return void
-	 */
-	public function offsetSet($identifier, $value) {
-		$this->add($identifier, $value);
-	}
+    /**
+     * Adds a variable to the context.
+     *
+     * @param string $identifier Identifier of the variable to add
+     * @param mixed $value The variable's value
+     * @return void
+     */
+    public function offsetSet($identifier, $value)
+    {
+        $this->add($identifier, $value);
+    }
 
-	/**
-	 * Remove a variable from context. Throws exception if variable is not found in context.
-	 *
-	 * @param string $identifier The identifier to remove
-	 * @return void
-	 */
-	public function offsetUnset($identifier) {
-		$this->remove($identifier);
-	}
+    /**
+     * Remove a variable from context. Throws exception if variable is not found in context.
+     *
+     * @param string $identifier The identifier to remove
+     * @return void
+     */
+    public function offsetUnset($identifier)
+    {
+        $this->remove($identifier);
+    }
 
-	/**
-	 * Checks if this property exists in the VariableContainer.
-	 *
-	 * @param string $identifier
-	 * @return boolean TRUE if $identifier exists, FALSE otherwise
-	 */
-	public function offsetExists($identifier) {
-		return $this->exists($identifier);
-	}
+    /**
+     * Checks if this property exists in the VariableContainer.
+     *
+     * @param string $identifier
+     * @return boolean TRUE if $identifier exists, FALSE otherwise
+     */
+    public function offsetExists($identifier)
+    {
+        return $this->exists($identifier);
+    }
 
-	/**
-	 * Get a variable from the context. Throws exception if variable is not found in context.
-	 *
-	 * @param string $identifier
-	 * @return mixed The variable identified by $identifier
-	 */
-	public function offsetGet($identifier) {
-		return $this->get($identifier);
-	}
-
+    /**
+     * Get a variable from the context. Throws exception if variable is not found in context.
+     *
+     * @param string $identifier
+     * @return mixed The variable identified by $identifier
+     */
+    public function offsetGet($identifier)
+    {
+        return $this->get($identifier);
+    }
 }

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -12,204 +12,213 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  * Extracts variables from arrays/objects by use
  * of array accessing and basic getter methods.
  */
-class VariableExtractor {
+class VariableExtractor
+{
 
-	const ACCESSOR_ARRAY = 'array';
-	const ACCESSOR_GETTER = 'getter';
-	const ACCESSOR_ASSERTER = 'asserter';
-	const ACCESSOR_PUBLICPROPERTY = 'public';
+    const ACCESSOR_ARRAY = 'array';
+    const ACCESSOR_GETTER = 'getter';
+    const ACCESSOR_ASSERTER = 'asserter';
+    const ACCESSOR_PUBLICPROPERTY = 'public';
 
-	/**
-	 * Static interface for instanciating and extracting
-	 * in a single operation. Delegates to getByPath.
-	 *
-	 * @param mixed $subject
-	 * @param string $propertyPath
-	 * @param array $accessors
-	 * @return mixed
-	 */
-	public static function extract($subject, $propertyPath, array $accessors = array()) {
-		$extractor = new self();
-		return $extractor->getByPath($subject, $propertyPath, $accessors);
-	}
+    /**
+     * Static interface for instanciating and extracting
+     * in a single operation. Delegates to getByPath.
+     *
+     * @param mixed $subject
+     * @param string $propertyPath
+     * @param array $accessors
+     * @return mixed
+     */
+    public static function extract($subject, $propertyPath, array $accessors = [])
+    {
+        $extractor = new self();
+        return $extractor->getByPath($subject, $propertyPath, $accessors);
+    }
 
-	/**
-	 * Static interface for instanciating and extracting
-	 * accessors for each segment of the path.
-	 *
-	 * @param VariableProviderInterface $subject
-	 * @param string $propertyPath
-	 * @return mixed
-	 */
-	public static function extractAccessors($subject, $propertyPath) {
-		$extractor = new self();
-		return $extractor->getAccessorsForPath($subject, $propertyPath);
-	}
+    /**
+     * Static interface for instanciating and extracting
+     * accessors for each segment of the path.
+     *
+     * @param VariableProviderInterface $subject
+     * @param string $propertyPath
+     * @return mixed
+     */
+    public static function extractAccessors($subject, $propertyPath)
+    {
+        $extractor = new self();
+        return $extractor->getAccessorsForPath($subject, $propertyPath);
+    }
 
-	/**
-	 * Extracts a variable by path, recursively, from the
-	 * subject pass in argument. This implementation supports
-	 * recursive variable references by using {} around sub-
-	 * references, e.g. "array.{index}" will first get the
-	 * "array" variable, then resolve the "index" variable
-	 * before using the value of "index" as name of the property
-	 * to return. So:
-	 *
-	 * $subject = array('foo' => array('bar' => 'baz'), 'key' => 'bar')
-	 * $propertyPath = 'foo.{key}';
-	 * $result = ...getByPath($subject, $propertyPath);
-	 * // $result value is "baz", because $subject['foo'][$subject['key']] = 'baz';
-	 *
-	 * @param mixed $subject
-	 * @param string $propertyPath
-	 * @param array $accessors
-	 * @return mixed
-	 */
-	public function getByPath($subject, $propertyPath, array $accessors = array()) {
-		if ($subject instanceof StandardVariableProvider) {
-			return $subject->getByPath($propertyPath, $accessors);
-		}
+    /**
+     * Extracts a variable by path, recursively, from the
+     * subject pass in argument. This implementation supports
+     * recursive variable references by using {} around sub-
+     * references, e.g. "array.{index}" will first get the
+     * "array" variable, then resolve the "index" variable
+     * before using the value of "index" as name of the property
+     * to return. So:
+     *
+     * $subject = array('foo' => array('bar' => 'baz'), 'key' => 'bar')
+     * $propertyPath = 'foo.{key}';
+     * $result = ...getByPath($subject, $propertyPath);
+     * // $result value is "baz", because $subject['foo'][$subject['key']] = 'baz';
+     *
+     * @param mixed $subject
+     * @param string $propertyPath
+     * @param array $accessors
+     * @return mixed
+     */
+    public function getByPath($subject, $propertyPath, array $accessors = [])
+    {
+        if ($subject instanceof StandardVariableProvider) {
+            return $subject->getByPath($propertyPath, $accessors);
+        }
 
-		$propertyPath = $this->resolveSubVariableReferences($subject, $propertyPath);
-		$propertyPathSegments = explode('.', $propertyPath);
-		foreach ($propertyPathSegments as $index => $pathSegment) {
-			$accessor = isset($accessors[$index]) ? $accessors[$index] : NULL;
-			$subject = $this->extractSingleValue($subject, $pathSegment, $accessor);
-			if ($subject === NULL) {
-				break;
-			}
-		}
-		return $subject;
-	}
+        $propertyPath = $this->resolveSubVariableReferences($subject, $propertyPath);
+        $propertyPathSegments = explode('.', $propertyPath);
+        foreach ($propertyPathSegments as $index => $pathSegment) {
+            $accessor = isset($accessors[$index]) ? $accessors[$index] : null;
+            $subject = $this->extractSingleValue($subject, $pathSegment, $accessor);
+            if ($subject === null) {
+                break;
+            }
+        }
+        return $subject;
+    }
 
-	/**
-	 * @param mixed $subject
-	 * @param string $propertyPath
-	 * @return array
-	 */
-	public function getAccessorsForPath($subject, $propertyPath) {
-		$accessors = array();
-		$propertyPathSegments = explode('.', $propertyPath);
-		foreach ($propertyPathSegments as $index => $pathSegment) {
-			$accessor = $this->detectAccessor($subject, $pathSegment);
-			if ($accessor === NULL) {
-				// Note: this may include cases of sub-variable references. When such
-				// a reference is encountered the accessor chain is stopped and new
-				// accessors will be detected for the sub-variable and all following
-				// path segments since the variable is now fully dynamic.
-				break;
-			}
-			$accessors[] = $accessor;
-			$subject = $this->extractSingleValue($subject, $pathSegment);
-		}
-		return $accessors;
-	}
+    /**
+     * @param mixed $subject
+     * @param string $propertyPath
+     * @return array
+     */
+    public function getAccessorsForPath($subject, $propertyPath)
+    {
+        $accessors = [];
+        $propertyPathSegments = explode('.', $propertyPath);
+        foreach ($propertyPathSegments as $index => $pathSegment) {
+            $accessor = $this->detectAccessor($subject, $pathSegment);
+            if ($accessor === null) {
+                // Note: this may include cases of sub-variable references. When such
+                // a reference is encountered the accessor chain is stopped and new
+                // accessors will be detected for the sub-variable and all following
+                // path segments since the variable is now fully dynamic.
+                break;
+            }
+            $accessors[] = $accessor;
+            $subject = $this->extractSingleValue($subject, $pathSegment);
+        }
+        return $accessors;
+    }
 
-	/**
-	 * @param mixed $subject
-	 * @param string $propertyPath
-	 * @return array
-	 */
-	protected function resolveSubVariableReferences($subject, $propertyPath) {
-		if (strpos($propertyPath, '{') !== FALSE) {
-			preg_match_all('/(\{.*\})/', $propertyPath, $matches);
-			foreach ($matches[1] as $match) {
-				$subPropertyPath = substr($match, 1, -1);
-				$propertyPath = str_replace($match, $this->getByPath($subject, $subPropertyPath), $propertyPath);
-			}
-		}
-		return $propertyPath;
-	}
+    /**
+     * @param mixed $subject
+     * @param string $propertyPath
+     * @return array
+     */
+    protected function resolveSubVariableReferences($subject, $propertyPath)
+    {
+        if (strpos($propertyPath, '{') !== false) {
+            preg_match_all('/(\{.*\})/', $propertyPath, $matches);
+            foreach ($matches[1] as $match) {
+                $subPropertyPath = substr($match, 1, -1);
+                $propertyPath = str_replace($match, $this->getByPath($subject, $subPropertyPath), $propertyPath);
+            }
+        }
+        return $propertyPath;
+    }
 
-	/**
-	 * Extracts a single value from an array or object.
-	 *
-	 * @param mixed $subject
-	 * @param string $propertyName
-	 * @param string|null $accessor
-	 * @return mixed
-	 */
-	protected function extractSingleValue($subject, $propertyName, $accessor = NULL) {
-		if (!$accessor || !$this->canExtractWithAccessor($subject, $propertyName, $accessor)) {
-			$accessor = $this->detectAccessor($subject, $propertyName);
-		}
-		return $this->extractWithAccessor($subject, $propertyName, $accessor);
-	}
+    /**
+     * Extracts a single value from an array or object.
+     *
+     * @param mixed $subject
+     * @param string $propertyName
+     * @param string|null $accessor
+     * @return mixed
+     */
+    protected function extractSingleValue($subject, $propertyName, $accessor = null)
+    {
+        if (!$accessor || !$this->canExtractWithAccessor($subject, $propertyName, $accessor)) {
+            $accessor = $this->detectAccessor($subject, $propertyName);
+        }
+        return $this->extractWithAccessor($subject, $propertyName, $accessor);
+    }
 
-	/**
-	 * Returns TRUE if the data type of $subject is potentially compatible
-	 * with the $accessor.
-	 *
-	 * @param mixed $subject
-	 * @param string $propertyName
-	 * @param string $accessor
-	 * @return boolean
-	 */
-	protected function canExtractWithAccessor($subject, $propertyName, $accessor) {
-		$class = is_object($subject) ? get_class($subject) : FALSE;
-		if ($accessor === self::ACCESSOR_ARRAY) {
-			return (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)));
-		} elseif ($accessor === self::ACCESSOR_GETTER) {
-			return ($class !== FALSE && method_exists($subject, 'get' . ucfirst($propertyName)));
-		} elseif ($accessor === self::ACCESSOR_ASSERTER) {
-			return ($class !== FALSE && method_exists($subject, 'is' . ucfirst($propertyName)));
-		} elseif ($accessor === self::ACCESSOR_PUBLICPROPERTY) {
-			return ($class !== FALSE && property_exists($subject, $propertyName));
-		}
-		return FALSE;
-	}
+    /**
+     * Returns TRUE if the data type of $subject is potentially compatible
+     * with the $accessor.
+     *
+     * @param mixed $subject
+     * @param string $propertyName
+     * @param string $accessor
+     * @return boolean
+     */
+    protected function canExtractWithAccessor($subject, $propertyName, $accessor)
+    {
+        $class = is_object($subject) ? get_class($subject) : false;
+        if ($accessor === self::ACCESSOR_ARRAY) {
+            return (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)));
+        } elseif ($accessor === self::ACCESSOR_GETTER) {
+            return ($class !== false && method_exists($subject, 'get' . ucfirst($propertyName)));
+        } elseif ($accessor === self::ACCESSOR_ASSERTER) {
+            return ($class !== false && method_exists($subject, 'is' . ucfirst($propertyName)));
+        } elseif ($accessor === self::ACCESSOR_PUBLICPROPERTY) {
+            return ($class !== false && property_exists($subject, $propertyName));
+        }
+        return false;
+    }
 
-	/**
-	 * @param mixed $subject
-	 * @param string $propertyName
-	 * @param string $accessor
-	 * @return mixed
-	 */
-	protected function extractWithAccessor($subject, $propertyName, $accessor) {
-		if ($accessor === self::ACCESSOR_ARRAY && is_array($subject) && array_key_exists($propertyName, $subject)
-			|| $subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)
-		) {
-			return $subject[$propertyName];
-		} elseif (is_object($subject)) {
-			if ($accessor === self::ACCESSOR_GETTER) {
-				return call_user_func_array(array($subject, 'get' . ucfirst($propertyName)), array());
-			} elseif ($accessor === self::ACCESSOR_ASSERTER) {
-				return call_user_func_array(array($subject, 'is' . ucfirst($propertyName)), array());
-			} elseif ($accessor === self::ACCESSOR_PUBLICPROPERTY && property_exists($subject, $propertyName)) {
-				return $subject->$propertyName;
-			}
-		}
-		return NULL;
-	}
+    /**
+     * @param mixed $subject
+     * @param string $propertyName
+     * @param string $accessor
+     * @return mixed
+     */
+    protected function extractWithAccessor($subject, $propertyName, $accessor)
+    {
+        if ($accessor === self::ACCESSOR_ARRAY && is_array($subject) && array_key_exists($propertyName, $subject)
+            || $subject instanceof \ArrayAccess && $subject->offsetExists($propertyName)
+        ) {
+            return $subject[$propertyName];
+        } elseif (is_object($subject)) {
+            if ($accessor === self::ACCESSOR_GETTER) {
+                return call_user_func_array([$subject, 'get' . ucfirst($propertyName)], []);
+            } elseif ($accessor === self::ACCESSOR_ASSERTER) {
+                return call_user_func_array([$subject, 'is' . ucfirst($propertyName)], []);
+            } elseif ($accessor === self::ACCESSOR_PUBLICPROPERTY && property_exists($subject, $propertyName)) {
+                return $subject->$propertyName;
+            }
+        }
+        return null;
+    }
 
-	/**
-	 * Detect which type of accessor to use when extracting
-	 * $propertyName from $subject.
-	 *
-	 * @param mixed $subject
-	 * @param string $propertyName
-	 * @return string|NULL
-	 */
-	protected function detectAccessor($subject, $propertyName) {
-		if (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName))) {
-			return self::ACCESSOR_ARRAY;
-		}
-		if (is_object($subject)) {
-			$upperCasePropertyName = ucfirst($propertyName);
-			$getter = 'get' . $upperCasePropertyName;
-			$asserter = 'is' . $upperCasePropertyName;
-			if (method_exists($subject, $getter)) {
-				return self::ACCESSOR_GETTER;
-			}
-			if (method_exists($subject, $asserter)) {
-				return self::ACCESSOR_ASSERTER;
-			}
-			if (property_exists($subject, $propertyName)) {
-				return self::ACCESSOR_PUBLICPROPERTY;
-			}
-		}
+    /**
+     * Detect which type of accessor to use when extracting
+     * $propertyName from $subject.
+     *
+     * @param mixed $subject
+     * @param string $propertyName
+     * @return string|NULL
+     */
+    protected function detectAccessor($subject, $propertyName)
+    {
+        if (is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName))) {
+            return self::ACCESSOR_ARRAY;
+        }
+        if (is_object($subject)) {
+            $upperCasePropertyName = ucfirst($propertyName);
+            $getter = 'get' . $upperCasePropertyName;
+            $asserter = 'is' . $upperCasePropertyName;
+            if (method_exists($subject, $getter)) {
+                return self::ACCESSOR_GETTER;
+            }
+            if (method_exists($subject, $asserter)) {
+                return self::ACCESSOR_ASSERTER;
+            }
+            if (property_exists($subject, $propertyName)) {
+                return self::ACCESSOR_PUBLICPROPERTY;
+            }
+        }
 
-		return NULL;
-	}
-
+        return null;
+    }
 }

--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -17,143 +17,143 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  * constructor variables argument for anything, but
  * should at least implement the getting methods.
  */
-interface VariableProviderInterface extends \ArrayAccess {
+interface VariableProviderInterface extends \ArrayAccess
+{
 
-	/**
-	 * Variables, if any, with which to initialize this
-	 * VariableProvider.
-	 *
-	 * @param array $variables
-	 */
-	public function __construct(array $variables = array());
+    /**
+     * Variables, if any, with which to initialize this
+     * VariableProvider.
+     *
+     * @param array $variables
+     */
+    public function __construct(array $variables = []);
 
-	/**
-	 * Gets a fresh instance of this type of VariableProvider
-	 * and fills it with the variables passed in $variables.
-	 *
-	 * Can be overridden to enable special instance creation
-	 * of the new VariableProvider as well as take care of any
-	 * automatically transferred variables (in the default
-	 * implementation the $settings variable is transferred).
-	 *
-	 * @param array|\ArrayAccess $variables
-	 * @return VariableProviderInterface
-	 */
-	public function getScopeCopy($variables);
+    /**
+     * Gets a fresh instance of this type of VariableProvider
+     * and fills it with the variables passed in $variables.
+     *
+     * Can be overridden to enable special instance creation
+     * of the new VariableProvider as well as take care of any
+     * automatically transferred variables (in the default
+     * implementation the $settings variable is transferred).
+     *
+     * @param array|\ArrayAccess $variables
+     * @return VariableProviderInterface
+     */
+    public function getScopeCopy($variables);
 
-	/**
-	 * Set the source data used by this VariableProvider. The
-	 * source can be any type, but the type must of course be
-	 * supported by the VariableProvider itself.
-	 *
-	 * @param mixed $source
-	 * @return void
-	 */
-	public function setSource($source);
+    /**
+     * Set the source data used by this VariableProvider. The
+     * source can be any type, but the type must of course be
+     * supported by the VariableProvider itself.
+     *
+     * @param mixed $source
+     * @return void
+     */
+    public function setSource($source);
 
-	/**
-	 * @return string
-	 */
-	public function getSource();
+    /**
+     * @return string
+     */
+    public function getSource();
 
-	/**
-	 * Get every variable provisioned by the VariableProvider
-	 * implementing the interface. Must return an array or
-	 * ArrayAccess instance!
-	 *
-	 * @return array|\ArrayAccess
-	 */
-	public function getAll();
+    /**
+     * Get every variable provisioned by the VariableProvider
+     * implementing the interface. Must return an array or
+     * ArrayAccess instance!
+     *
+     * @return array|\ArrayAccess
+     */
+    public function getAll();
 
-	/**
-	 * Add a variable to the context
-	 *
-	 * @param string $identifier Identifier of the variable to add
-	 * @param mixed $value The variable's value
-	 * @return void
-	 * @throws Exception\InvalidVariableException
-	 * @api
-	 */
-	public function add($identifier, $value);
+    /**
+     * Add a variable to the context
+     *
+     * @param string $identifier Identifier of the variable to add
+     * @param mixed $value The variable's value
+     * @return void
+     * @throws Exception\InvalidVariableException
+     * @api
+     */
+    public function add($identifier, $value);
 
-	/**
-	 * Get a variable from the context.
-	 *
-	 * @param string $identifier
-	 * @return mixed The variable value identified by $identifier
-	 * @api
-	 */
-	public function get($identifier);
+    /**
+     * Get a variable from the context.
+     *
+     * @param string $identifier
+     * @return mixed The variable value identified by $identifier
+     * @api
+     */
+    public function get($identifier);
 
-	/**
-	 * Get a variable by dotted path expression, retrieving the
-	 * variable from nested arrays/objects one segment at a time.
-	 * If the second variable is passed, it is expected to contain
-	 * extraction method names (constants from VariableExtractor)
-	 * which indicate how each value is extracted.
-	 *
-	 * @param string $path
-	 * @param array $accessors
-	 * @return mixed
-	 */
-	public function getByPath($path, array $accessors = array());
+    /**
+     * Get a variable by dotted path expression, retrieving the
+     * variable from nested arrays/objects one segment at a time.
+     * If the second variable is passed, it is expected to contain
+     * extraction method names (constants from VariableExtractor)
+     * which indicate how each value is extracted.
+     *
+     * @param string $path
+     * @param array $accessors
+     * @return mixed
+     */
+    public function getByPath($path, array $accessors = []);
 
-	/**
-	 * Remove a variable from context.
-	 *
-	 * @param string $identifier The identifier to remove
-	 * @return void
-	 * @api
-	 */
-	public function remove($identifier);
+    /**
+     * Remove a variable from context.
+     *
+     * @param string $identifier The identifier to remove
+     * @return void
+     * @api
+     */
+    public function remove($identifier);
 
-	/**
-	 * Returns an array of all identifiers available in the context.
-	 *
-	 * @return array Array of identifier strings
-	 */
-	public function getAllIdentifiers();
+    /**
+     * Returns an array of all identifiers available in the context.
+     *
+     * @return array Array of identifier strings
+     */
+    public function getAllIdentifiers();
 
-	/**
-	 * Checks if this property exists in the VariableContainer.
-	 *
-	 * @param string $identifier
-	 * @return boolean TRUE if $identifier exists, FALSE otherwise
-	 * @api
-	 */
-	public function exists($identifier);
+    /**
+     * Checks if this property exists in the VariableContainer.
+     *
+     * @param string $identifier
+     * @return boolean TRUE if $identifier exists, FALSE otherwise
+     * @api
+     */
+    public function exists($identifier);
 
-	/**
-	 * Adds a variable to the context.
-	 *
-	 * @param string $identifier Identifier of the variable to add
-	 * @param mixed $value The variable's value
-	 * @return void
-	 */
-	public function offsetSet($identifier, $value);
+    /**
+     * Adds a variable to the context.
+     *
+     * @param string $identifier Identifier of the variable to add
+     * @param mixed $value The variable's value
+     * @return void
+     */
+    public function offsetSet($identifier, $value);
 
-	/**
-	 * Remove a variable from context.
-	 *
-	 * @param string $identifier The identifier to remove
-	 * @return void
-	 */
-	public function offsetUnset($identifier);
+    /**
+     * Remove a variable from context.
+     *
+     * @param string $identifier The identifier to remove
+     * @return void
+     */
+    public function offsetUnset($identifier);
 
-	/**
-	 * Checks if this property exists in the VariableContainer.
-	 *
-	 * @param string $identifier
-	 * @return boolean TRUE if $identifier exists, FALSE otherwise
-	 */
-	public function offsetExists($identifier);
+    /**
+     * Checks if this property exists in the VariableContainer.
+     *
+     * @param string $identifier
+     * @return boolean TRUE if $identifier exists, FALSE otherwise
+     */
+    public function offsetExists($identifier);
 
-	/**
-	 * Get a variable from the context.
-	 *
-	 * @param string $identifier
-	 * @return mixed The variable identified by $identifier
-	 */
-	public function offsetGet($identifier);
-
+    /**
+     * Get a variable from the context.
+     *
+     * @param string $identifier
+     * @return mixed The variable identified by $identifier
+     */
+    public function offsetGet($identifier);
 }

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -29,186 +29,194 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *
  * @api
  */
-abstract class AbstractConditionViewHelper extends AbstractViewHelper {
+abstract class AbstractConditionViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * Initializes the "then" and "else" arguments
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', FALSE);
-		$this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', FALSE);
-		$this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', FALSE, FALSE);
-	}
+    /**
+     * Initializes the "then" and "else" arguments
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
+        $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
+        $this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', false, false);
+    }
 
-	/**
-	 * Static method which can be overridden by subclasses. If a subclass
-	 * requires a different (or faster) decision then this method is the one
-	 * to override and implement.
-	 *
-	 * Note: method signature does not type-hint that an array is desired,
-	 * and as such, *appears* to accept any input type. There is no type hint
-	 * here for legacy reasons - the signature is kept compatible with third
-	 * party packages which depending on PHP version would error out if this
-	 * signature was not compatible with that of existing and in-production
-	 * subclasses that will be using this base class in the future. Let this
-	 * be a warning if someone considers changing this method signature!
-	 *
-	 * @param array|NULL $arguments
-	 * @return boolean
-	 * @api
-	 */
-	protected static function evaluateCondition($arguments = NULL) {
-		return (boolean) $arguments['condition'];
-	}
+    /**
+     * Static method which can be overridden by subclasses. If a subclass
+     * requires a different (or faster) decision then this method is the one
+     * to override and implement.
+     *
+     * Note: method signature does not type-hint that an array is desired,
+     * and as such, *appears* to accept any input type. There is no type hint
+     * here for legacy reasons - the signature is kept compatible with third
+     * party packages which depending on PHP version would error out if this
+     * signature was not compatible with that of existing and in-production
+     * subclasses that will be using this base class in the future. Let this
+     * be a warning if someone considers changing this method signature!
+     *
+     * @param array|NULL $arguments
+     * @return boolean
+     * @api
+     */
+    protected static function evaluateCondition($arguments = null)
+    {
+        return (boolean) $arguments['condition'];
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		if (static::evaluateCondition($arguments)) {
-			if (isset($arguments['then'])) {
-				return $arguments['then'];
-			}
-			if (isset($arguments['__thenClosure'])) {
-				return $arguments['__thenClosure']();
-			}
-		} elseif (!empty($arguments['__elseClosures'])) {
-			$elseIfClosures = isset($arguments['__elseifClosures']) ? $arguments['__elseifClosures'] : array();
-			return static::evaluateElseClosures($arguments['__elseClosures'], $elseIfClosures, $renderingContext);
-		} elseif (array_key_exists('else', $arguments)) {
-			return $arguments['else'];
-		}
-		return '';
-	}
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        if (static::evaluateCondition($arguments)) {
+            if (isset($arguments['then'])) {
+                return $arguments['then'];
+            }
+            if (isset($arguments['__thenClosure'])) {
+                return $arguments['__thenClosure']();
+            }
+        } elseif (!empty($arguments['__elseClosures'])) {
+            $elseIfClosures = isset($arguments['__elseifClosures']) ? $arguments['__elseifClosures'] : [];
+            return static::evaluateElseClosures($arguments['__elseClosures'], $elseIfClosures, $renderingContext);
+        } elseif (array_key_exists('else', $arguments)) {
+            return $arguments['else'];
+        }
+        return '';
+    }
 
-	/**
-	 * @param array $closures
-	 * @param array $conditionClosures
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 */
-	private static function evaluateElseClosures(array $closures, array $conditionClosures, RenderingContextInterface $renderingContext) {
-		foreach ($closures as $elseNodeIndex => $elseNodeClosure) {
-			if (!isset($conditionClosures[$elseNodeIndex])) {
-				return $elseNodeClosure();
-			} else {
-				if ($conditionClosures[$elseNodeIndex]()) {
-					return $elseNodeClosure();
-				}
-			}
-		}
-		return '';
-	}
+    /**
+     * @param array $closures
+     * @param array $conditionClosures
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    private static function evaluateElseClosures(array $closures, array $conditionClosures, RenderingContextInterface $renderingContext)
+    {
+        foreach ($closures as $elseNodeIndex => $elseNodeClosure) {
+            if (!isset($conditionClosures[$elseNodeIndex])) {
+                return $elseNodeClosure();
+            } else {
+                if ($conditionClosures[$elseNodeIndex]()) {
+                    return $elseNodeClosure();
+                }
+            }
+        }
+        return '';
+    }
 
-	/**
-	 * Returns value of "then" attribute.
-	 * If then attribute is not set, iterates through child nodes and renders ThenViewHelper.
-	 * If then attribute is not set and no ThenViewHelper and no ElseViewHelper is found, all child nodes are rendered
-	 *
-	 * @return mixed rendered ThenViewHelper or contents of <f:if> if no ThenViewHelper was found
-	 * @api
-	 */
-	protected function renderThenChild() {
-		if ($this->hasArgument('then')) {
-			return $this->arguments['then'];
-		}
+    /**
+     * Returns value of "then" attribute.
+     * If then attribute is not set, iterates through child nodes and renders ThenViewHelper.
+     * If then attribute is not set and no ThenViewHelper and no ElseViewHelper is found, all child nodes are rendered
+     *
+     * @return mixed rendered ThenViewHelper or contents of <f:if> if no ThenViewHelper was found
+     * @api
+     */
+    protected function renderThenChild()
+    {
+        if ($this->hasArgument('then')) {
+            return $this->arguments['then'];
+        }
 
-		$elseViewHelperEncountered = FALSE;
-		foreach ($this->childNodes as $childNode) {
-			if ($childNode instanceof ViewHelperNode
-				&& substr($childNode->getViewHelperClassName(), -14) === 'ThenViewHelper') {
-				$data = $childNode->evaluate($this->renderingContext);
-				return $data;
-			}
-			if ($childNode instanceof ViewHelperNode
-				&& substr($childNode->getViewHelperClassName(), -14) === 'ElseViewHelper') {
-				$elseViewHelperEncountered = TRUE;
-			}
-		}
+        $elseViewHelperEncountered = false;
+        foreach ($this->childNodes as $childNode) {
+            if ($childNode instanceof ViewHelperNode
+                && substr($childNode->getViewHelperClassName(), -14) === 'ThenViewHelper') {
+                $data = $childNode->evaluate($this->renderingContext);
+                return $data;
+            }
+            if ($childNode instanceof ViewHelperNode
+                && substr($childNode->getViewHelperClassName(), -14) === 'ElseViewHelper') {
+                $elseViewHelperEncountered = true;
+            }
+        }
 
-		if ($elseViewHelperEncountered) {
-			return '';
-		} else {
-			return $this->renderChildren();
-		}
-	}
+        if ($elseViewHelperEncountered) {
+            return '';
+        } else {
+            return $this->renderChildren();
+        }
+    }
 
-	/**
-	 * Returns value of "else" attribute.
-	 * If else attribute is not set, iterates through child nodes and renders ElseViewHelper.
-	 * If else attribute is not set and no ElseViewHelper is found, an empty string will be returned.
-	 *
-	 * @return string rendered ElseViewHelper or an empty string if no ThenViewHelper was found
-	 * @api
-	 */
-	protected function renderElseChild() {
+    /**
+     * Returns value of "else" attribute.
+     * If else attribute is not set, iterates through child nodes and renders ElseViewHelper.
+     * If else attribute is not set and no ElseViewHelper is found, an empty string will be returned.
+     *
+     * @return string rendered ElseViewHelper or an empty string if no ThenViewHelper was found
+     * @api
+     */
+    protected function renderElseChild()
+    {
 
-		if ($this->hasArgument('else')) {
-			return $this->arguments['else'];
-		}
+        if ($this->hasArgument('else')) {
+            return $this->arguments['else'];
+        }
 
-		/** @var ViewHelperNode|NULL $elseNode */
-		$elseNode = NULL;
-		foreach ($this->childNodes as $childNode) {
-			if ($childNode instanceof ViewHelperNode
-				&& substr($childNode->getViewHelperClassName(), -14) === 'ElseViewHelper') {
-				$arguments = $childNode->getArguments();
-				if (isset($arguments['if']) && $arguments['if']->evaluate($this->renderingContext)) {
-					return $childNode->evaluate($this->renderingContext);
-				} else {
-					$elseNode = $childNode;
-				}
-			}
-		}
+        /** @var ViewHelperNode|NULL $elseNode */
+        $elseNode = null;
+        foreach ($this->childNodes as $childNode) {
+            if ($childNode instanceof ViewHelperNode
+                && substr($childNode->getViewHelperClassName(), -14) === 'ElseViewHelper') {
+                $arguments = $childNode->getArguments();
+                if (isset($arguments['if']) && $arguments['if']->evaluate($this->renderingContext)) {
+                    return $childNode->evaluate($this->renderingContext);
+                } else {
+                    $elseNode = $childNode;
+                }
+            }
+        }
 
-		return $elseNode instanceof ViewHelperNode ? $elseNode->evaluate($this->renderingContext) : '';
-	}
+        return $elseNode instanceof ViewHelperNode ? $elseNode->evaluate($this->renderingContext) : '';
+    }
 
-	/**
-	 * The compiled ViewHelper adds two new ViewHelper arguments: __thenClosure and __elseClosure.
-	 * These contain closures which are be executed to render the then(), respectively else() case.
-	 *
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		$thenViewHelperEncountered = $elseViewHelperEncountered = FALSE;
-		foreach ($node->getChildNodes() as $childNode) {
-			if ($childNode instanceof ViewHelperNode) {
-				$viewHelperClassName = $childNode->getViewHelperClassName();
-				if (substr($viewHelperClassName, -14) === 'ThenViewHelper') {
-					$thenViewHelperEncountered = TRUE;
-					$childNodesAsClosure = $compiler->wrapChildNodesInClosure($childNode);
-					$initializationPhpCode .= sprintf('%s[\'__thenClosure\'] = %s;', $argumentsName, $childNodesAsClosure) . chr(10);
-				} elseif (substr($viewHelperClassName, -14) === 'ElseViewHelper') {
-					$elseViewHelperEncountered = TRUE;
-					$childNodesAsClosure = $compiler->wrapChildNodesInClosure($childNode);
-					$initializationPhpCode .= sprintf('%s[\'__elseClosures\'][] = %s;', $argumentsName, $childNodesAsClosure) . chr(10);
-					$arguments = $childNode->getArguments();
-					if (isset($arguments['if'])) {
-						// The "else" has an argument, indicating it has a secondary (elseif) condition.
-						// Compile a closure which will evaluate the condition.
-						$elseIfConditionAsClosure = $compiler->wrapViewHelperNodeArgumentEvaluationInClosure($childNode, 'if');
-						$initializationPhpCode .= sprintf('%s[\'__elseifClosures\'][] = %s;', $argumentsName, $elseIfConditionAsClosure) . chr(10);
-					}
-				}
-			}
-		}
-		if (!$thenViewHelperEncountered && !$elseViewHelperEncountered && !isset($node->getArguments()['then'])) {
-			$initializationPhpCode .= sprintf('%s[\'__thenClosure\'] = %s;', $argumentsName, $closureName) . chr(10);
-		}
-		return parent::compile($argumentsName, $closureName, $initializationPhpCode, $node, $compiler);
-	}
+    /**
+     * The compiled ViewHelper adds two new ViewHelper arguments: __thenClosure and __elseClosure.
+     * These contain closures which are be executed to render the then(), respectively else() case.
+     *
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        $thenViewHelperEncountered = $elseViewHelperEncountered = false;
+        foreach ($node->getChildNodes() as $childNode) {
+            if ($childNode instanceof ViewHelperNode) {
+                $viewHelperClassName = $childNode->getViewHelperClassName();
+                if (substr($viewHelperClassName, -14) === 'ThenViewHelper') {
+                    $thenViewHelperEncountered = true;
+                    $childNodesAsClosure = $compiler->wrapChildNodesInClosure($childNode);
+                    $initializationPhpCode .= sprintf('%s[\'__thenClosure\'] = %s;', $argumentsName, $childNodesAsClosure) . chr(10);
+                } elseif (substr($viewHelperClassName, -14) === 'ElseViewHelper') {
+                    $elseViewHelperEncountered = true;
+                    $childNodesAsClosure = $compiler->wrapChildNodesInClosure($childNode);
+                    $initializationPhpCode .= sprintf('%s[\'__elseClosures\'][] = %s;', $argumentsName, $childNodesAsClosure) . chr(10);
+                    $arguments = $childNode->getArguments();
+                    if (isset($arguments['if'])) {
+                        // The "else" has an argument, indicating it has a secondary (elseif) condition.
+                        // Compile a closure which will evaluate the condition.
+                        $elseIfConditionAsClosure = $compiler->wrapViewHelperNodeArgumentEvaluationInClosure($childNode, 'if');
+                        $initializationPhpCode .= sprintf('%s[\'__elseifClosures\'][] = %s;', $argumentsName, $elseIfConditionAsClosure) . chr(10);
+                    }
+                }
+            }
+        }
+        if (!$thenViewHelperEncountered && !$elseViewHelperEncountered && !isset($node->getArguments()['then'])) {
+            $initializationPhpCode .= sprintf('%s[\'__thenClosure\'] = %s;', $argumentsName, $closureName) . chr(10);
+        }
+        return parent::compile($argumentsName, $closureName, $initializationPhpCode, $node, $compiler);
+    }
 }

--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -13,157 +13,165 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  *
  * @api
  */
-abstract class AbstractTagBasedViewHelper extends AbstractViewHelper {
+abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * Disable escaping of tag based ViewHelpers so that the rendered tag is not htmlspecialchar'd
-	 *
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * Disable escaping of tag based ViewHelpers so that the rendered tag is not htmlspecialchar'd
+     *
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * Names of all registered tag attributes
-	 *
-	 * @var array
-	 */
-	static private $tagAttributes = array();
+    /**
+     * Names of all registered tag attributes
+     *
+     * @var array
+     */
+    static private $tagAttributes = [];
 
-	/**
-	 * Tag builder instance
-	 *
-	 * @var TagBuilder
-	 * @api
-	 */
-	protected $tag = NULL;
+    /**
+     * Tag builder instance
+     *
+     * @var TagBuilder
+     * @api
+     */
+    protected $tag = null;
 
-	/**
-	 * Name of the tag to be created by this view helper
-	 *
-	 * @var string
-	 * @api
-	 */
-	protected $tagName = 'div';
+    /**
+     * Name of the tag to be created by this view helper
+     *
+     * @var string
+     * @api
+     */
+    protected $tagName = 'div';
 
-	/**
-	 * Constructor
-	 */
-	public function __construct() {
-		$this->setTagBuilder(new TagBuilder($this->tagName));
-	}
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->setTagBuilder(new TagBuilder($this->tagName));
+    }
 
-	/**
-	 * @param TagBuilder $tag
-	 * @return void
-	 */
-	public function setTagBuilder(TagBuilder $tag) {
-		$this->tag = $tag;
-		$this->tag->setTagName($this->tagName);
-	}
+    /**
+     * @param TagBuilder $tag
+     * @return void
+     */
+    public function setTagBuilder(TagBuilder $tag)
+    {
+        $this->tag = $tag;
+        $this->tag->setTagName($this->tagName);
+    }
 
-	/**
-	 * Constructor
-	 *
-	 * @api
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.', FALSE);
-		$this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.', FALSE);
-	}
+    /**
+     * Constructor
+     *
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.', false);
+        $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.', false);
+    }
 
-	/**
-	 * Sets the tag name to $this->tagName.
-	 * Additionally, sets all tag attributes which were registered in
-	 * $this->tagAttributes and additionalArguments.
-	 *
-	 * Will be invoked just before the render method.
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function initialize() {
-		parent::initialize();
-		if ($this->hasArgument('additionalAttributes') && is_array($this->arguments['additionalAttributes'])) {
-			$this->tag->addAttributes($this->arguments['additionalAttributes']);
-		}
+    /**
+     * Sets the tag name to $this->tagName.
+     * Additionally, sets all tag attributes which were registered in
+     * $this->tagAttributes and additionalArguments.
+     *
+     * Will be invoked just before the render method.
+     *
+     * @return void
+     * @api
+     */
+    public function initialize()
+    {
+        parent::initialize();
+        if ($this->hasArgument('additionalAttributes') && is_array($this->arguments['additionalAttributes'])) {
+            $this->tag->addAttributes($this->arguments['additionalAttributes']);
+        }
 
-		if ($this->hasArgument('data') && is_array($this->arguments['data'])) {
-			foreach ($this->arguments['data'] as $dataAttributeKey => $dataAttributeValue) {
-				$this->tag->addAttribute('data-' . $dataAttributeKey, $dataAttributeValue);
-			}
-		}
+        if ($this->hasArgument('data') && is_array($this->arguments['data'])) {
+            foreach ($this->arguments['data'] as $dataAttributeKey => $dataAttributeValue) {
+                $this->tag->addAttribute('data-' . $dataAttributeKey, $dataAttributeValue);
+            }
+        }
 
-		if (isset(self::$tagAttributes[get_class($this)])) {
-			foreach (self::$tagAttributes[get_class($this)] as $attributeName) {
-				if ($this->hasArgument($attributeName) && $this->arguments[$attributeName] !== '') {
-					$this->tag->addAttribute($attributeName, $this->arguments[$attributeName]);
-				}
-			}
-		}
-	}
+        if (isset(self::$tagAttributes[get_class($this)])) {
+            foreach (self::$tagAttributes[get_class($this)] as $attributeName) {
+                if ($this->hasArgument($attributeName) && $this->arguments[$attributeName] !== '') {
+                    $this->tag->addAttribute($attributeName, $this->arguments[$attributeName]);
+                }
+            }
+        }
+    }
 
-	/**
-	 * Register a new tag attribute. Tag attributes are all arguments which will be directly appended to a tag if you call $this->initializeTag()
-	 *
-	 * @param string $name Name of tag attribute
-	 * @param string $type Type of the tag attribute
-	 * @param string $description Description of tag attribute
-	 * @param boolean $required set to TRUE if tag attribute is required. Defaults to FALSE.
-	 * @param mixed $defaultValue Optional, default value of attribute if one applies
-	 * @return void
-	 * @api
-	 */
-	protected function registerTagAttribute($name, $type, $description, $required = FALSE, $defaultValue = NULL) {
-		$this->registerArgument($name, $type, $description, $required, $defaultValue);
-		self::$tagAttributes[get_class($this)][$name] = $name;
-	}
+    /**
+     * Register a new tag attribute. Tag attributes are all arguments which will be directly appended to a tag if you call $this->initializeTag()
+     *
+     * @param string $name Name of tag attribute
+     * @param string $type Type of the tag attribute
+     * @param string $description Description of tag attribute
+     * @param boolean $required set to TRUE if tag attribute is required. Defaults to FALSE.
+     * @param mixed $defaultValue Optional, default value of attribute if one applies
+     * @return void
+     * @api
+     */
+    protected function registerTagAttribute($name, $type, $description, $required = false, $defaultValue = null)
+    {
+        $this->registerArgument($name, $type, $description, $required, $defaultValue);
+        self::$tagAttributes[get_class($this)][$name] = $name;
+    }
 
-	/**
-	 * Registers all standard HTML universal attributes.
-	 * Should be used inside registerArguments();
-	 *
-	 * @return void
-	 * @api
-	 */
-	protected function registerUniversalTagAttributes() {
-		$this->registerTagAttribute('class', 'string', 'CSS class(es) for this element');
-		$this->registerTagAttribute('dir', 'string', 'Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)');
-		$this->registerTagAttribute('id', 'string', 'Unique (in this file) identifier for this HTML element.');
-		$this->registerTagAttribute('lang', 'string', 'Language for this element. Use short names specified in RFC 1766');
-		$this->registerTagAttribute('style', 'string', 'Individual CSS styles for this element');
-		$this->registerTagAttribute('title', 'string', 'Tooltip text of element');
-		$this->registerTagAttribute('accesskey', 'string', 'Keyboard shortcut to access this element');
-		$this->registerTagAttribute('tabindex', 'integer', 'Specifies the tab order of this element');
-		$this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
-	}
+    /**
+     * Registers all standard HTML universal attributes.
+     * Should be used inside registerArguments();
+     *
+     * @return void
+     * @api
+     */
+    protected function registerUniversalTagAttributes()
+    {
+        $this->registerTagAttribute('class', 'string', 'CSS class(es) for this element');
+        $this->registerTagAttribute('dir', 'string', 'Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)');
+        $this->registerTagAttribute('id', 'string', 'Unique (in this file) identifier for this HTML element.');
+        $this->registerTagAttribute('lang', 'string', 'Language for this element. Use short names specified in RFC 1766');
+        $this->registerTagAttribute('style', 'string', 'Individual CSS styles for this element');
+        $this->registerTagAttribute('title', 'string', 'Tooltip text of element');
+        $this->registerTagAttribute('accesskey', 'string', 'Keyboard shortcut to access this element');
+        $this->registerTagAttribute('tabindex', 'integer', 'Specifies the tab order of this element');
+        $this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
+    }
 
-	/**
-	 * Handles additional arguments, sorting out any data-
-	 * prefixed tag attributes and assigning them. Then passes
-	 * the unassigned arguments to the parent class' method,
-	 * which in the default implementation will throw an error
-	 * about "undeclared argument used".
-	 *
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function handleAdditionalArguments(array $arguments) {
-		$unassigned = array();
-		foreach ($arguments as $argumentName => $argumentValue) {
-			if (strpos($argumentName, 'data-') === 0) {
-				$this->tag->addAttribute($argumentName, $argumentValue);
-			} else {
-				$unassigned[$argumentName] = $argumentValue;
-			}
-		}
-		parent::handleAdditionalArguments($unassigned);
-	}
+    /**
+     * Handles additional arguments, sorting out any data-
+     * prefixed tag attributes and assigning them. Then passes
+     * the unassigned arguments to the parent class' method,
+     * which in the default implementation will throw an error
+     * about "undeclared argument used".
+     *
+     * @param array $arguments
+     * @return void
+     */
+    public function handleAdditionalArguments(array $arguments)
+    {
+        $unassigned = [];
+        foreach ($arguments as $argumentName => $argumentValue) {
+            if (strpos($argumentName, 'data-') === 0) {
+                $this->tag->addAttribute($argumentName, $argumentValue);
+            } else {
+                $unassigned[$argumentName] = $argumentValue;
+            }
+        }
+        parent::handleAdditionalArguments($unassigned);
+    }
 
-	/**
-	 * @return string
-	 */
-	public function render() {
-		return $this->tag->render();
-	}
-
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return $this->tag->render();
+    }
 }

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -19,484 +19,509 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  *
  * @api
  */
-abstract class AbstractViewHelper implements ViewHelperInterface {
+abstract class AbstractViewHelper implements ViewHelperInterface
+{
 
-	/**
-	 * Stores all \TYPO3Fluid\Fluid\ArgumentDefinition instances
-	 * @var ArgumentDefinition[]
-	 */
-	protected $argumentDefinitions = array();
+    /**
+     * Stores all \TYPO3Fluid\Fluid\ArgumentDefinition instances
+     * @var ArgumentDefinition[]
+     */
+    protected $argumentDefinitions = [];
 
-	/**
-	 * Cache of argument definitions; the key is the ViewHelper class name, and the
-	 * value is the array of argument definitions.
-	 *
-	 * In our benchmarks, this cache leads to a 40% improvement when using a certain
-	 * ViewHelper class many times throughout the rendering process.
-	 * @var array
-	 */
-	static private $argumentDefinitionCache = array();
+    /**
+     * Cache of argument definitions; the key is the ViewHelper class name, and the
+     * value is the array of argument definitions.
+     *
+     * In our benchmarks, this cache leads to a 40% improvement when using a certain
+     * ViewHelper class many times throughout the rendering process.
+     * @var array
+     */
+    static private $argumentDefinitionCache = [];
 
-	/**
-	 * Current view helper node
-	 * @var ViewHelperNode
-	 */
-	protected $viewHelperNode;
+    /**
+     * Current view helper node
+     * @var ViewHelperNode
+     */
+    protected $viewHelperNode;
 
-	/**
-	 * Arguments array.
-	 * @var array
-	 * @api
-	 */
-	protected $arguments = array();
+    /**
+     * Arguments array.
+     * @var array
+     * @api
+     */
+    protected $arguments = [];
 
-	/**
-	 * Arguments array.
-	 * @var NodeInterface[] array
-	 * @api
-	 */
-	protected $childNodes = array();
+    /**
+     * Arguments array.
+     * @var NodeInterface[] array
+     * @api
+     */
+    protected $childNodes = [];
 
-	/**
-	 * Current variable container reference.
-	 * @var VariableProviderInterface
-	 * @api
-	 */
-	protected $templateVariableContainer;
+    /**
+     * Current variable container reference.
+     * @var VariableProviderInterface
+     * @api
+     */
+    protected $templateVariableContainer;
 
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
 
-	/**
-	 * @var \Closure
-	 */
-	protected $renderChildrenClosure = NULL;
+    /**
+     * @var \Closure
+     */
+    protected $renderChildrenClosure = null;
 
-	/**
-	 * ViewHelper Variable Container
-	 * @var ViewHelperVariableContainer
-	 * @api
-	 */
-	protected $viewHelperVariableContainer;
+    /**
+     * ViewHelper Variable Container
+     * @var ViewHelperVariableContainer
+     * @api
+     */
+    protected $viewHelperVariableContainer;
 
-	/**
-	 * Specifies whether the escaping interceptors should be disabled or enabled for the result of renderChildren() calls within this ViewHelper
-	 * @see isChildrenEscapingEnabled()
-	 *
-	 * Note: If this is NULL the value of $this->escapingInterceptorEnabled is considered for backwards compatibility
-	 *
-	 * @var boolean
-	 * @api
-	 */
-	protected $escapeChildren = NULL;
+    /**
+     * Specifies whether the escaping interceptors should be disabled or enabled for the result of renderChildren() calls within this ViewHelper
+     * @see isChildrenEscapingEnabled()
+     *
+     * Note: If this is NULL the value of $this->escapingInterceptorEnabled is considered for backwards compatibility
+     *
+     * @var boolean
+     * @api
+     */
+    protected $escapeChildren = null;
 
-	/**
-	 * Specifies whether the escaping interceptors should be disabled or enabled for the render-result of this ViewHelper
-	 * @see isOutputEscapingEnabled()
-	 *
-	 * @var boolean
-	 * @api
-	 */
-	protected $escapeOutput = NULL;
+    /**
+     * Specifies whether the escaping interceptors should be disabled or enabled for the render-result of this ViewHelper
+     * @see isOutputEscapingEnabled()
+     *
+     * @var boolean
+     * @api
+     */
+    protected $escapeOutput = null;
 
-	/**
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function setArguments(array $arguments) {
-		$this->arguments = $arguments;
-	}
+    /**
+     * @param array $arguments
+     * @return void
+     */
+    public function setArguments(array $arguments)
+    {
+        $this->arguments = $arguments;
+    }
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext) {
-		$this->renderingContext = $renderingContext;
-		$this->templateVariableContainer = $renderingContext->getVariableProvider();
-		$this->viewHelperVariableContainer = $renderingContext->getViewHelperVariableContainer();
-	}
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        $this->renderingContext = $renderingContext;
+        $this->templateVariableContainer = $renderingContext->getVariableProvider();
+        $this->viewHelperVariableContainer = $renderingContext->getViewHelperVariableContainer();
+    }
 
-	/**
-	 * Returns whether the escaping interceptors should be disabled or enabled for the result of renderChildren() calls within this ViewHelper
-	 *
-	 * Note: This method is no public API, use $this->escapeChildren instead!
-	 *
-	 * @return boolean
-	 */
-	public function isChildrenEscapingEnabled() {
-		if ($this->escapeChildren === NULL) {
-			// Disable children escaping automatically, if output escaping is on anyway.
-			return !$this->isOutputEscapingEnabled();
-		}
-		return $this->escapeChildren;
-	}
+    /**
+     * Returns whether the escaping interceptors should be disabled or enabled for the result of renderChildren() calls within this ViewHelper
+     *
+     * Note: This method is no public API, use $this->escapeChildren instead!
+     *
+     * @return boolean
+     */
+    public function isChildrenEscapingEnabled()
+    {
+        if ($this->escapeChildren === null) {
+            // Disable children escaping automatically, if output escaping is on anyway.
+            return !$this->isOutputEscapingEnabled();
+        }
+        return $this->escapeChildren;
+    }
 
-	/**
-	 * Returns whether the escaping interceptors should be disabled or enabled for the render-result of this ViewHelper
-	 *
-	 * Note: This method is no public API, use $this->escapeChildren instead!
-	 *
-	 * @return boolean
-	 */
-	public function isOutputEscapingEnabled() {
-		return $this->escapeOutput !== FALSE;
-	}
+    /**
+     * Returns whether the escaping interceptors should be disabled or enabled for the render-result of this ViewHelper
+     *
+     * Note: This method is no public API, use $this->escapeChildren instead!
+     *
+     * @return boolean
+     */
+    public function isOutputEscapingEnabled()
+    {
+        return $this->escapeOutput !== false;
+    }
 
-	/**
-	 * Register a new argument. Call this method from your ViewHelper subclass
-	 * inside the initializeArguments() method.
-	 *
-	 * @param string $name Name of the argument
-	 * @param string $type Type of the argument
-	 * @param string $description Description of the argument
-	 * @param boolean $required If TRUE, argument is required. Defaults to FALSE.
-	 * @param mixed $defaultValue Default value of argument
-	 * @return \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper $this, to allow chaining.
-	 * @throws Exception
-	 * @api
-	 */
-	protected function registerArgument($name, $type, $description, $required = FALSE, $defaultValue = NULL) {
-		if (array_key_exists($name, $this->argumentDefinitions)) {
-			throw new Exception('Argument "' . $name . '" has already been defined, thus it should not be defined again.', 1253036401);
-		}
-		$this->argumentDefinitions[$name] = new ArgumentDefinition($name, $type, $description, $required, $defaultValue);
-		return $this;
-	}
+    /**
+     * Register a new argument. Call this method from your ViewHelper subclass
+     * inside the initializeArguments() method.
+     *
+     * @param string $name Name of the argument
+     * @param string $type Type of the argument
+     * @param string $description Description of the argument
+     * @param boolean $required If TRUE, argument is required. Defaults to FALSE.
+     * @param mixed $defaultValue Default value of argument
+     * @return \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper $this, to allow chaining.
+     * @throws Exception
+     * @api
+     */
+    protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null)
+    {
+        if (array_key_exists($name, $this->argumentDefinitions)) {
+            throw new Exception('Argument "' . $name . '" has already been defined, thus it should not be defined again.', 1253036401);
+        }
+        $this->argumentDefinitions[$name] = new ArgumentDefinition($name, $type, $description, $required, $defaultValue);
+        return $this;
+    }
 
-	/**
-	 * Overrides a registered argument. Call this method from your ViewHelper subclass
-	 * inside the initializeArguments() method if you want to override a previously registered argument.
-	 * @see registerArgument()
-	 *
-	 * @param string $name Name of the argument
-	 * @param string $type Type of the argument
-	 * @param string $description Description of the argument
-	 * @param boolean $required If TRUE, argument is required. Defaults to FALSE.
-	 * @param mixed $defaultValue Default value of argument
-	 * @return \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper $this, to allow chaining.
-	 * @throws Exception
-	 * @api
-	 */
-	protected function overrideArgument($name, $type, $description, $required = FALSE, $defaultValue = NULL) {
-		if (!array_key_exists($name, $this->argumentDefinitions)) {
-			throw new Exception('Argument "' . $name . '" has not been defined, thus it can\'t be overridden.', 1279212461);
-		}
-		$this->argumentDefinitions[$name] = new ArgumentDefinition($name, $type, $description, $required, $defaultValue);
-		return $this;
-	}
+    /**
+     * Overrides a registered argument. Call this method from your ViewHelper subclass
+     * inside the initializeArguments() method if you want to override a previously registered argument.
+     * @see registerArgument()
+     *
+     * @param string $name Name of the argument
+     * @param string $type Type of the argument
+     * @param string $description Description of the argument
+     * @param boolean $required If TRUE, argument is required. Defaults to FALSE.
+     * @param mixed $defaultValue Default value of argument
+     * @return \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper $this, to allow chaining.
+     * @throws Exception
+     * @api
+     */
+    protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null)
+    {
+        if (!array_key_exists($name, $this->argumentDefinitions)) {
+            throw new Exception('Argument "' . $name . '" has not been defined, thus it can\'t be overridden.', 1279212461);
+        }
+        $this->argumentDefinitions[$name] = new ArgumentDefinition($name, $type, $description, $required, $defaultValue);
+        return $this;
+    }
 
-	/**
-	 * Sets all needed attributes needed for the rendering. Called by the
-	 * framework. Populates $this->viewHelperNode.
-	 * This is PURELY INTERNAL! Never override this method!!
-	 *
-	 * @param ViewHelperNode $node View Helper node to be set.
-	 * @return void
-	 */
-	public function setViewHelperNode(ViewHelperNode $node) {
-		$this->viewHelperNode = $node;
-	}
+    /**
+     * Sets all needed attributes needed for the rendering. Called by the
+     * framework. Populates $this->viewHelperNode.
+     * This is PURELY INTERNAL! Never override this method!!
+     *
+     * @param ViewHelperNode $node View Helper node to be set.
+     * @return void
+     */
+    public function setViewHelperNode(ViewHelperNode $node)
+    {
+        $this->viewHelperNode = $node;
+    }
 
-	/**
-	 * Sets all needed attributes needed for the rendering. Called by the
-	 * framework. Populates $this->viewHelperNode.
-	 * This is PURELY INTERNAL! Never override this method!!
-	 *
-	 * @param NodeInterface[] $childNodes
-	 * @return void
-	 */
-	public function setChildNodes(array $childNodes) {
-		$this->childNodes = $childNodes;
-	}
+    /**
+     * Sets all needed attributes needed for the rendering. Called by the
+     * framework. Populates $this->viewHelperNode.
+     * This is PURELY INTERNAL! Never override this method!!
+     *
+     * @param NodeInterface[] $childNodes
+     * @return void
+     */
+    public function setChildNodes(array $childNodes)
+    {
+        $this->childNodes = $childNodes;
+    }
 
-	/**
-	 * Called when being inside a cached template.
-	 *
-	 * @param \Closure $renderChildrenClosure
-	 * @return void
-	 */
-	public function setRenderChildrenClosure(\Closure $renderChildrenClosure) {
-		$this->renderChildrenClosure = $renderChildrenClosure;
-	}
+    /**
+     * Called when being inside a cached template.
+     *
+     * @param \Closure $renderChildrenClosure
+     * @return void
+     */
+    public function setRenderChildrenClosure(\Closure $renderChildrenClosure)
+    {
+        $this->renderChildrenClosure = $renderChildrenClosure;
+    }
 
-	/**
-	 * Initialize the arguments of the ViewHelper, and call the render() method of the ViewHelper.
-	 *
-	 * @return string the rendered ViewHelper.
-	 */
-	public function initializeArgumentsAndRender() {
-		$this->validateArguments();
-		$this->initialize();
+    /**
+     * Initialize the arguments of the ViewHelper, and call the render() method of the ViewHelper.
+     *
+     * @return string the rendered ViewHelper.
+     */
+    public function initializeArgumentsAndRender()
+    {
+        $this->validateArguments();
+        $this->initialize();
 
-		return $this->callRenderMethod();
-	}
+        return $this->callRenderMethod();
+    }
 
-	/**
-	 * Call the render() method and handle errors.
-	 *
-	 * @return string the rendered ViewHelper
-	 * @throws Exception
-	 */
-	protected function callRenderMethod() {
-		return call_user_func(array($this, 'render'));
-	}
+    /**
+     * Call the render() method and handle errors.
+     *
+     * @return string the rendered ViewHelper
+     * @throws Exception
+     */
+    protected function callRenderMethod()
+    {
+        return call_user_func([$this, 'render']);
+    }
 
-	/**
-	 * Initializes the view helper before invoking the render method.
-	 *
-	 * Override this method to solve tasks before the view helper content is rendered.
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function initialize() {
-	}
+    /**
+     * Initializes the view helper before invoking the render method.
+     *
+     * Override this method to solve tasks before the view helper content is rendered.
+     *
+     * @return void
+     * @api
+     */
+    public function initialize()
+    {
+    }
 
-	/**
-	 * Helper method which triggers the rendering of everything between the
-	 * opening and the closing tag.
-	 *
-	 * @return mixed The finally rendered child nodes.
-	 * @api
-	 */
-	public function renderChildren() {
-		if ($this->renderChildrenClosure !== NULL) {
-			$closure = $this->renderChildrenClosure;
-			return $closure();
-		}
-		return $this->viewHelperNode->evaluateChildNodes($this->renderingContext);
-	}
+    /**
+     * Helper method which triggers the rendering of everything between the
+     * opening and the closing tag.
+     *
+     * @return mixed The finally rendered child nodes.
+     * @api
+     */
+    public function renderChildren()
+    {
+        if ($this->renderChildrenClosure !== null) {
+            $closure = $this->renderChildrenClosure;
+            return $closure();
+        }
+        return $this->viewHelperNode->evaluateChildNodes($this->renderingContext);
+    }
 
-	/**
-	 * Helper which is mostly needed when calling renderStatic() from within
-	 * render().
-	 *
-	 * No public API yet.
-	 *
-	 * @return \Closure
-	 */
-	protected function buildRenderChildrenClosure() {
-		$self = clone $this;
-		return function() use ($self) {
-			return $self->renderChildren();
-		};
-	}
+    /**
+     * Helper which is mostly needed when calling renderStatic() from within
+     * render().
+     *
+     * No public API yet.
+     *
+     * @return \Closure
+     */
+    protected function buildRenderChildrenClosure()
+    {
+        $self = clone $this;
+        return function () use ($self) {
+            return $self->renderChildren();
+        };
+    }
 
-	/**
-	 * Initialize all arguments and return them
-	 *
-	 * @return ArgumentDefinition[]
-	 */
-	public function prepareArguments() {
-		$thisClassName = get_class($this);
-		if (isset(self::$argumentDefinitionCache[$thisClassName])) {
-			$this->argumentDefinitions = self::$argumentDefinitionCache[$thisClassName];
-		} else {
-			$this->initializeArguments();
-			self::$argumentDefinitionCache[$thisClassName] = $this->argumentDefinitions;
-		}
-		return $this->argumentDefinitions;
-	}
+    /**
+     * Initialize all arguments and return them
+     *
+     * @return ArgumentDefinition[]
+     */
+    public function prepareArguments()
+    {
+        $thisClassName = get_class($this);
+        if (isset(self::$argumentDefinitionCache[$thisClassName])) {
+            $this->argumentDefinitions = self::$argumentDefinitionCache[$thisClassName];
+        } else {
+            $this->initializeArguments();
+            self::$argumentDefinitionCache[$thisClassName] = $this->argumentDefinitions;
+        }
+        return $this->argumentDefinitions;
+    }
 
-	/**
-	 * Validate arguments, and throw exception if arguments do not validate.
-	 *
-	 * @return void
-	 * @throws \InvalidArgumentException
-	 */
-	public function validateArguments() {
-		$argumentDefinitions = $this->prepareArguments();
-		foreach ($argumentDefinitions as $argumentName => $registeredArgument) {
-			if ($this->hasArgument($argumentName)) {
-				$value = $this->arguments[$argumentName];
-				$type = $registeredArgument->getType();
-				if ($value !== $registeredArgument->getDefaultValue() && $type !== 'mixed') {
-					$givenType = is_object($value) ? get_class($value) : gettype($value);
-					$errorException = new \InvalidArgumentException(
-						'The argument "' . $argumentName . '" was registered with type "' . $type . '", but is of type "' .
-						$givenType . '" in view helper "' . get_class($this) . '".',
-						1256475113
-					);
-					if (!$this->isValidType($type, $value, $errorException)) {
-						throw $errorException;
-					}
-				}
-			}
-		}
-	}
+    /**
+     * Validate arguments, and throw exception if arguments do not validate.
+     *
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    public function validateArguments()
+    {
+        $argumentDefinitions = $this->prepareArguments();
+        foreach ($argumentDefinitions as $argumentName => $registeredArgument) {
+            if ($this->hasArgument($argumentName)) {
+                $value = $this->arguments[$argumentName];
+                $type = $registeredArgument->getType();
+                if ($value !== $registeredArgument->getDefaultValue() && $type !== 'mixed') {
+                    $givenType = is_object($value) ? get_class($value) : gettype($value);
+                    $errorException = new \InvalidArgumentException(
+                        'The argument "' . $argumentName . '" was registered with type "' . $type . '", but is of type "' .
+                        $givenType . '" in view helper "' . get_class($this) . '".',
+                        1256475113
+                    );
+                    if (!$this->isValidType($type, $value, $errorException)) {
+                        throw $errorException;
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 * Check whether the defined type matches the value type
-	 *
-	 * @param string $type
-	 * @param mixed $value
-	 * @return boolean
-	 */
-	protected function isValidType($type, $value) {
-		if ($type === 'object') {
-			if (!is_object($value)) {
-				return FALSE;
-			}
-		} elseif ($type === 'array' || substr($type, -2) === '[]') {
-			if (!is_array($value) && !$value instanceof \ArrayAccess && !$value instanceof \Traversable && !empty($value)) {
-				return FALSE;
-			} elseif (count($value) > 0 && substr($type, -2) === '[]') {
-				$firstElement = $this->getFirstElementOfNonEmpty($value);
-				if ($firstElement == NULL) {
-					return FALSE;
-				}
-				return $this->isValidType(substr($type, 0, -2), $firstElement);
-			}
-		} elseif ($type === 'string') {
-			if (is_object($value) && !method_exists($value, '__toString')) {
-				return FALSE;
-			}
-		} elseif ($type === 'boolean' && !is_bool($value)) {
-			return FALSE;
-		} elseif (class_exists($type) && $value !== NULL && !$value instanceof $type) {
-			return FALSE;
-		} elseif (is_object($value) && !is_a($value, $type, TRUE)) {
-			return FALSE;
-		}
-		return TRUE;
-	}
+    /**
+     * Check whether the defined type matches the value type
+     *
+     * @param string $type
+     * @param mixed $value
+     * @return boolean
+     */
+    protected function isValidType($type, $value)
+    {
+        if ($type === 'object') {
+            if (!is_object($value)) {
+                return false;
+            }
+        } elseif ($type === 'array' || substr($type, -2) === '[]') {
+            if (!is_array($value) && !$value instanceof \ArrayAccess && !$value instanceof \Traversable && !empty($value)) {
+                return false;
+            } elseif (count($value) > 0 && substr($type, -2) === '[]') {
+                $firstElement = $this->getFirstElementOfNonEmpty($value);
+                if ($firstElement == null) {
+                    return false;
+                }
+                return $this->isValidType(substr($type, 0, -2), $firstElement);
+            }
+        } elseif ($type === 'string') {
+            if (is_object($value) && !method_exists($value, '__toString')) {
+                return false;
+            }
+        } elseif ($type === 'boolean' && !is_bool($value)) {
+            return false;
+        } elseif (class_exists($type) && $value !== null && !$value instanceof $type) {
+            return false;
+        } elseif (is_object($value) && !is_a($value, $type, true)) {
+            return false;
+        }
+        return true;
+    }
 
-	/**
-	 * Return the first element of the given array, ArrayAccess or Traversable
-	 * that is not empty
-	 *
-	 * @param mixed $value
-	 */
-	protected function getFirstElementOfNonEmpty($value)
-	{
-		if (is_array($value)) {
-			return reset($value);
-		} elseif ($value instanceof \Traversable) {
-			foreach ($value as $element) {
-				return $element;
-			}
-		}
-		return null;
-	}
+    /**
+     * Return the first element of the given array, ArrayAccess or Traversable
+     * that is not empty
+     *
+     * @param mixed $value
+     */
+    protected function getFirstElementOfNonEmpty($value)
+    {
+        if (is_array($value)) {
+            return reset($value);
+        } elseif ($value instanceof \Traversable) {
+            foreach ($value as $element) {
+                return $element;
+            }
+        }
+        return null;
+    }
 
-	/**
-	 * Initialize all arguments. You need to override this method and call
-	 * $this->registerArgument(...) inside this method, to register all your arguments.
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function initializeArguments() {
-	}
+    /**
+     * Initialize all arguments. You need to override this method and call
+     * $this->registerArgument(...) inside this method, to register all your arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+    }
 
-	/**
-	 * Tests if the given $argumentName is set, and not NULL.
-	 * The isset() test used fills both those requirements.
-	 *
-	 * @param string $argumentName
-	 * @return boolean TRUE if $argumentName is found, FALSE otherwise
-	 * @api
-	 */
-	protected function hasArgument($argumentName) {
-		return isset($this->arguments[$argumentName]);
-	}
+    /**
+     * Tests if the given $argumentName is set, and not NULL.
+     * The isset() test used fills both those requirements.
+     *
+     * @param string $argumentName
+     * @return boolean TRUE if $argumentName is found, FALSE otherwise
+     * @api
+     */
+    protected function hasArgument($argumentName)
+    {
+        return isset($this->arguments[$argumentName]);
+    }
 
-	/**
-	 * Default implementation of "handling" additional, undeclared arguments.
-	 * In this implementation the behavior is to consistently throw an error
-	 * about NOT supporting any additional arguments. This method MUST be
-	 * overridden by any ViewHelper that desires this support and this inherited
-	 * method must not be called, obviously.
-	 *
-	 * @throws Exception
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function handleAdditionalArguments(array $arguments) {
-	}
+    /**
+     * Default implementation of "handling" additional, undeclared arguments.
+     * In this implementation the behavior is to consistently throw an error
+     * about NOT supporting any additional arguments. This method MUST be
+     * overridden by any ViewHelper that desires this support and this inherited
+     * method must not be called, obviously.
+     *
+     * @throws Exception
+     * @param array $arguments
+     * @return void
+     */
+    public function handleAdditionalArguments(array $arguments)
+    {
+    }
 
-	/**
-	 * Default implementation of validating additional, undeclared arguments.
-	 * In this implementation the behavior is to consistently throw an error
-	 * about NOT supporting any additional arguments. This method MUST be
-	 * overridden by any ViewHelper that desires this support and this inherited
-	 * method must not be called, obviously.
-	 *
-	 * @throws Exception
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function validateAdditionalArguments(array $arguments) {
-		if (!empty($arguments)) {
-			throw new Exception(
-				sprintf(
-					'Undeclared arguments passed to ViewHelper %s: %s',
-					get_class($this),
-					implode(', ', array_keys($arguments))
-				)
-			);
-		}
-	}
+    /**
+     * Default implementation of validating additional, undeclared arguments.
+     * In this implementation the behavior is to consistently throw an error
+     * about NOT supporting any additional arguments. This method MUST be
+     * overridden by any ViewHelper that desires this support and this inherited
+     * method must not be called, obviously.
+     *
+     * @throws Exception
+     * @param array $arguments
+     * @return void
+     */
+    public function validateAdditionalArguments(array $arguments)
+    {
+        if (!empty($arguments)) {
+            throw new Exception(
+                sprintf(
+                    'Undeclared arguments passed to ViewHelper %s: %s',
+                    get_class($this),
+                    implode(', ', array_keys($arguments))
+                )
+            );
+        }
+    }
 
-	/**
-	 * You only should override this method *when you absolutely know what you
-	 * are doing*, and really want to influence the generated PHP code during
-	 * template compilation directly.
-	 *
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return sprintf(
-			'%s::renderStatic(%s, %s, $renderingContext)',
-			get_class($this),
-			$argumentsName,
-			$closureName
-		);
-	}
+    /**
+     * You only should override this method *when you absolutely know what you
+     * are doing*, and really want to influence the generated PHP code during
+     * template compilation directly.
+     *
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return sprintf(
+            '%s::renderStatic(%s, %s, $renderingContext)',
+            get_class($this),
+            $argumentsName,
+            $closureName
+        );
+    }
 
-	/**
-	 * Default implementation of static rendering; useful API method if your ViewHelper
-	 * when compiled is able to render itself statically to increase performance. This
-	 * default implementation will simply delegate to the ViewHelperInvoker.
-	 *
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		$viewHelperClassName = get_called_class();
-		return $renderingContext->getViewHelperInvoker()->invoke($viewHelperClassName, $arguments, $renderingContext, $renderChildrenClosure);
-	}
+    /**
+     * Default implementation of static rendering; useful API method if your ViewHelper
+     * when compiled is able to render itself statically to increase performance. This
+     * default implementation will simply delegate to the ViewHelperInvoker.
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $viewHelperClassName = get_called_class();
+        return $renderingContext->getViewHelperInvoker()->invoke($viewHelperClassName, $arguments, $renderingContext, $renderChildrenClosure);
+    }
 
-	/**
-	 * Save the associated ViewHelper node in a static public class variable.
-	 * called directly after the ViewHelper was built.
-	 *
-	 * @param ViewHelperNode $node
-	 * @param TextNode[] $arguments
-	 * @param VariableProviderInterface $variableContainer
-	 * @return void
-	 */
-	public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer) {
-	}
+    /**
+     * Save the associated ViewHelper node in a static public class variable.
+     * called directly after the ViewHelper was built.
+     *
+     * @param ViewHelperNode $node
+     * @param TextNode[] $arguments
+     * @param VariableProviderInterface $variableContainer
+     * @return void
+     */
+    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer)
+    {
+    }
 
-	/**
-	 * Resets the ViewHelper state.
-	 *
-	 * Overwrite this method if you need to get a clean state of your ViewHelper.
-	 *
-	 * @return void
-	 */
-	public function resetState() {
-	}
-
+    /**
+     * Resets the ViewHelper state.
+     *
+     * Overwrite this method if you need to get a clean state of your ViewHelper.
+     *
+     * @return void
+     */
+    public function resetState()
+    {
+    }
 }

--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -9,103 +9,109 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 /**
  * Argument definition of each view helper argument
  */
-class ArgumentDefinition {
+class ArgumentDefinition
+{
 
-	/**
-	 * Name of argument
-	 *
-	 * @var string
-	 */
-	protected $name;
+    /**
+     * Name of argument
+     *
+     * @var string
+     */
+    protected $name;
 
-	/**
-	 * Type of argument
-	 *
-	 * @var string
-	 */
-	protected $type;
+    /**
+     * Type of argument
+     *
+     * @var string
+     */
+    protected $type;
 
-	/**
-	 * Description of argument
-	 *
-	 * @var string
-	 */
-	protected $description;
+    /**
+     * Description of argument
+     *
+     * @var string
+     */
+    protected $description;
 
-	/**
-	 * Is argument required?
-	 *
-	 * @var boolean
-	 */
-	protected $required = FALSE;
+    /**
+     * Is argument required?
+     *
+     * @var boolean
+     */
+    protected $required = false;
 
-	/**
-	 * Default value for argument
-	 *
-	 * @var mixed
-	 */
-	protected $defaultValue = NULL;
+    /**
+     * Default value for argument
+     *
+     * @var mixed
+     */
+    protected $defaultValue = null;
 
-	/**
-	 * Constructor for this argument definition.
-	 *
-	 * @param string $name Name of argument
-	 * @param string $type Type of argument
-	 * @param string $description Description of argument
-	 * @param boolean $required TRUE if argument is required
-	 * @param mixed $defaultValue Default value
-	 */
-	public function __construct($name, $type, $description, $required, $defaultValue = NULL) {
-		$this->name = $name;
-		$this->type = $type;
-		$this->description = $description;
-		$this->required = $required;
-		$this->defaultValue = $defaultValue;
-	}
+    /**
+     * Constructor for this argument definition.
+     *
+     * @param string $name Name of argument
+     * @param string $type Type of argument
+     * @param string $description Description of argument
+     * @param boolean $required TRUE if argument is required
+     * @param mixed $defaultValue Default value
+     */
+    public function __construct($name, $type, $description, $required, $defaultValue = null)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->description = $description;
+        $this->required = $required;
+        $this->defaultValue = $defaultValue;
+    }
 
-	/**
-	 * Get the name of the argument
-	 *
-	 * @return string Name of argument
-	 */
-	public function getName() {
-		return $this->name;
-	}
+    /**
+     * Get the name of the argument
+     *
+     * @return string Name of argument
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 
-	/**
-	 * Get the type of the argument
-	 *
-	 * @return string Type of argument
-	 */
-	public function getType() {
-		return $this->type;
-	}
+    /**
+     * Get the type of the argument
+     *
+     * @return string Type of argument
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
 
-	/**
-	 * Get the description of the argument
-	 *
-	 * @return string Description of argument
-	 */
-	public function getDescription() {
-		return $this->description;
-	}
+    /**
+     * Get the description of the argument
+     *
+     * @return string Description of argument
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
 
-	/**
-	 * Get the optionality of the argument
-	 *
-	 * @return boolean TRUE if argument is optional
-	 */
-	public function isRequired() {
-		return $this->required;
-	}
+    /**
+     * Get the optionality of the argument
+     *
+     * @return boolean TRUE if argument is optional
+     */
+    public function isRequired()
+    {
+        return $this->required;
+    }
 
-	/**
-	 * Get the default value, if set
-	 *
-	 * @return mixed Default value
-	 */
-	public function getDefaultValue() {
-		return $this->defaultValue;
-	}
-
+    /**
+     * Get the default value, if set
+     *
+     * @return mixed Default value
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
+    }
 }

--- a/src/Core/ViewHelper/Exception.php
+++ b/src/Core/ViewHelper/Exception.php
@@ -11,5 +11,6 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  *
  * @api
  */
-class Exception extends \TYPO3Fluid\Fluid\Core\Exception {
+class Exception extends \TYPO3Fluid\Fluid\Core\Exception
+{
 }

--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -11,223 +11,239 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  *
  * @api
  */
-class TagBuilder {
+class TagBuilder
+{
 
-	/**
-	 * Name of the Tag to be rendered
-	 *
-	 * @var string
-	 */
-	protected $tagName = '';
+    /**
+     * Name of the Tag to be rendered
+     *
+     * @var string
+     */
+    protected $tagName = '';
 
-	/**
-	 * Content of the tag to be rendered
-	 *
-	 * @var string
-	 */
-	protected $content = '';
+    /**
+     * Content of the tag to be rendered
+     *
+     * @var string
+     */
+    protected $content = '';
 
-	/**
-	 * Attributes of the tag to be rendered
-	 *
-	 * @var array
-	 */
-	protected $attributes = array();
+    /**
+     * Attributes of the tag to be rendered
+     *
+     * @var array
+     */
+    protected $attributes = [];
 
-	/**
-	 * Specifies whether this tag needs a closing tag.
-	 * E.g. <textarea> cant be self-closing even if its empty
-	 *
-	 * @var boolean
-	 */
-	protected $forceClosingTag = FALSE;
+    /**
+     * Specifies whether this tag needs a closing tag.
+     * E.g. <textarea> cant be self-closing even if its empty
+     *
+     * @var boolean
+     */
+    protected $forceClosingTag = false;
 
-	/**
-	 * Constructor
-	 *
-	 * @param string $tagName name of the tag to be rendered
-	 * @param string $tagContent content of the tag to be rendered
-	 * @api
-	 */
-	public function __construct($tagName = '', $tagContent = '') {
-		$this->setTagName($tagName);
-		$this->setContent($tagContent);
-	}
+    /**
+     * Constructor
+     *
+     * @param string $tagName name of the tag to be rendered
+     * @param string $tagContent content of the tag to be rendered
+     * @api
+     */
+    public function __construct($tagName = '', $tagContent = '')
+    {
+        $this->setTagName($tagName);
+        $this->setContent($tagContent);
+    }
 
-	/**
-	 * Sets the tag name
-	 *
-	 * @param string $tagName name of the tag to be rendered
-	 * @return void
-	 * @api
-	 */
-	public function setTagName($tagName) {
-		$this->tagName = $tagName;
-	}
+    /**
+     * Sets the tag name
+     *
+     * @param string $tagName name of the tag to be rendered
+     * @return void
+     * @api
+     */
+    public function setTagName($tagName)
+    {
+        $this->tagName = $tagName;
+    }
 
-	/**
-	 * Gets the tag name
-	 *
-	 * @return string tag name of the tag to be rendered
-	 * @api
-	 */
-	public function getTagName() {
-		return $this->tagName;
-	}
+    /**
+     * Gets the tag name
+     *
+     * @return string tag name of the tag to be rendered
+     * @api
+     */
+    public function getTagName()
+    {
+        return $this->tagName;
+    }
 
-	/**
-	 * Sets the content of the tag
-	 *
-	 * @param string $tagContent content of the tag to be rendered
-	 * @return void
-	 * @api
-	 */
-	public function setContent($tagContent) {
-		$this->content = $tagContent;
-	}
+    /**
+     * Sets the content of the tag
+     *
+     * @param string $tagContent content of the tag to be rendered
+     * @return void
+     * @api
+     */
+    public function setContent($tagContent)
+    {
+        $this->content = $tagContent;
+    }
 
-	/**
-	 * Gets the content of the tag
-	 *
-	 * @return string content of the tag to be rendered
-	 * @api
-	 */
-	public function getContent() {
-		return $this->content;
-	}
+    /**
+     * Gets the content of the tag
+     *
+     * @return string content of the tag to be rendered
+     * @api
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
 
-	/**
-	 * Returns TRUE if tag contains content, otherwise FALSE
-	 *
-	 * @return boolean TRUE if tag contains text, otherwise FALSE
-	 * @api
-	 */
-	public function hasContent() {
-		if ($this->content === NULL) {
-			return FALSE;
-		}
-		return $this->content !== '';
-	}
+    /**
+     * Returns TRUE if tag contains content, otherwise FALSE
+     *
+     * @return boolean TRUE if tag contains text, otherwise FALSE
+     * @api
+     */
+    public function hasContent()
+    {
+        if ($this->content === null) {
+            return false;
+        }
+        return $this->content !== '';
+    }
 
-	/**
-	 * Set this to TRUE to force a closing tag
-	 * E.g. <textarea> cant be self-closing even if its empty
-	 *
-	 * @param boolean $forceClosingTag
-	 * @api
-	 */
-	public function forceClosingTag($forceClosingTag) {
-		$this->forceClosingTag = $forceClosingTag;
-	}
+    /**
+     * Set this to TRUE to force a closing tag
+     * E.g. <textarea> cant be self-closing even if its empty
+     *
+     * @param boolean $forceClosingTag
+     * @api
+     */
+    public function forceClosingTag($forceClosingTag)
+    {
+        $this->forceClosingTag = $forceClosingTag;
+    }
 
-	/**
-	 * Returns TRUE if the tag has an attribute with the given name
-	 *
-	 * @param string $attributeName name of the attribute
-	 * @return boolean TRUE if the tag has an attribute with the given name, otherwise FALSE
-	 * @api
-	 */
-	public function hasAttribute($attributeName) {
-		return array_key_exists($attributeName, $this->attributes);
-	}
+    /**
+     * Returns TRUE if the tag has an attribute with the given name
+     *
+     * @param string $attributeName name of the attribute
+     * @return boolean TRUE if the tag has an attribute with the given name, otherwise FALSE
+     * @api
+     */
+    public function hasAttribute($attributeName)
+    {
+        return array_key_exists($attributeName, $this->attributes);
+    }
 
-	/**
-	 * Get an attribute from the $attributes-collection
-	 *
-	 * @param string $attributeName name of the attribute
-	 * @return string The attribute value or NULL if the attribute is not registered
-	 * @api
-	 */
-	public function getAttribute($attributeName) {
-		if (!$this->hasAttribute($attributeName)) {
-			return NULL;
-		}
-		return $this->attributes[$attributeName];
-	}
+    /**
+     * Get an attribute from the $attributes-collection
+     *
+     * @param string $attributeName name of the attribute
+     * @return string The attribute value or NULL if the attribute is not registered
+     * @api
+     */
+    public function getAttribute($attributeName)
+    {
+        if (!$this->hasAttribute($attributeName)) {
+            return null;
+        }
+        return $this->attributes[$attributeName];
+    }
 
-	/**
-	 * Get all attribute from the $attributes-collection
-	 *
-	 * @return array Attributes indexed by attribute name
-	 * @api
-	 */
-	public function getAttributes() {
-		return $this->attributes;
-	}
+    /**
+     * Get all attribute from the $attributes-collection
+     *
+     * @return array Attributes indexed by attribute name
+     * @api
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
 
-	/**
-	 * Adds an attribute to the $attributes-collection
-	 *
-	 * @param string $attributeName name of the attribute to be added to the tag
-	 * @param string $attributeValue attribute value
-	 * @param boolean $escapeSpecialCharacters apply htmlspecialchars to attribute value
-	 * @return void
-	 * @api
-	 */
-	public function addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters = TRUE) {
-		if ($escapeSpecialCharacters) {
-			$attributeValue = htmlspecialchars($attributeValue);
-		}
-		$this->attributes[$attributeName] = $attributeValue;
-	}
+    /**
+     * Adds an attribute to the $attributes-collection
+     *
+     * @param string $attributeName name of the attribute to be added to the tag
+     * @param string $attributeValue attribute value
+     * @param boolean $escapeSpecialCharacters apply htmlspecialchars to attribute value
+     * @return void
+     * @api
+     */
+    public function addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters = true)
+    {
+        if ($escapeSpecialCharacters) {
+            $attributeValue = htmlspecialchars($attributeValue);
+        }
+        $this->attributes[$attributeName] = $attributeValue;
+    }
 
-	/**
-	 * Adds attributes to the $attributes-collection
-	 *
-	 * @param array $attributes collection of attributes to add. key = attribute name, value = attribute value
-	 * @param boolean $escapeSpecialCharacters apply htmlspecialchars to attribute values#
-	 * @return void
-	 * @api
-	 */
-	public function addAttributes(array $attributes, $escapeSpecialCharacters = TRUE) {
-		foreach ($attributes as $attributeName => $attributeValue) {
-			$this->addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters);
-		}
-	}
+    /**
+     * Adds attributes to the $attributes-collection
+     *
+     * @param array $attributes collection of attributes to add. key = attribute name, value = attribute value
+     * @param boolean $escapeSpecialCharacters apply htmlspecialchars to attribute values#
+     * @return void
+     * @api
+     */
+    public function addAttributes(array $attributes, $escapeSpecialCharacters = true)
+    {
+        foreach ($attributes as $attributeName => $attributeValue) {
+            $this->addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters);
+        }
+    }
 
-	/**
-	 * Removes an attribute from the $attributes-collection
-	 *
-	 * @param string $attributeName name of the attribute to be removed from the tag
-	 * @return void
-	 * @api
-	 */
-	public function removeAttribute($attributeName) {
-		unset($this->attributes[$attributeName]);
-	}
+    /**
+     * Removes an attribute from the $attributes-collection
+     *
+     * @param string $attributeName name of the attribute to be removed from the tag
+     * @return void
+     * @api
+     */
+    public function removeAttribute($attributeName)
+    {
+        unset($this->attributes[$attributeName]);
+    }
 
-	/**
-	 * Resets the TagBuilder by setting all members to their default value
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function reset() {
-		$this->tagName = '';
-		$this->content = '';
-		$this->attributes = array();
-		$this->forceClosingTag = FALSE;
-	}
+    /**
+     * Resets the TagBuilder by setting all members to their default value
+     *
+     * @return void
+     * @api
+     */
+    public function reset()
+    {
+        $this->tagName = '';
+        $this->content = '';
+        $this->attributes = [];
+        $this->forceClosingTag = false;
+    }
 
-	/**
-	 * Renders and returns the tag
-	 *
-	 * @return string
-	 * @api
-	 */
-	public function render() {
-		if (empty($this->tagName)) {
-			return '';
-		}
-		$output = '<' . $this->tagName;
-		foreach ($this->attributes as $attributeName => $attributeValue) {
-			$output .= ' ' . $attributeName . '="' . $attributeValue . '"';
-		}
-		if ($this->hasContent() || $this->forceClosingTag) {
-			$output .= '>' . $this->content . '</' . $this->tagName . '>';
-		} else {
-			$output .= ' />';
-		}
-		return $output;
-	}
+    /**
+     * Renders and returns the tag
+     *
+     * @return string
+     * @api
+     */
+    public function render()
+    {
+        if (empty($this->tagName)) {
+            return '';
+        }
+        $output = '<' . $this->tagName;
+        foreach ($this->attributes as $attributeName => $attributeValue) {
+            $output .= ' ' . $attributeName . '="' . $attributeValue . '"';
+        }
+        if ($this->hasContent() || $this->forceClosingTag) {
+            $output .= '>' . $this->content . '</' . $this->tagName . '>';
+        } else {
+            $output .= ' />';
+        }
+        return $output;
+    }
 }

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -17,7 +17,8 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * the normal render children closure, if that named
  * argument is specified and not empty.
  */
-trait CompileWithContentArgumentAndRenderStatic {
+trait CompileWithContentArgumentAndRenderStatic
+{
 
     /**
      * Name of variable that contains the value to use
@@ -43,13 +44,16 @@ trait CompileWithContentArgumentAndRenderStatic {
      * @return string Rendered string
      * @api
      */
-    public function render() {
+    public function render()
+    {
         $argumentName = $this->resolveContentArgumentName();
         $arguments = $this->arguments;
         if (!empty($argumentName) && isset($arguments[$argumentName])) {
-            $renderChildrenClosure = function() use ($arguments, $argumentName) { return $arguments[$argumentName]; };
+            $renderChildrenClosure = function () use ($arguments, $argumentName) {
+                return $arguments[$argumentName];
+            };
         } else {
-            $renderChildrenClosure = call_user_func_array(array($this, 'buildRenderChildrenClosure'), array());
+            $renderChildrenClosure = call_user_func_array([$this, 'buildRenderChildrenClosure'], []);
         }
         return self::renderStatic(
             $arguments,
@@ -88,9 +92,10 @@ trait CompileWithContentArgumentAndRenderStatic {
     /**
      * @return string
      */
-    protected function resolveContentArgumentName() {
+    protected function resolveContentArgumentName()
+    {
         if (empty($this->contentArgumentName)) {
-            $registeredArguments = call_user_func_array(array($this, 'prepareArguments'), array());
+            $registeredArguments = call_user_func_array([$this, 'prepareArguments'], []);
             foreach ($registeredArguments as $registeredArgument) {
                 if (!$registeredArgument->isRequired()) {
                     $this->contentArgumentName = $registeredArgument->getName();
@@ -104,5 +109,4 @@ trait CompileWithContentArgumentAndRenderStatic {
         }
         return $this->contentArgumentName;
     }
-
 }

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -13,7 +13,8 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * any ViewHelper that conforms to the `renderStatic`
  * method pattern.
  */
-trait CompileWithRenderStatic {
+trait CompileWithRenderStatic
+{
 
     /**
      * Default render method - simply calls renderStatic() with a
@@ -22,10 +23,11 @@ trait CompileWithRenderStatic {
      * @return string Rendered string
      * @api
      */
-    public function render() {
+    public function render()
+    {
         return self::renderStatic(
             $this->arguments,
-            call_user_func_array(array($this, 'buildRenderChildrenClosure'), array()),
+            call_user_func_array([$this, 'buildRenderChildrenClosure'], []),
             $this->renderingContext
         );
     }
@@ -53,5 +55,4 @@ trait CompileWithRenderStatic {
         $initializationPhpCode .= $initialization;
         return $execution;
     }
-
 }

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -16,90 +16,91 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *
  * Implemented by all ViewHelpers
  */
-interface ViewHelperInterface {
+interface ViewHelperInterface
+{
 
-	/**
-	 * @return ArgumentDefinition[]
-	 */
-	public function prepareArguments();
+    /**
+     * @return ArgumentDefinition[]
+     */
+    public function prepareArguments();
 
-	/**
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function setArguments(array $arguments);
+    /**
+     * @param array $arguments
+     * @return void
+     */
+    public function setArguments(array $arguments);
 
-	/**
-	 * @param NodeInterface[] $nodes
-	 * @return void
-	 */
-	public function setChildNodes(array $nodes);
+    /**
+     * @param NodeInterface[] $nodes
+     * @return void
+     */
+    public function setChildNodes(array $nodes);
 
-	/**
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext);
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext);
 
-	/**
-	 * Initialize the arguments of the ViewHelper, and call the render() method of the ViewHelper.
-	 *
-	 * @return string the rendered ViewHelper.
-	 */
-	public function initializeArgumentsAndRender();
+    /**
+     * Initialize the arguments of the ViewHelper, and call the render() method of the ViewHelper.
+     *
+     * @return string the rendered ViewHelper.
+     */
+    public function initializeArgumentsAndRender();
 
-	/**
-	 * Initializes the view helper before invoking the render method.
-	 *
-	 * Override this method to solve tasks before the view helper content is rendered.
-	 *
-	 * @return void
-	 */
-	public function initialize();
+    /**
+     * Initializes the view helper before invoking the render method.
+     *
+     * Override this method to solve tasks before the view helper content is rendered.
+     *
+     * @return void
+     */
+    public function initialize();
 
-	/**
-	 * Helper method which triggers the rendering of everything between the
-	 * opening and the closing tag.
-	 *
-	 * @return mixed The finally rendered child nodes.
-	 */
-	public function renderChildren();
+    /**
+     * Helper method which triggers the rendering of everything between the
+     * opening and the closing tag.
+     *
+     * @return mixed The finally rendered child nodes.
+     */
+    public function renderChildren();
 
-	/**
-	 * Validate arguments, and throw exception if arguments do not validate.
-	 *
-	 * @return void
-	 * @throws \InvalidArgumentException
-	 */
-	public function validateArguments();
+    /**
+     * Validate arguments, and throw exception if arguments do not validate.
+     *
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    public function validateArguments();
 
-	/**
-	 * Initialize all arguments. You need to override this method and call
-	 * $this->registerArgument(...) inside this method, to register all your arguments.
-	 *
-	 * @return void
-	 */
-	public function initializeArguments();
+    /**
+     * Initialize all arguments. You need to override this method and call
+     * $this->registerArgument(...) inside this method, to register all your arguments.
+     *
+     * @return void
+     */
+    public function initializeArguments();
 
-	/**
-	 * Method which can be implemented in any ViewHelper if that ViewHelper desires
-	 * the ability to allow additional, undeclared, dynamic etc. arguments for the
-	 * node in the template. Do not implement this unless you need it!
-	 *
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function handleAdditionalArguments(array $arguments);
+    /**
+     * Method which can be implemented in any ViewHelper if that ViewHelper desires
+     * the ability to allow additional, undeclared, dynamic etc. arguments for the
+     * node in the template. Do not implement this unless you need it!
+     *
+     * @param array $arguments
+     * @return void
+     */
+    public function handleAdditionalArguments(array $arguments);
 
-	/**
-	 * Method which can be implemented in any ViewHelper if that ViewHelper desires
-	 * the ability to allow additional, undeclared, dynamic etc. arguments for the
-	 * node in the template. Do not implement this unless you need it!
-	 *
-	 * @param array $arguments
-	 * @return void
-	 */
-	public function validateAdditionalArguments(array $arguments);
+    /**
+     * Method which can be implemented in any ViewHelper if that ViewHelper desires
+     * the ability to allow additional, undeclared, dynamic etc. arguments for the
+     * node in the template. Do not implement this unless you need it!
+     *
+     * @param array $arguments
+     * @return void
+     */
+    public function validateAdditionalArguments(array $arguments);
 
 //	/**
 //	 * Render method you need to implement for your custom view helper.
@@ -110,64 +111,64 @@ interface ViewHelperInterface {
 //	 */
 //	public function render();
 
-	/**
-	 * Here follows a more detailed description of the arguments of this function:
-	 *
-	 * $arguments contains a plain array of all arguments this ViewHelper has received,
-	 * including the default argument values if an argument has not been specified
-	 * in the ViewHelper invocation.
-	 *
-	 * $renderChildrenClosure is a closure you can execute instead of $this->renderChildren().
-	 * It returns the rendered child nodes, so you can simply do $renderChildrenClosure() to execute
-	 * it. It does not take any parameters.
-	 *
-	 * $renderingContext contains references to the VariableProvider and the
-	 * ViewHelperVariableContainer.
-	 *
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string the resulting string which is directly shown
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext);
+    /**
+     * Here follows a more detailed description of the arguments of this function:
+     *
+     * $arguments contains a plain array of all arguments this ViewHelper has received,
+     * including the default argument values if an argument has not been specified
+     * in the ViewHelper invocation.
+     *
+     * $renderChildrenClosure is a closure you can execute instead of $this->renderChildren().
+     * It returns the rendered child nodes, so you can simply do $renderChildrenClosure() to execute
+     * it. It does not take any parameters.
+     *
+     * $renderingContext contains references to the VariableProvider and the
+     * ViewHelperVariableContainer.
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string the resulting string which is directly shown
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext);
 
-	/**
-	 * This method is called on compilation time.
-	 *
-	 * It has to return a *single* PHP statement without semi-colon or newline
-	 * at the end, which will be embedded at various places.
-	 *
-	 * Furthermore, it can append PHP code to the variable $initializationPhpCode.
-	 * In this case, all statements have to end with semi-colon and newline.
-	 *
-	 * Outputting new variables
-	 * ========================
-	 * If you want create a new PHP variable, you need to use
-	 * $templateCompiler->variableName('nameOfVariable') for this, as all variables
-	 * need to be globally unique.
-	 *
-	 * Return Value
-	 * ============
-	 * Besides returning a single string, it can also return the constant
-	 * \TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::SHOULD_GENERATE_VIEWHELPER_INVOCATION
-	 * which means that after the $initializationPhpCode, the ViewHelper invocation
-	 * is built as normal. This is especially needed if you want to build new arguments
-	 * at run-time, as it is done for the AbstractConditionViewHelper.
-	 *
-	 * @param string $argumentsName Name of the variable in which the ViewHelper arguments are stored
-	 * @param string $closureName Name of the closure which can be executed to render the child nodes
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler);
+    /**
+     * This method is called on compilation time.
+     *
+     * It has to return a *single* PHP statement without semi-colon or newline
+     * at the end, which will be embedded at various places.
+     *
+     * Furthermore, it can append PHP code to the variable $initializationPhpCode.
+     * In this case, all statements have to end with semi-colon and newline.
+     *
+     * Outputting new variables
+     * ========================
+     * If you want create a new PHP variable, you need to use
+     * $templateCompiler->variableName('nameOfVariable') for this, as all variables
+     * need to be globally unique.
+     *
+     * Return Value
+     * ============
+     * Besides returning a single string, it can also return the constant
+     * \TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::SHOULD_GENERATE_VIEWHELPER_INVOCATION
+     * which means that after the $initializationPhpCode, the ViewHelper invocation
+     * is built as normal. This is especially needed if you want to build new arguments
+     * at run-time, as it is done for the AbstractConditionViewHelper.
+     *
+     * @param string $argumentsName Name of the variable in which the ViewHelper arguments are stored
+     * @param string $closureName Name of the closure which can be executed to render the child nodes
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler);
 
-	/**
-	 * Called when being inside a cached template.
-	 *
-	 * @param \Closure $renderChildrenClosure
-	 * @return void
-	 */
-	public function setRenderChildrenClosure(\Closure $renderChildrenClosure);
+    /**
+     * Called when being inside a cached template.
+     *
+     * @param \Closure $renderChildrenClosure
+     * @return void
+     */
+    public function setRenderChildrenClosure(\Closure $renderChildrenClosure);
 }

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -28,52 +28,53 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
  * responsible for invoking the render method of a ViewHelper
  * using the properties available in the node.
  */
-class ViewHelperInvoker {
+class ViewHelperInvoker
+{
 
-	/**
-	 * Invoke the ViewHelper described by the ViewHelperNode, the properties
-	 * of which will already have been filled by the ViewHelperResolver.
-	 *
-	 * @param string|ViewHelperInterface $viewHelperClassNameOrInstance
-	 * @param array $arguments
-	 * @param RenderingContextInterface $renderingContext
-	 * @param null|\Closure $renderChildrenClosure
-	 * @return string
-	 */
-	public function invoke($viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, \Closure $renderChildrenClosure = NULL) {
-		$viewHelperResolver = $renderingContext->getViewHelperResolver();
-		if ($viewHelperClassNameOrInstance instanceof ViewHelperInterface) {
-			$viewHelper = $viewHelperClassNameOrInstance;
-		} else {
-			$viewHelper = $viewHelperResolver->createViewHelperInstanceFromClassName($viewHelperClassNameOrInstance);
-		}
-		$expectedViewHelperArguments = $viewHelperResolver->getArgumentDefinitionsForViewHelper($viewHelper);
+    /**
+     * Invoke the ViewHelper described by the ViewHelperNode, the properties
+     * of which will already have been filled by the ViewHelperResolver.
+     *
+     * @param string|ViewHelperInterface $viewHelperClassNameOrInstance
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     * @param null|\Closure $renderChildrenClosure
+     * @return string
+     */
+    public function invoke($viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, \Closure $renderChildrenClosure = null)
+    {
+        $viewHelperResolver = $renderingContext->getViewHelperResolver();
+        if ($viewHelperClassNameOrInstance instanceof ViewHelperInterface) {
+            $viewHelper = $viewHelperClassNameOrInstance;
+        } else {
+            $viewHelper = $viewHelperResolver->createViewHelperInstanceFromClassName($viewHelperClassNameOrInstance);
+        }
+        $expectedViewHelperArguments = $viewHelperResolver->getArgumentDefinitionsForViewHelper($viewHelper);
 
-		// Rendering process
-		$evaluatedArguments = array();
-		$undeclaredArguments = array();
-		foreach ($expectedViewHelperArguments as $argumentName => $argumentDefinition) {
-			if (isset($arguments[$argumentName])) {
-				/** @var NodeInterface|mixed $argumentValue */
-				$argumentValue = $arguments[$argumentName];
-				$evaluatedArguments[$argumentName] = $argumentValue instanceof NodeInterface ? $argumentValue->evaluate($renderingContext) : $argumentValue;
-			} else {
-				$evaluatedArguments[$argumentName] = $argumentDefinition->getDefaultValue();
-			}
-		}
-		foreach ($arguments as $argumentName => $argumentValue) {
-			if (!array_key_exists($argumentName, $evaluatedArguments)) {
-				$undeclaredArguments[$argumentName] = $argumentValue instanceof NodeInterface ? $argumentValue->evaluate($renderingContext) : $argumentValue;
-			}
-		}
+        // Rendering process
+        $evaluatedArguments = [];
+        $undeclaredArguments = [];
+        foreach ($expectedViewHelperArguments as $argumentName => $argumentDefinition) {
+            if (isset($arguments[$argumentName])) {
+                /** @var NodeInterface|mixed $argumentValue */
+                $argumentValue = $arguments[$argumentName];
+                $evaluatedArguments[$argumentName] = $argumentValue instanceof NodeInterface ? $argumentValue->evaluate($renderingContext) : $argumentValue;
+            } else {
+                $evaluatedArguments[$argumentName] = $argumentDefinition->getDefaultValue();
+            }
+        }
+        foreach ($arguments as $argumentName => $argumentValue) {
+            if (!array_key_exists($argumentName, $evaluatedArguments)) {
+                $undeclaredArguments[$argumentName] = $argumentValue instanceof NodeInterface ? $argumentValue->evaluate($renderingContext) : $argumentValue;
+            }
+        }
 
-		if ($renderChildrenClosure) {
-			$viewHelper->setRenderChildrenClosure($renderChildrenClosure);
-		}
-		$viewHelper->setRenderingContext($renderingContext);
-		$viewHelper->setArguments($evaluatedArguments);
-		$viewHelper->handleAdditionalArguments($undeclaredArguments);
-		return $viewHelper->initializeArgumentsAndRender();
-	}
-
+        if ($renderChildrenClosure) {
+            $viewHelper->setRenderChildrenClosure($renderChildrenClosure);
+        }
+        $viewHelper->setRenderingContext($renderingContext);
+        $viewHelper->setArguments($evaluatedArguments);
+        $viewHelper->handleAdditionalArguments($undeclaredArguments);
+        return $viewHelper->initializeArgumentsAndRender();
+    }
 }

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -20,297 +20,313 @@ use TYPO3Fluid\Fluid\Core\Parser\Patterns;
  * framework to be responsible for creating ViewHelper instances
  * and detecting possible arguments.
  */
-class ViewHelperResolver {
+class ViewHelperResolver
+{
 
-	/**
-	 * @var array
-	 */
-	protected static $resolvedViewHelperClassNames = array();
+    /**
+     * @var array
+     */
+    protected static $resolvedViewHelperClassNames = [];
 
-	/**
-	 * Namespaces requested by the template being rendered,
-	 * in [shortname => phpnamespace] format.
-	 *
-	 * @var array
-	 */
-	protected $namespaces = array(
-		'f' => array('TYPO3Fluid\\Fluid\\ViewHelpers')
-	);
+    /**
+     * Namespaces requested by the template being rendered,
+     * in [shortname => phpnamespace] format.
+     *
+     * @var array
+     */
+    protected $namespaces = [
+        'f' => ['TYPO3Fluid\\Fluid\\ViewHelpers']
+    ];
 
-	/**
-	 * @return array
-	 */
-	public function getNamespaces() {
-		return $this->namespaces;
-	}
+    /**
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        return $this->namespaces;
+    }
 
-	/**
-	 * Add a PHP namespace where ViewHelpers can be found and give
-	 * it an alias/identifier.
-	 *
-	 * The provided namespace can be either a single namespace or
-	 * an array of namespaces, as strings. The identifier/alias is
-	 * always a single, alpha-numeric ASCII string.
-	 *
-	 * Calling this method multiple times with different PHP namespaces
-	 * for the same alias causes that namespace to be *extended*,
-	 * meaning that the PHP namespace you provide second, third etc.
-	 * are also used in lookups and are used *first*, so that if any
-	 * of the namespaces you add contains a class placed and named the
-	 * same way as one that exists in an earlier namespace, then your
-	 * class gets used instead of the earlier one.
-	 *
-	 * Example:
-	 *
-	 * $resolver->addNamespace('my', 'My\Package\ViewHelpers');
-	 * // Any ViewHelpers under this namespace can now be accessed using for example {my:example()}
-	 * // Now, assuming you also have an ExampleViewHelper class in a different
-	 * // namespace and wish to make that ExampleViewHelper override the other:
-	 * $resolver->addNamespace('my', 'My\OtherPackage\ViewHelpers');
-	 * // Now, since ExampleViewHelper exists in both places but the
-	 * // My\OtherPackage\ViewHelpers namespace was added *last*, Fluid
-	 * // will find and use My\OtherPackage\ViewHelpers\ExampleViewHelper.
-	 *
-	 * Alternatively, setNamespaces() can be used to reset and redefine
-	 * all previously added namespaces - which is great for cases where
-	 * you need to remove or replace previously added namespaces. Be aware
-	 * that setNamespaces() also removes the default "f" namespace, so
-	 * when you use this method you should always include the "f" namespace.
-	 *
-	 * @param string $identifier
-	 * @param string|array $phpNamespace
-	 * @return void
-	 */
-	public function addNamespace($identifier, $phpNamespace) {
-		if (!array_key_exists($identifier, $this->namespaces)) {
-			$this->namespaces[$identifier] = $phpNamespace === NULL ? NULL : (array) $phpNamespace;
-		} elseif (is_array($phpNamespace)) {
-			$this->namespaces[$identifier] = array_unique(array_merge($this->namespaces[$identifier], $phpNamespace));
-		} elseif (!in_array($phpNamespace, $this->namespaces[$identifier])) {
-			$this->namespaces[$identifier][] = $phpNamespace;
-		}
-	}
+    /**
+     * Add a PHP namespace where ViewHelpers can be found and give
+     * it an alias/identifier.
+     *
+     * The provided namespace can be either a single namespace or
+     * an array of namespaces, as strings. The identifier/alias is
+     * always a single, alpha-numeric ASCII string.
+     *
+     * Calling this method multiple times with different PHP namespaces
+     * for the same alias causes that namespace to be *extended*,
+     * meaning that the PHP namespace you provide second, third etc.
+     * are also used in lookups and are used *first*, so that if any
+     * of the namespaces you add contains a class placed and named the
+     * same way as one that exists in an earlier namespace, then your
+     * class gets used instead of the earlier one.
+     *
+     * Example:
+     *
+     * $resolver->addNamespace('my', 'My\Package\ViewHelpers');
+     * // Any ViewHelpers under this namespace can now be accessed using for example {my:example()}
+     * // Now, assuming you also have an ExampleViewHelper class in a different
+     * // namespace and wish to make that ExampleViewHelper override the other:
+     * $resolver->addNamespace('my', 'My\OtherPackage\ViewHelpers');
+     * // Now, since ExampleViewHelper exists in both places but the
+     * // My\OtherPackage\ViewHelpers namespace was added *last*, Fluid
+     * // will find and use My\OtherPackage\ViewHelpers\ExampleViewHelper.
+     *
+     * Alternatively, setNamespaces() can be used to reset and redefine
+     * all previously added namespaces - which is great for cases where
+     * you need to remove or replace previously added namespaces. Be aware
+     * that setNamespaces() also removes the default "f" namespace, so
+     * when you use this method you should always include the "f" namespace.
+     *
+     * @param string $identifier
+     * @param string|array $phpNamespace
+     * @return void
+     */
+    public function addNamespace($identifier, $phpNamespace)
+    {
+        if (!array_key_exists($identifier, $this->namespaces)) {
+            $this->namespaces[$identifier] = $phpNamespace === null ? null : (array) $phpNamespace;
+        } elseif (is_array($phpNamespace)) {
+            $this->namespaces[$identifier] = array_unique(array_merge($this->namespaces[$identifier], $phpNamespace));
+        } elseif (!in_array($phpNamespace, $this->namespaces[$identifier])) {
+            $this->namespaces[$identifier][] = $phpNamespace;
+        }
+    }
 
-	/**
-	 * Wrapper to allow adding namespaces in bulk *without* first
-	 * clearing the already added namespaces. Utility method mainly
-	 * used in compiled templates, where some namespaces can be added
-	 * from outside and some can be added from compiled values.
-	 *
-	 * @param array $namespaces
-	 * @return void
-	 */
-	public function addNamespaces(array $namespaces) {
-		foreach ($namespaces as $identifier => $namespace) {
-			$this->addNamespace($identifier, $namespace);
-		}
-	}
+    /**
+     * Wrapper to allow adding namespaces in bulk *without* first
+     * clearing the already added namespaces. Utility method mainly
+     * used in compiled templates, where some namespaces can be added
+     * from outside and some can be added from compiled values.
+     *
+     * @param array $namespaces
+     * @return void
+     */
+    public function addNamespaces(array $namespaces)
+    {
+        foreach ($namespaces as $identifier => $namespace) {
+            $this->addNamespace($identifier, $namespace);
+        }
+    }
 
-	/**
-	 * Resolves the PHP namespace based on the Fluid xmlns namespace,
-	 * which can be either a URL matching the Patterns::NAMESPACEPREFIX
-	 * and Patterns::NAMESPACESUFFIX rules, or a PHP namespace. When
-	 * namespace is a PHP namespace it is optional to suffix it with
-	 * the "\ViewHelpers" segment, e.g. "My\Package" is as valid to
-	 * use as "My\Package\ViewHelpers" is.
-	 *
-	 * @param string $fluidNamespace
-	 * @return string
-	 */
-	public function resolvePhpNamespaceFromFluidNamespace($fluidNamespace) {
-		$namespace = $fluidNamespace;
-		$suffixLength = strlen(Patterns::NAMESPACESUFFIX);
-		$phpNamespaceSuffix = str_replace('/', '\\', Patterns::NAMESPACESUFFIX);
-		$extractedSuffix = substr($fluidNamespace, 0 - $suffixLength);
-		if (strpos($fluidNamespace, Patterns::NAMESPACEPREFIX) === 0 && $extractedSuffix === Patterns::NAMESPACESUFFIX) {
-			// convention assumed: URL starts with prefix and ends with suffix
-			$namespace = substr($fluidNamespace, strlen(Patterns::NAMESPACEPREFIX));
-		}
-		$namespace = str_replace('/', '\\', $namespace);
-		if (substr($namespace, 0 - strlen($phpNamespaceSuffix)) !== $phpNamespaceSuffix) {
-			$namespace .= $phpNamespaceSuffix;
-		}
-		return $namespace;
-	}
+    /**
+     * Resolves the PHP namespace based on the Fluid xmlns namespace,
+     * which can be either a URL matching the Patterns::NAMESPACEPREFIX
+     * and Patterns::NAMESPACESUFFIX rules, or a PHP namespace. When
+     * namespace is a PHP namespace it is optional to suffix it with
+     * the "\ViewHelpers" segment, e.g. "My\Package" is as valid to
+     * use as "My\Package\ViewHelpers" is.
+     *
+     * @param string $fluidNamespace
+     * @return string
+     */
+    public function resolvePhpNamespaceFromFluidNamespace($fluidNamespace)
+    {
+        $namespace = $fluidNamespace;
+        $suffixLength = strlen(Patterns::NAMESPACESUFFIX);
+        $phpNamespaceSuffix = str_replace('/', '\\', Patterns::NAMESPACESUFFIX);
+        $extractedSuffix = substr($fluidNamespace, 0 - $suffixLength);
+        if (strpos($fluidNamespace, Patterns::NAMESPACEPREFIX) === 0 && $extractedSuffix === Patterns::NAMESPACESUFFIX) {
+            // convention assumed: URL starts with prefix and ends with suffix
+            $namespace = substr($fluidNamespace, strlen(Patterns::NAMESPACEPREFIX));
+        }
+        $namespace = str_replace('/', '\\', $namespace);
+        if (substr($namespace, 0 - strlen($phpNamespaceSuffix)) !== $phpNamespaceSuffix) {
+            $namespace .= $phpNamespaceSuffix;
+        }
+        return $namespace;
+    }
 
-	/**
-	 * Set all namespaces as an array of ['identifier' => ['Php\Namespace1', 'Php\Namespace2']]
-	 * namespace definitions. For convenience and legacy support, a
-	 * format of ['identifier' => 'Only\Php\Namespace'] is allowed,
-	 * but will internally convert the namespace to an array and
-	 * allow it to be extended by addNamespace().
-	 *
-	 * Note that when using this method the default "f" namespace is
-	 * also removed and so must be included in $namespaces or added
-	 * after using addNamespace(). Or, add the PHP namespaces that
-	 * belonged to "f" as a new alias and use that in your templates.
-	 *
-	 * Use getNamespaces() to get an array of currently added namespaces.
-	 *
-	 * @param array $namespaces
-	 * @return void
-	 */
-	public function setNamespaces(array $namespaces) {
-		$this->namespaces = array();
-		foreach ($namespaces as $identifier => $phpNamespace) {
-			$this->namespaces[$identifier] = $phpNamespace === NULL ? NULL : (array) $phpNamespace;
-		}
-	}
+    /**
+     * Set all namespaces as an array of ['identifier' => ['Php\Namespace1', 'Php\Namespace2']]
+     * namespace definitions. For convenience and legacy support, a
+     * format of ['identifier' => 'Only\Php\Namespace'] is allowed,
+     * but will internally convert the namespace to an array and
+     * allow it to be extended by addNamespace().
+     *
+     * Note that when using this method the default "f" namespace is
+     * also removed and so must be included in $namespaces or added
+     * after using addNamespace(). Or, add the PHP namespaces that
+     * belonged to "f" as a new alias and use that in your templates.
+     *
+     * Use getNamespaces() to get an array of currently added namespaces.
+     *
+     * @param array $namespaces
+     * @return void
+     */
+    public function setNamespaces(array $namespaces)
+    {
+        $this->namespaces = [];
+        foreach ($namespaces as $identifier => $phpNamespace) {
+            $this->namespaces[$identifier] = $phpNamespace === null ? null : (array) $phpNamespace;
+        }
+    }
 
-	/**
-	 * Validates the given namespaceIdentifier and returns FALSE
-	 * if the namespace is unknown, causing the tag to be rendered
-	 * without processing.
-	 *
-	 * @param string $namespaceIdentifier
-	 * @return boolean TRUE if the given namespace is valid, otherwise FALSE
-	 */
-	public function isNamespaceValid($namespaceIdentifier) {
-		if (!array_key_exists($namespaceIdentifier, $this->namespaces)) {
-			return FALSE;
-		}
+    /**
+     * Validates the given namespaceIdentifier and returns FALSE
+     * if the namespace is unknown, causing the tag to be rendered
+     * without processing.
+     *
+     * @param string $namespaceIdentifier
+     * @return boolean TRUE if the given namespace is valid, otherwise FALSE
+     */
+    public function isNamespaceValid($namespaceIdentifier)
+    {
+        if (!array_key_exists($namespaceIdentifier, $this->namespaces)) {
+            return false;
+        }
 
-		return $this->namespaces[$namespaceIdentifier] !== NULL;
-	}
+        return $this->namespaces[$namespaceIdentifier] !== null;
+    }
 
-	/**
-	 * Validates the given namespaceIdentifier and returns FALSE
-	 * if the namespace is unknown and not ignored
-	 *
-	 * @param string $namespaceIdentifier
-	 * @return boolean TRUE if the given namespace is valid, otherwise FALSE
-	 */
-	public function isNamespaceValidOrIgnored($namespaceIdentifier) {
-		if ($this->isNamespaceValid($namespaceIdentifier) === TRUE) {
-			return TRUE;
-		}
+    /**
+     * Validates the given namespaceIdentifier and returns FALSE
+     * if the namespace is unknown and not ignored
+     *
+     * @param string $namespaceIdentifier
+     * @return boolean TRUE if the given namespace is valid, otherwise FALSE
+     */
+    public function isNamespaceValidOrIgnored($namespaceIdentifier)
+    {
+        if ($this->isNamespaceValid($namespaceIdentifier) === true) {
+            return true;
+        }
 
-		if (array_key_exists($namespaceIdentifier, $this->namespaces)) {
-			return TRUE;
-		}
+        if (array_key_exists($namespaceIdentifier, $this->namespaces)) {
+            return true;
+        }
 
-		if ($this->isNamespaceIgnored($namespaceIdentifier)) {
-			return TRUE;
-		}
+        if ($this->isNamespaceIgnored($namespaceIdentifier)) {
+            return true;
+        }
 
-		return FALSE;
-	}
+        return false;
+    }
 
-	/**
-	 * @param string $namespaceIdentifier
-	 * @return boolean
-	 */
-	public function isNamespaceIgnored($namespaceIdentifier) {
-		if (array_key_exists($namespaceIdentifier, $this->namespaces) && $this->namespaces[$namespaceIdentifier] === NULL) {
-			return TRUE;
-		}
-		foreach (array_keys($this->namespaces) as $existingNamespaceIdentifier) {
-			if (strpos($existingNamespaceIdentifier, '*') === FALSE) {
-				continue;
-			}
-			$pattern = '/' . str_replace(array('.', '*'), array('\\.', '[a-zA-Z0-9\.]*'), $existingNamespaceIdentifier) . '/';
-			if (preg_match($pattern, $namespaceIdentifier) === 1) {
-				return TRUE;
-			}
-		}
-		return FALSE;
-	}
+    /**
+     * @param string $namespaceIdentifier
+     * @return boolean
+     */
+    public function isNamespaceIgnored($namespaceIdentifier)
+    {
+        if (array_key_exists($namespaceIdentifier, $this->namespaces) && $this->namespaces[$namespaceIdentifier] === null) {
+            return true;
+        }
+        foreach (array_keys($this->namespaces) as $existingNamespaceIdentifier) {
+            if (strpos($existingNamespaceIdentifier, '*') === false) {
+                continue;
+            }
+            $pattern = '/' . str_replace(['.', '*'], ['\\.', '[a-zA-Z0-9\.]*'], $existingNamespaceIdentifier) . '/';
+            if (preg_match($pattern, $namespaceIdentifier) === 1) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * Resolves a ViewHelper class name by namespace alias and
-	 * Fluid-format identity, e.g. "f" and "format.htmlspecialchars".
-	 *
-	 * Looks in all PHP namespaces which have been added for the
-	 * provided alias, starting in the last added PHP namespace. If
-	 * a ViewHelper class exists in multiple PHP namespaces Fluid
-	 * will detect and use whichever one was added last.
-	 *
-	 * If no ViewHelper class can be detected in any of the added
-	 * PHP namespaces a Fluid Parser Exception is thrown.
-	 *
-	 * @param string $namespaceIdentifier
-	 * @param string $methodIdentifier
-	 * @return string|NULL
-	 * @throws ParserException
-	 */
-	public function resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier) {
-		if (!isset(static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier])) {
-			$resolvedViewHelperClassName = $this->resolveViewHelperName($namespaceIdentifier, $methodIdentifier);
-			$actualViewHelperClassName = implode('\\', array_map('ucfirst', explode('.', $resolvedViewHelperClassName)));
-			if (FALSE === class_exists($actualViewHelperClassName) || $actualViewHelperClassName === FALSE) {
-				throw new ParserException(sprintf(
-					'The ViewHelper "<%s:%s>" could not be resolved.' . chr(10) .
-					'Based on your spelling, the system would load the class "%s", however this class does not exist.',
-					$namespaceIdentifier, $methodIdentifier, $resolvedViewHelperClassName), 1407060572);
-			}
-			static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier] = $actualViewHelperClassName;
-		}
-		return static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier];
-	}
+    /**
+     * Resolves a ViewHelper class name by namespace alias and
+     * Fluid-format identity, e.g. "f" and "format.htmlspecialchars".
+     *
+     * Looks in all PHP namespaces which have been added for the
+     * provided alias, starting in the last added PHP namespace. If
+     * a ViewHelper class exists in multiple PHP namespaces Fluid
+     * will detect and use whichever one was added last.
+     *
+     * If no ViewHelper class can be detected in any of the added
+     * PHP namespaces a Fluid Parser Exception is thrown.
+     *
+     * @param string $namespaceIdentifier
+     * @param string $methodIdentifier
+     * @return string|NULL
+     * @throws ParserException
+     */
+    public function resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier)
+    {
+        if (!isset(static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier])) {
+            $resolvedViewHelperClassName = $this->resolveViewHelperName($namespaceIdentifier, $methodIdentifier);
+            $actualViewHelperClassName = implode('\\', array_map('ucfirst', explode('.', $resolvedViewHelperClassName)));
+            if (false === class_exists($actualViewHelperClassName) || $actualViewHelperClassName === false) {
+                throw new ParserException(sprintf(
+                    'The ViewHelper "<%s:%s>" could not be resolved.' . chr(10) .
+                    'Based on your spelling, the system would load the class "%s", however this class does not exist.',
+                    $namespaceIdentifier,
+                    $methodIdentifier,
+                    $resolvedViewHelperClassName
+                ), 1407060572);
+            }
+            static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier] = $actualViewHelperClassName;
+        }
+        return static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier];
+    }
 
-	/**
-	 * Can be overridden by custom implementations to change the way
-	 * classes are loaded when the class is a ViewHelper - for
-	 * example making it possible to use a DI-aware class loader.
-	 *
-	 * @param string $namespace
-	 * @param string $viewHelperShortName
-	 */
-	public function createViewHelperInstance($namespace, $viewHelperShortName) {
-		$className = $this->resolveViewHelperClassName($namespace, $viewHelperShortName);
-		return $this->createViewHelperInstanceFromClassName($className);
-	}
+    /**
+     * Can be overridden by custom implementations to change the way
+     * classes are loaded when the class is a ViewHelper - for
+     * example making it possible to use a DI-aware class loader.
+     *
+     * @param string $namespace
+     * @param string $viewHelperShortName
+     */
+    public function createViewHelperInstance($namespace, $viewHelperShortName)
+    {
+        $className = $this->resolveViewHelperClassName($namespace, $viewHelperShortName);
+        return $this->createViewHelperInstanceFromClassName($className);
+    }
 
-	/**
-	 * Wrapper to create a ViewHelper instance by class name. This is
-	 * the final method called when creating ViewHelper classes -
-	 * overriding this method allows custom constructors, dependency
-	 * injections etc. to be performed on the ViewHelper instance.
-	 *
-	 * @param string $viewHelperClassName
-	 * @return ViewHelperInterface
-	 */
-	public function createViewHelperInstanceFromClassName($viewHelperClassName) {
-		return new $viewHelperClassName();
-	}
+    /**
+     * Wrapper to create a ViewHelper instance by class name. This is
+     * the final method called when creating ViewHelper classes -
+     * overriding this method allows custom constructors, dependency
+     * injections etc. to be performed on the ViewHelper instance.
+     *
+     * @param string $viewHelperClassName
+     * @return ViewHelperInterface
+     */
+    public function createViewHelperInstanceFromClassName($viewHelperClassName)
+    {
+        return new $viewHelperClassName();
+    }
 
-	/**
-	 * Return an array of ArgumentDefinition instances which describe
-	 * the arguments that the ViewHelper supports. By default, the
-	 * arguments are simply fetched from the ViewHelper - but custom
-	 * implementations can if necessary add/remove/replace arguments
-	 * which will be passed to the ViewHelper.
-	 *
-	 * @param ViewHelperInterface $viewHelper
-	 * @return ArgumentDefinition[]
-	 */
-	public function getArgumentDefinitionsForViewHelper(ViewHelperInterface $viewHelper) {
-		return $viewHelper->prepareArguments();
-	}
+    /**
+     * Return an array of ArgumentDefinition instances which describe
+     * the arguments that the ViewHelper supports. By default, the
+     * arguments are simply fetched from the ViewHelper - but custom
+     * implementations can if necessary add/remove/replace arguments
+     * which will be passed to the ViewHelper.
+     *
+     * @param ViewHelperInterface $viewHelper
+     * @return ArgumentDefinition[]
+     */
+    public function getArgumentDefinitionsForViewHelper(ViewHelperInterface $viewHelper)
+    {
+        return $viewHelper->prepareArguments();
+    }
 
-	/**
-	 * Resolve a viewhelper name.
-	 *
-	 * @param string $namespaceIdentifier Namespace identifier for the view helper.
-	 * @param string $methodIdentifier Method identifier, might be hierarchical like "link.url"
-	 * @return string The fully qualified class name of the viewhelper
-	 */
-	protected function resolveViewHelperName($namespaceIdentifier, $methodIdentifier) {
-		$explodedViewHelperName = explode('.', $methodIdentifier);
-		if (count($explodedViewHelperName) > 1) {
-			$className = implode('\\', array_map('ucfirst', $explodedViewHelperName));
-		} else {
-			$className = ucfirst($explodedViewHelperName[0]);
-		}
-		$className .= 'ViewHelper';
+    /**
+     * Resolve a viewhelper name.
+     *
+     * @param string $namespaceIdentifier Namespace identifier for the view helper.
+     * @param string $methodIdentifier Method identifier, might be hierarchical like "link.url"
+     * @return string The fully qualified class name of the viewhelper
+     */
+    protected function resolveViewHelperName($namespaceIdentifier, $methodIdentifier)
+    {
+        $explodedViewHelperName = explode('.', $methodIdentifier);
+        if (count($explodedViewHelperName) > 1) {
+            $className = implode('\\', array_map('ucfirst', $explodedViewHelperName));
+        } else {
+            $className = ucfirst($explodedViewHelperName[0]);
+        }
+        $className .= 'ViewHelper';
 
-		$namespaces = (array) $this->namespaces[$namespaceIdentifier];
+        $namespaces = (array) $this->namespaces[$namespaceIdentifier];
 
-		do {
-			$name = rtrim(array_pop($namespaces), '\\') . '\\' . $className;
-		} while (!class_exists($name) && count($namespaces));
+        do {
+            $name = rtrim(array_pop($namespaces), '\\') . '\\' . $className;
+        } while (!class_exists($name) && count($namespaces));
 
-		return $name;
-	}
-
+        return $name;
+    }
 }

--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -13,121 +13,130 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
  *
  * @api
  */
-class ViewHelperVariableContainer {
+class ViewHelperVariableContainer
+{
 
-	/**
-	 * Two-dimensional object array storing the values. The first dimension is the fully qualified ViewHelper name,
-	 * and the second dimension is the identifier for the data the ViewHelper wants to store.
-	 *
-	 * @var array
-	 */
-	protected $objects = array();
+    /**
+     * Two-dimensional object array storing the values. The first dimension is the fully qualified ViewHelper name,
+     * and the second dimension is the identifier for the data the ViewHelper wants to store.
+     *
+     * @var array
+     */
+    protected $objects = [];
 
-	/**
-	 * @var ViewInterface
-	 */
-	protected $view;
+    /**
+     * @var ViewInterface
+     */
+    protected $view;
 
-	/**
-	 * Add a variable to the Variable Container. Make sure that $viewHelperName is ALWAYS set
-	 * to your fully qualified ViewHelper Class Name
-	 *
-	 * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-	 * @param string $key Key of the data
-	 * @param mixed $value The value to store
-	 * @return void
-	 * @api
-	 */
-	public function add($viewHelperName, $key, $value) {
-		$this->addOrUpdate($viewHelperName, $key, $value);
-	}
+    /**
+     * Add a variable to the Variable Container. Make sure that $viewHelperName is ALWAYS set
+     * to your fully qualified ViewHelper Class Name
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param string $key Key of the data
+     * @param mixed $value The value to store
+     * @return void
+     * @api
+     */
+    public function add($viewHelperName, $key, $value)
+    {
+        $this->addOrUpdate($viewHelperName, $key, $value);
+    }
 
-	/**
-	 * Add a variable to the Variable Container. Make sure that $viewHelperName is ALWAYS set
-	 * to your fully qualified ViewHelper Class Name.
-	 * In case the value is already inside, it is silently overridden.
-	 *
-	 * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-	 * @param string $key Key of the data
-	 * @param mixed $value The value to store
-	 * @return void
-	 */
-	public function addOrUpdate($viewHelperName, $key, $value) {
-		if (!isset($this->objects[$viewHelperName])) {
-			$this->objects[$viewHelperName] = array();
-		}
-		$this->objects[$viewHelperName][$key] = $value;
-	}
+    /**
+     * Add a variable to the Variable Container. Make sure that $viewHelperName is ALWAYS set
+     * to your fully qualified ViewHelper Class Name.
+     * In case the value is already inside, it is silently overridden.
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param string $key Key of the data
+     * @param mixed $value The value to store
+     * @return void
+     */
+    public function addOrUpdate($viewHelperName, $key, $value)
+    {
+        if (!isset($this->objects[$viewHelperName])) {
+            $this->objects[$viewHelperName] = [];
+        }
+        $this->objects[$viewHelperName][$key] = $value;
+    }
 
-	/**
-	 * Gets a variable which is stored
-	 *
-	 * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-	 * @param string $key Key of the data
-	 * @param mixed $default Default value to use if no value is found.
-	 * @return mixed The object stored
-	 * @api
-	 */
-	public function get($viewHelperName, $key, $default = NULL) {
-		if ($this->exists($viewHelperName, $key)) {
-			return $this->objects[$viewHelperName][$key];
-		}
-		return $default;
-	}
+    /**
+     * Gets a variable which is stored
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param string $key Key of the data
+     * @param mixed $default Default value to use if no value is found.
+     * @return mixed The object stored
+     * @api
+     */
+    public function get($viewHelperName, $key, $default = null)
+    {
+        if ($this->exists($viewHelperName, $key)) {
+            return $this->objects[$viewHelperName][$key];
+        }
+        return $default;
+    }
 
-	/**
-	 * Determine whether there is a variable stored for the given key
-	 *
-	 * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-	 * @param string $key Key of the data
-	 * @return boolean TRUE if a value for the given ViewHelperName / Key is stored, FALSE otherwise.
-	 * @api
-	 */
-	public function exists($viewHelperName, $key) {
-		return isset($this->objects[$viewHelperName]) && array_key_exists($key, $this->objects[$viewHelperName]);
-	}
+    /**
+     * Determine whether there is a variable stored for the given key
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param string $key Key of the data
+     * @return boolean TRUE if a value for the given ViewHelperName / Key is stored, FALSE otherwise.
+     * @api
+     */
+    public function exists($viewHelperName, $key)
+    {
+        return isset($this->objects[$viewHelperName]) && array_key_exists($key, $this->objects[$viewHelperName]);
+    }
 
-	/**
-	 * Remove a value from the variable container
-	 *
-	 * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-	 * @param string $key Key of the data to remove
-	 * @return void
-	 * @api
-	 */
-	public function remove($viewHelperName, $key) {
-		if ($this->exists($viewHelperName, $key)) {
-			unset($this->objects[$viewHelperName][$key]);
-		}
-	}
+    /**
+     * Remove a value from the variable container
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param string $key Key of the data to remove
+     * @return void
+     * @api
+     */
+    public function remove($viewHelperName, $key)
+    {
+        if ($this->exists($viewHelperName, $key)) {
+            unset($this->objects[$viewHelperName][$key]);
+        }
+    }
 
-	/**
-	 * Set the view to pass it to ViewHelpers.
-	 *
-	 * @param ViewInterface $view View to set
-	 * @return void
-	 */
-	public function setView(ViewInterface $view) {
-		$this->view = $view;
-	}
+    /**
+     * Set the view to pass it to ViewHelpers.
+     *
+     * @param ViewInterface $view View to set
+     * @return void
+     */
+    public function setView(ViewInterface $view)
+    {
+        $this->view = $view;
+    }
 
-	/**
-	 * Get the view.
-	 *
-	 * !!! This is NOT a public API and might still change!!!
-	 *
-	 * @return ViewInterface The View
-	 */
-	public function getView() {
-		return $this->view;
-	}
+    /**
+     * Get the view.
+     *
+     * !!! This is NOT a public API and might still change!!!
+     *
+     * @return ViewInterface The View
+     */
+    public function getView()
+    {
+        return $this->view;
+    }
 
-	/**
-	 * Clean up for serializing.
-	 *
-	 * @return array
-	 */
-	public function __sleep() {
-		return array('objects');
-	}
+    /**
+     * Clean up for serializing.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['objects'];
+    }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -11,5 +11,6 @@ namespace TYPO3Fluid\Fluid;
  *
  * @api
  */
-class Exception extends \RuntimeException {
+class Exception extends \RuntimeException
+{
 }

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -20,329 +20,346 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
  *
  * Contains the fundamental methods which any Fluid based template view needs.
  */
-abstract class AbstractTemplateView extends AbstractView {
+abstract class AbstractTemplateView extends AbstractView
+{
 
-	/**
-	 * Constants defining possible rendering types
-	 */
-	const RENDERING_TEMPLATE = 1;
-	const RENDERING_PARTIAL = 2;
-	const RENDERING_LAYOUT = 3;
+    /**
+     * Constants defining possible rendering types
+     */
+    const RENDERING_TEMPLATE = 1;
+    const RENDERING_PARTIAL = 2;
+    const RENDERING_LAYOUT = 3;
 
-	/**
-	 * The initial rendering context for this template view.
-	 * Due to the rendering stack, another rendering context might be active
-	 * at certain points while rendering the template.
-	 *
-	 * @var RenderingContextInterface
-	 */
-	protected $baseRenderingContext;
+    /**
+     * The initial rendering context for this template view.
+     * Due to the rendering stack, another rendering context might be active
+     * at certain points while rendering the template.
+     *
+     * @var RenderingContextInterface
+     */
+    protected $baseRenderingContext;
 
-	/**
-	 * Stack containing the current rendering type, the current rendering context, and the current parsed template
-	 * Do not manipulate directly, instead use the methods"getCurrent*()", "startRendering(...)" and "stopRendering()"
-	 *
-	 * @var array
-	 */
-	protected $renderingStack = array();
+    /**
+     * Stack containing the current rendering type, the current rendering context, and the current parsed template
+     * Do not manipulate directly, instead use the methods"getCurrent*()", "startRendering(...)" and "stopRendering()"
+     *
+     * @var array
+     */
+    protected $renderingStack = [];
 
-	/**
-	 * Partial Name -> Partial Identifier cache.
-	 * This is a performance optimization, effective when rendering a
-	 * single partial many times.
-	 *
-	 * @var array
-	 */
-	protected $partialIdentifierCache = array();
+    /**
+     * Partial Name -> Partial Identifier cache.
+     * This is a performance optimization, effective when rendering a
+     * single partial many times.
+     *
+     * @var array
+     */
+    protected $partialIdentifierCache = [];
 
-	/**
-	 * Constructor
-	 *
-	 * @param null|RenderingContextInterface $context
-	 */
-	public function __construct(RenderingContextInterface $context = NULL) {
-		if (!$context) {
-			$context = new RenderingContext($this);
-			$context->setControllerName('Default');
-			$context->setControllerAction('Default');
-		}
-		$this->setRenderingContext($context);
-	}
+    /**
+     * Constructor
+     *
+     * @param null|RenderingContextInterface $context
+     */
+    public function __construct(RenderingContextInterface $context = null)
+    {
+        if (!$context) {
+            $context = new RenderingContext($this);
+            $context->setControllerName('Default');
+            $context->setControllerAction('Default');
+        }
+        $this->setRenderingContext($context);
+    }
 
-	/**
-	 * Initialize the RenderingContext. This method can be overridden in your
-	 * View implementation to manipulate the rendering context *before* it is
-	 * passed during rendering.
-	 */
-	public function initializeRenderingContext() {
-		$this->baseRenderingContext->getViewHelperVariableContainer()->setView($this);
-	}
+    /**
+     * Initialize the RenderingContext. This method can be overridden in your
+     * View implementation to manipulate the rendering context *before* it is
+     * passed during rendering.
+     */
+    public function initializeRenderingContext()
+    {
+        $this->baseRenderingContext->getViewHelperVariableContainer()->setView($this);
+    }
 
-	/**
-	 * Sets the cache to use in RenderingContext.
-	 *
-	 * @param FluidCacheInterface $cache
-	 * @return void
-	 */
-	public function setCache(FluidCacheInterface $cache) {
-		$this->baseRenderingContext->setCache($cache);
-	}
+    /**
+     * Sets the cache to use in RenderingContext.
+     *
+     * @param FluidCacheInterface $cache
+     * @return void
+     */
+    public function setCache(FluidCacheInterface $cache)
+    {
+        $this->baseRenderingContext->setCache($cache);
+    }
 
-	/**
-	 * Gets the TemplatePaths instance from RenderingContext
-	 *
-	 * @return TemplatePaths
-	 */
-	public function getTemplatePaths() {
-		return $this->baseRenderingContext->getTemplatePaths();
-	}
+    /**
+     * Gets the TemplatePaths instance from RenderingContext
+     *
+     * @return TemplatePaths
+     */
+    public function getTemplatePaths()
+    {
+        return $this->baseRenderingContext->getTemplatePaths();
+    }
 
-	/**
-	 * Gets the ViewHelperResolver instance from RenderingContext
-	 *
-	 * @return ViewHelperResolver
-	 */
-	public function getViewHelperResolver() {
-		return $this->baseRenderingContext->getViewHelperResolver();
-	}
+    /**
+     * Gets the ViewHelperResolver instance from RenderingContext
+     *
+     * @return ViewHelperResolver
+     */
+    public function getViewHelperResolver()
+    {
+        return $this->baseRenderingContext->getViewHelperResolver();
+    }
 
-	/**
-	 * Gets the RenderingContext used by the View
-	 *
-	 * @return RenderingContextInterface
-	 */
-	public function getRenderingContext() {
-		return $this->baseRenderingContext;
-	}
+    /**
+     * Gets the RenderingContext used by the View
+     *
+     * @return RenderingContextInterface
+     */
+    public function getRenderingContext()
+    {
+        return $this->baseRenderingContext;
+    }
 
-	/**
-	 * Injects a fresh rendering context
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @return void
-	 */
-	public function setRenderingContext(RenderingContextInterface $renderingContext) {
-		$this->baseRenderingContext = $renderingContext;
-		$this->initializeRenderingContext();
-	}
+    /**
+     * Injects a fresh rendering context
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        $this->baseRenderingContext = $renderingContext;
+        $this->initializeRenderingContext();
+    }
 
-	/**
-	 * Assign a value to the variable container.
-	 *
-	 * @param string $key The key of a view variable to set
-	 * @param mixed $value The value of the view variable
-	 * @return $this
-	 * @api
-	 */
-	public function assign($key, $value) {
-		$this->baseRenderingContext->getVariableProvider()->add($key, $value);
-		return $this;
-	}
+    /**
+     * Assign a value to the variable container.
+     *
+     * @param string $key The key of a view variable to set
+     * @param mixed $value The value of the view variable
+     * @return $this
+     * @api
+     */
+    public function assign($key, $value)
+    {
+        $this->baseRenderingContext->getVariableProvider()->add($key, $value);
+        return $this;
+    }
 
-	/**
-	 * Assigns multiple values to the JSON output.
-	 * However, only the key "value" is accepted.
-	 *
-	 * @param array $values Keys and values - only a value with key "value" is considered
-	 * @return $this
-	 * @api
-	 */
-	public function assignMultiple(array $values) {
-		$templateVariableContainer = $this->baseRenderingContext->getVariableProvider();
-		foreach ($values as $key => $value) {
-			$templateVariableContainer->add($key, $value);
-		}
-		return $this;
-	}
+    /**
+     * Assigns multiple values to the JSON output.
+     * However, only the key "value" is accepted.
+     *
+     * @param array $values Keys and values - only a value with key "value" is considered
+     * @return $this
+     * @api
+     */
+    public function assignMultiple(array $values)
+    {
+        $templateVariableContainer = $this->baseRenderingContext->getVariableProvider();
+        foreach ($values as $key => $value) {
+            $templateVariableContainer->add($key, $value);
+        }
+        return $this;
+    }
 
-	/**
-	 * Loads the template source and render the template.
-	 * If "layoutName" is set in a PostParseFacet callback, it will render the file with the given layout.
-	 *
-	 * @param string|null $actionName If set, this action's template will be rendered instead of the one defined in the context.
-	 * @return string Rendered Template
-	 * @api
-	 */
-	public function render($actionName = NULL) {
-		$controllerName = $this->baseRenderingContext->getControllerName();
-		$templateParser = $this->baseRenderingContext->getTemplateParser();
-		$templatePaths = $this->baseRenderingContext->getTemplatePaths();
-		if ($actionName === NULL) {
-			$actionName = $this->baseRenderingContext->getControllerAction();
-		}
-		$actionName = ucfirst($actionName);
-		$templateIdentifier = $templatePaths->getTemplateIdentifier($controllerName, $actionName);
-		$parsedTemplate = $templateParser->getOrParseAndStoreTemplate(
-			$templateIdentifier,
-			function($parent, TemplatePaths $paths) use ($controllerName, $actionName) {
-				return $paths->getTemplateSource($controllerName, $actionName);
-			}
-		);
-		$parsedTemplate->addCompiledNamespaces($this->baseRenderingContext);
+    /**
+     * Loads the template source and render the template.
+     * If "layoutName" is set in a PostParseFacet callback, it will render the file with the given layout.
+     *
+     * @param string|null $actionName If set, this action's template will be rendered instead of the one defined in the context.
+     * @return string Rendered Template
+     * @api
+     */
+    public function render($actionName = null)
+    {
+        $controllerName = $this->baseRenderingContext->getControllerName();
+        $templateParser = $this->baseRenderingContext->getTemplateParser();
+        $templatePaths = $this->baseRenderingContext->getTemplatePaths();
+        if ($actionName === null) {
+            $actionName = $this->baseRenderingContext->getControllerAction();
+        }
+        $actionName = ucfirst($actionName);
+        $templateIdentifier = $templatePaths->getTemplateIdentifier($controllerName, $actionName);
+        $parsedTemplate = $templateParser->getOrParseAndStoreTemplate(
+            $templateIdentifier,
+            function ($parent, TemplatePaths $paths) use ($controllerName, $actionName) {
+                return $paths->getTemplateSource($controllerName, $actionName);
+            }
+        );
+        $parsedTemplate->addCompiledNamespaces($this->baseRenderingContext);
 
-		if (!$parsedTemplate->hasLayout()) {
-			$this->startRendering(self::RENDERING_TEMPLATE, $parsedTemplate, $this->baseRenderingContext);
-			$output = $parsedTemplate->render($this->baseRenderingContext);
-			$this->stopRendering();
-		} else {
-			$layoutName = $parsedTemplate->getLayoutName($this->baseRenderingContext);
-			$layoutIdentifier = $templatePaths->getLayoutIdentifier($layoutName);
-			$parsedLayout = $templateParser->getOrParseAndStoreTemplate(
-				$layoutIdentifier,
-				function($parent, TemplatePaths $paths) use ($layoutName) {
-					return $paths->getLayoutSource($layoutName);
-				}
-			);
-			$this->startRendering(self::RENDERING_LAYOUT, $parsedTemplate, $this->baseRenderingContext);
-			$output = $parsedLayout->render($this->baseRenderingContext);
-			$this->stopRendering();
-		}
+        if (!$parsedTemplate->hasLayout()) {
+            $this->startRendering(self::RENDERING_TEMPLATE, $parsedTemplate, $this->baseRenderingContext);
+            $output = $parsedTemplate->render($this->baseRenderingContext);
+            $this->stopRendering();
+        } else {
+            $layoutName = $parsedTemplate->getLayoutName($this->baseRenderingContext);
+            $layoutIdentifier = $templatePaths->getLayoutIdentifier($layoutName);
+            $parsedLayout = $templateParser->getOrParseAndStoreTemplate(
+                $layoutIdentifier,
+                function ($parent, TemplatePaths $paths) use ($layoutName) {
+                    return $paths->getLayoutSource($layoutName);
+                }
+            );
+            $this->startRendering(self::RENDERING_LAYOUT, $parsedTemplate, $this->baseRenderingContext);
+            $output = $parsedLayout->render($this->baseRenderingContext);
+            $this->stopRendering();
+        }
 
-		return $output;
-	}
+        return $output;
+    }
 
-	/**
-	 * Renders a given section.
-	 *
-	 * @param string $sectionName Name of section to render
-	 * @param array $variables The variables to use
-	 * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
-	 * @return string rendered template for the section
-	 * @throws InvalidSectionException
-	 */
-	public function renderSection($sectionName, array $variables = array(), $ignoreUnknown = FALSE) {
-		$renderingContext = $this->getCurrentRenderingContext();
+    /**
+     * Renders a given section.
+     *
+     * @param string $sectionName Name of section to render
+     * @param array $variables The variables to use
+     * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
+     * @return string rendered template for the section
+     * @throws InvalidSectionException
+     */
+    public function renderSection($sectionName, array $variables = [], $ignoreUnknown = false)
+    {
+        $renderingContext = $this->getCurrentRenderingContext();
 
-		if ($this->getCurrentRenderingType() === self::RENDERING_LAYOUT) {
-			// in case we render a layout right now, we will render a section inside a TEMPLATE.
-			$renderingTypeOnNextLevel = self::RENDERING_TEMPLATE;
-		} else {
-			$renderingContext = clone $renderingContext;
-			$renderingContext->setVariableProvider($renderingContext->getVariableProvider()->getScopeCopy($variables));
-			$renderingTypeOnNextLevel = $this->getCurrentRenderingType();
-		}
+        if ($this->getCurrentRenderingType() === self::RENDERING_LAYOUT) {
+            // in case we render a layout right now, we will render a section inside a TEMPLATE.
+            $renderingTypeOnNextLevel = self::RENDERING_TEMPLATE;
+        } else {
+            $renderingContext = clone $renderingContext;
+            $renderingContext->setVariableProvider($renderingContext->getVariableProvider()->getScopeCopy($variables));
+            $renderingTypeOnNextLevel = $this->getCurrentRenderingType();
+        }
 
-		$parsedTemplate = $this->getCurrentParsedTemplate();
+        $parsedTemplate = $this->getCurrentParsedTemplate();
 
-		if ($parsedTemplate->isCompiled()) {
-			$methodNameOfSection = 'section_' . sha1($sectionName);
-			if (!method_exists($parsedTemplate, $methodNameOfSection)) {
-				if ($ignoreUnknown) {
-					return '';
-				} else {
-					throw new InvalidSectionException('Section "' . $sectionName . '" does not exist.');
-				}
-			}
-			$this->startRendering($renderingTypeOnNextLevel, $parsedTemplate, $renderingContext);
-			$output = $parsedTemplate->$methodNameOfSection($renderingContext);
-			$this->stopRendering();
-		} else {
-			$sections = $parsedTemplate->getVariableContainer()->get('1457379500_sections');
-			if (!isset($sections[$sectionName])) {
-				if ($ignoreUnknown) {
-					return '';
-				}
-				throw new InvalidSectionException('Section "' . $sectionName . '" does not exist.');
-			}
-			/** @var $section ViewHelperNode */
-			$section = $sections[$sectionName];
+        if ($parsedTemplate->isCompiled()) {
+            $methodNameOfSection = 'section_' . sha1($sectionName);
+            if (!method_exists($parsedTemplate, $methodNameOfSection)) {
+                if ($ignoreUnknown) {
+                    return '';
+                } else {
+                    throw new InvalidSectionException('Section "' . $sectionName . '" does not exist.');
+                }
+            }
+            $this->startRendering($renderingTypeOnNextLevel, $parsedTemplate, $renderingContext);
+            $output = $parsedTemplate->$methodNameOfSection($renderingContext);
+            $this->stopRendering();
+        } else {
+            $sections = $parsedTemplate->getVariableContainer()->get('1457379500_sections');
+            if (!isset($sections[$sectionName])) {
+                if ($ignoreUnknown) {
+                    return '';
+                }
+                throw new InvalidSectionException('Section "' . $sectionName . '" does not exist.');
+            }
+            /** @var $section ViewHelperNode */
+            $section = $sections[$sectionName];
 
-			$renderingContext->getViewHelperVariableContainer()->add(
-				SectionViewHelper::class,
-				'isCurrentlyRenderingSection',
-				TRUE
-			);
+            $renderingContext->getViewHelperVariableContainer()->add(
+                SectionViewHelper::class,
+                'isCurrentlyRenderingSection',
+                true
+            );
 
-			$this->startRendering($renderingTypeOnNextLevel, $parsedTemplate, $renderingContext);
-			$output = $section->evaluate($renderingContext);
-			$this->stopRendering();
-		}
+            $this->startRendering($renderingTypeOnNextLevel, $parsedTemplate, $renderingContext);
+            $output = $section->evaluate($renderingContext);
+            $this->stopRendering();
+        }
 
-		return $output;
-	}
+        return $output;
+    }
 
-	/**
-	 * Renders a partial.
-	 *
-	 * @param string $partialName
-	 * @param string $sectionName
-	 * @param array $variables
-	 * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
-	 * @return string
-	 */
-	public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = FALSE) {
-		if (!isset($this->partialIdentifierCache[$partialName])) {
-			$this->partialIdentifierCache[$partialName] = $this->baseRenderingContext->getTemplatePaths()->getPartialIdentifier($partialName);
-		}
-		$partialIdentifier = $this->partialIdentifierCache[$partialName];
-		$parsedPartial = $this->baseRenderingContext->getTemplateParser()->getOrParseAndStoreTemplate(
-			$partialIdentifier,
-			function($parent, TemplatePaths $paths) use ($partialName) {
-				return $paths->getPartialSource($partialName);
-			}
-		);
-		$renderingContext = clone $this->getCurrentRenderingContext();
-		$renderingContext->setVariableProvider($renderingContext->getVariableProvider()->getScopeCopy($variables));
-		$this->startRendering(self::RENDERING_PARTIAL, $parsedPartial, $renderingContext);
-		if ($sectionName !== NULL) {
-			$output = $this->renderSection($sectionName, $variables, $ignoreUnknown);
-		} else {
-			$output = $parsedPartial->render($renderingContext);
-		}
-		$this->stopRendering();
-		return $output;
-	}
+    /**
+     * Renders a partial.
+     *
+     * @param string $partialName
+     * @param string $sectionName
+     * @param array $variables
+     * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
+     * @return string
+     */
+    public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = false)
+    {
+        if (!isset($this->partialIdentifierCache[$partialName])) {
+            $this->partialIdentifierCache[$partialName] = $this->baseRenderingContext->getTemplatePaths()->getPartialIdentifier($partialName);
+        }
+        $partialIdentifier = $this->partialIdentifierCache[$partialName];
+        $parsedPartial = $this->baseRenderingContext->getTemplateParser()->getOrParseAndStoreTemplate(
+            $partialIdentifier,
+            function ($parent, TemplatePaths $paths) use ($partialName) {
+                return $paths->getPartialSource($partialName);
+            }
+        );
+        $renderingContext = clone $this->getCurrentRenderingContext();
+        $renderingContext->setVariableProvider($renderingContext->getVariableProvider()->getScopeCopy($variables));
+        $this->startRendering(self::RENDERING_PARTIAL, $parsedPartial, $renderingContext);
+        if ($sectionName !== null) {
+            $output = $this->renderSection($sectionName, $variables, $ignoreUnknown);
+        } else {
+            $output = $parsedPartial->render($renderingContext);
+        }
+        $this->stopRendering();
+        return $output;
+    }
 
-	/**
-	 * Start a new nested rendering. Pushes the given information onto the $renderingStack.
-	 *
-	 * @param integer $type one of the RENDERING_* constants
-	 * @param ParsedTemplateInterface $template
-	 * @param RenderingContextInterface $context
-	 * @return void
-	 */
-	protected function startRendering($type, ParsedTemplateInterface $template, RenderingContextInterface $context) {
-		array_push($this->renderingStack, array('type' => $type, 'parsedTemplate' => $template, 'renderingContext' => $context));
-	}
+    /**
+     * Start a new nested rendering. Pushes the given information onto the $renderingStack.
+     *
+     * @param integer $type one of the RENDERING_* constants
+     * @param ParsedTemplateInterface $template
+     * @param RenderingContextInterface $context
+     * @return void
+     */
+    protected function startRendering($type, ParsedTemplateInterface $template, RenderingContextInterface $context)
+    {
+        array_push($this->renderingStack, ['type' => $type, 'parsedTemplate' => $template, 'renderingContext' => $context]);
+    }
 
-	/**
-	 * Stops the current rendering. Removes one element from the $renderingStack. Make sure to always call this
-	 * method pair-wise with startRendering().
-	 *
-	 * @return void
-	 */
-	protected function stopRendering() {
-		array_pop($this->renderingStack);
-	}
+    /**
+     * Stops the current rendering. Removes one element from the $renderingStack. Make sure to always call this
+     * method pair-wise with startRendering().
+     *
+     * @return void
+     */
+    protected function stopRendering()
+    {
+        array_pop($this->renderingStack);
+    }
 
-	/**
-	 * Get the current rendering type.
-	 *
-	 * @return integer one of RENDERING_* constants
-	 */
-	protected function getCurrentRenderingType() {
-		$currentRendering = end($this->renderingStack);
-		return $currentRendering['type'] ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
-	}
+    /**
+     * Get the current rendering type.
+     *
+     * @return integer one of RENDERING_* constants
+     */
+    protected function getCurrentRenderingType()
+    {
+        $currentRendering = end($this->renderingStack);
+        return $currentRendering['type'] ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
+    }
 
-	/**
-	 * Get the parsed template which is currently being rendered or compiled.
-	 *
-	 * @return ParsedTemplateInterface
-	 */
-	protected function getCurrentParsedTemplate() {
-		$currentRendering = end($this->renderingStack);
-		return $currentRendering['parsedTemplate'] ? $currentRendering['parsedTemplate'] : $this->getCurrentRenderingContext()->getTemplateCompiler()->getCurrentlyProcessingState();
-	}
+    /**
+     * Get the parsed template which is currently being rendered or compiled.
+     *
+     * @return ParsedTemplateInterface
+     */
+    protected function getCurrentParsedTemplate()
+    {
+        $currentRendering = end($this->renderingStack);
+        return $currentRendering['parsedTemplate'] ? $currentRendering['parsedTemplate'] : $this->getCurrentRenderingContext()->getTemplateCompiler()->getCurrentlyProcessingState();
+    }
 
-	/**
-	 * Get the rendering context which is currently used.
-	 *
-	 * @return RenderingContextInterface
-	 */
-	protected function getCurrentRenderingContext() {
-		$currentRendering = end($this->renderingStack);
-		return $currentRendering['renderingContext'] ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
-	}
-
+    /**
+     * Get the rendering context which is currently used.
+     *
+     * @return RenderingContextInterface
+     */
+    protected function getCurrentRenderingContext()
+    {
+        $currentRendering = end($this->renderingStack);
+        return $currentRendering['renderingContext'] ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
+    }
 }

--- a/src/View/AbstractView.php
+++ b/src/View/AbstractView.php
@@ -11,51 +11,54 @@ namespace TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-abstract class AbstractView implements ViewInterface {
+abstract class AbstractView implements ViewInterface
+{
 
-	/**
-	 * View variables and their values
-	 * @var array
-	 * @see assign()
-	 */
-	protected $variables = array();
+    /**
+     * View variables and their values
+     * @var array
+     * @see assign()
+     */
+    protected $variables = [];
 
-	/**
-	 * Renders the view
-	 *
-	 * @return string The rendered view
-	 * @api
-	 */
-	public function render() {
-		return '';
-	}
+    /**
+     * Renders the view
+     *
+     * @return string The rendered view
+     * @api
+     */
+    public function render()
+    {
+        return '';
+    }
 
-	/**
-	 * Add a variable to $this->variables.
-	 * Can be chained, so $this->view->assign(..., ...)->assign(..., ...); is possible
-	 *
-	 * @param string $key Key of variable
-	 * @param mixed $value Value of object
-	 * @return $this
-	 * @api
-	 */
-	public function assign($key, $value) {
-		$this->variables[$key] = $value;
-		return $this;
-	}
+    /**
+     * Add a variable to $this->variables.
+     * Can be chained, so $this->view->assign(..., ...)->assign(..., ...); is possible
+     *
+     * @param string $key Key of variable
+     * @param mixed $value Value of object
+     * @return $this
+     * @api
+     */
+    public function assign($key, $value)
+    {
+        $this->variables[$key] = $value;
+        return $this;
+    }
 
-	/**
-	 * Add multiple variables to $this->variables.
-	 *
-	 * @param array $values array in the format array(key1 => value1, key2 => value2)
-	 * @return AbstractView an instance of $this, to enable chaining
-	 * @api
-	 */
-	public function assignMultiple(array $values) {
-		foreach ($values as $key => $value) {
-			$this->assign($key, $value);
-		}
-		return $this;
-	}
-
+    /**
+     * Add multiple variables to $this->variables.
+     *
+     * @param array $values array in the format array(key1 => value1, key2 => value2)
+     * @return AbstractView an instance of $this, to enable chaining
+     * @api
+     */
+    public function assignMultiple(array $values)
+    {
+        foreach ($values as $key => $value) {
+            $this->assign($key, $value);
+        }
+        return $this;
+    }
 }

--- a/src/View/Exception.php
+++ b/src/View/Exception.php
@@ -13,5 +13,6 @@ use TYPO3Fluid\Fluid;
  *
  * @api
  */
-class Exception extends Fluid\Exception {
+class Exception extends Fluid\Exception
+{
 }

--- a/src/View/Exception/InvalidSectionException.php
+++ b/src/View/Exception/InvalidSectionException.php
@@ -13,5 +13,6 @@ use TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class InvalidSectionException extends View\Exception {
+class InvalidSectionException extends View\Exception
+{
 }

--- a/src/View/Exception/InvalidTemplateResourceException.php
+++ b/src/View/Exception/InvalidTemplateResourceException.php
@@ -13,5 +13,6 @@ use TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class InvalidTemplateResourceException extends View\Exception {
+class InvalidTemplateResourceException extends View\Exception
+{
 }

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -35,664 +35,704 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
  * is created, but both will overwrite any paths
  * you have previously configured.
  */
-class TemplatePaths {
+class TemplatePaths
+{
 
-	const DEFAULT_FORMAT = 'html';
-	const DEFAULT_TEMPLATES_DIRECTORY = 'Resources/Private/Templates/';
-	const DEFAULT_LAYOUTS_DIRECTORY = 'Resources/Private/Layouts/';
-	const DEFAULT_PARTIALS_DIRECTORY = 'Resources/Private/Partials/';
-	const CONFIG_TEMPLATEROOTPATHS = 'templateRootPaths';
-	const CONFIG_LAYOUTROOTPATHS = 'layoutRootPaths';
-	const CONFIG_PARTIALROOTPATHS = 'partialRootPaths';
-	const CONFIG_FORMAT = 'format';
-	const NAME_TEMPLATES = 'templates';
-	const NAME_LAYOUTS = 'layouts';
-	const NAME_PARTIALS = 'partials';
+    const DEFAULT_FORMAT = 'html';
+    const DEFAULT_TEMPLATES_DIRECTORY = 'Resources/Private/Templates/';
+    const DEFAULT_LAYOUTS_DIRECTORY = 'Resources/Private/Layouts/';
+    const DEFAULT_PARTIALS_DIRECTORY = 'Resources/Private/Partials/';
+    const CONFIG_TEMPLATEROOTPATHS = 'templateRootPaths';
+    const CONFIG_LAYOUTROOTPATHS = 'layoutRootPaths';
+    const CONFIG_PARTIALROOTPATHS = 'partialRootPaths';
+    const CONFIG_FORMAT = 'format';
+    const NAME_TEMPLATES = 'templates';
+    const NAME_LAYOUTS = 'layouts';
+    const NAME_PARTIALS = 'partials';
 
-	/**
-	 * Holds already resolved identifiers for template files
-	 *
-	 * @var array
-	 */
-	protected static $resolvedIdentifiers = array(
-		self::NAME_TEMPLATES => array(),
-		self::NAME_LAYOUTS => array(),
-		self::NAME_PARTIALS => array()
-	);
+    /**
+     * Holds already resolved identifiers for template files
+     *
+     * @var array
+     */
+    protected static $resolvedIdentifiers = [
+        self::NAME_TEMPLATES => [],
+        self::NAME_LAYOUTS => [],
+        self::NAME_PARTIALS => []
+    ];
 
-	/**
-	 * Holds already resolved identifiers for template files
-	 *
-	 * @var array
-	 */
-	protected static $resolvedFiles = array(
-		self::NAME_TEMPLATES => array(),
-		self::NAME_LAYOUTS => array(),
-		self::NAME_PARTIALS => array()
-	);
+    /**
+     * Holds already resolved identifiers for template files
+     *
+     * @var array
+     */
+    protected static $resolvedFiles = [
+        self::NAME_TEMPLATES => [],
+        self::NAME_LAYOUTS => [],
+        self::NAME_PARTIALS => []
+    ];
 
-	/**
-	 * @var array
-	 */
-	protected $templateRootPaths = array();
+    /**
+     * @var array
+     */
+    protected $templateRootPaths = [];
 
-	/**
-	 * @var array
-	 */
-	protected $layoutRootPaths = array();
+    /**
+     * @var array
+     */
+    protected $layoutRootPaths = [];
 
-	/**
-	 * @var array
-	 */
-	protected $partialRootPaths = array();
+    /**
+     * @var array
+     */
+    protected $partialRootPaths = [];
 
-	/**
-	 * @var string
-	 */
-	protected $templatePathAndFilename = NULL;
+    /**
+     * @var string
+     */
+    protected $templatePathAndFilename = null;
 
-	/**
-	 * @var string
-	 */
-	protected $layoutPathAndFilename = NULL;
+    /**
+     * @var string
+     */
+    protected $layoutPathAndFilename = null;
 
-	/**
-	 * @var string|NULL
-	 */
-	protected $templateSource = NULL;
+    /**
+     * @var string|NULL
+     */
+    protected $templateSource = null;
 
-	/**
-	 * @var string
-	 */
-	protected $format = self::DEFAULT_FORMAT;
+    /**
+     * @var string
+     */
+    protected $format = self::DEFAULT_FORMAT;
 
-	/**
-	 * @param string|NULL $packageNameOrArray
-	 */
-	public function __construct($packageNameOrArray = NULL) {
-		$this->clearResolvedIdentifiersAndTemplates();
-		if (is_array($packageNameOrArray)) {
-			$this->fillFromConfigurationArray($packageNameOrArray);
-		} elseif (!empty($packageNameOrArray)) {
-			$this->fillDefaultsByPackageName($packageNameOrArray);
-		}
-	}
+    /**
+     * @param string|NULL $packageNameOrArray
+     */
+    public function __construct($packageNameOrArray = null)
+    {
+        $this->clearResolvedIdentifiersAndTemplates();
+        if (is_array($packageNameOrArray)) {
+            $this->fillFromConfigurationArray($packageNameOrArray);
+        } elseif (!empty($packageNameOrArray)) {
+            $this->fillDefaultsByPackageName($packageNameOrArray);
+        }
+    }
 
-	/**
-	 * @return array
-	 */
-	public function toArray() {
-		return array(
-			self::CONFIG_TEMPLATEROOTPATHS => $this->sanitizePaths($this->getTemplateRootPaths()),
-			self::CONFIG_LAYOUTROOTPATHS => $this->sanitizePaths($this->getLayoutRootPaths()),
-			self::CONFIG_PARTIALROOTPATHS => $this->sanitizePaths($this->getPartialRootPaths())
-		);
-	}
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            self::CONFIG_TEMPLATEROOTPATHS => $this->sanitizePaths($this->getTemplateRootPaths()),
+            self::CONFIG_LAYOUTROOTPATHS => $this->sanitizePaths($this->getLayoutRootPaths()),
+            self::CONFIG_PARTIALROOTPATHS => $this->sanitizePaths($this->getPartialRootPaths())
+        ];
+    }
 
-	/**
-	 * @param string $templatePathAndFilename
-	 * @return void
-	 */
-	public function setTemplatePathAndFilename($templatePathAndFilename) {
-		$this->templatePathAndFilename = $this->sanitizePath($templatePathAndFilename);
-	}
+    /**
+     * @param string $templatePathAndFilename
+     * @return void
+     */
+    public function setTemplatePathAndFilename($templatePathAndFilename)
+    {
+        $this->templatePathAndFilename = $this->sanitizePath($templatePathAndFilename);
+    }
 
-	/**
-	 * @param string $layoutPathAndFilename
-	 * @return void
-	 */
-	public function setLayoutPathAndFilename($layoutPathAndFilename) {
-		$this->layoutPathAndFilename = $layoutPathAndFilename;
-	}
+    /**
+     * @param string $layoutPathAndFilename
+     * @return void
+     */
+    public function setLayoutPathAndFilename($layoutPathAndFilename)
+    {
+        $this->layoutPathAndFilename = $layoutPathAndFilename;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateRootPaths() {
-		return $this->templateRootPaths;
-	}
+    /**
+     * @return array
+     */
+    public function getTemplateRootPaths()
+    {
+        return $this->templateRootPaths;
+    }
 
-	/**
-	 * @param array $templateRootPaths
-	 * @return void
-	 */
-	public function setTemplateRootPaths(array $templateRootPaths) {
-		$this->templateRootPaths = $this->sanitizePaths($templateRootPaths);
-		$this->clearResolvedIdentifiersAndTemplates(self::NAME_TEMPLATES);
-	}
+    /**
+     * @param array $templateRootPaths
+     * @return void
+     */
+    public function setTemplateRootPaths(array $templateRootPaths)
+    {
+        $this->templateRootPaths = $this->sanitizePaths($templateRootPaths);
+        $this->clearResolvedIdentifiersAndTemplates(self::NAME_TEMPLATES);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getLayoutRootPaths() {
-		return $this->layoutRootPaths;
-	}
+    /**
+     * @return array
+     */
+    public function getLayoutRootPaths()
+    {
+        return $this->layoutRootPaths;
+    }
 
-	/**
-	 * @param array $layoutRootPaths
-	 * @return void
-	 */
-	public function setLayoutRootPaths(array $layoutRootPaths) {
-		$this->layoutRootPaths = $this->sanitizePaths($layoutRootPaths);
-		$this->clearResolvedIdentifiersAndTemplates(self::NAME_LAYOUTS);
-	}
+    /**
+     * @param array $layoutRootPaths
+     * @return void
+     */
+    public function setLayoutRootPaths(array $layoutRootPaths)
+    {
+        $this->layoutRootPaths = $this->sanitizePaths($layoutRootPaths);
+        $this->clearResolvedIdentifiersAndTemplates(self::NAME_LAYOUTS);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getPartialRootPaths() {
-		return $this->partialRootPaths;
-	}
+    /**
+     * @return array
+     */
+    public function getPartialRootPaths()
+    {
+        return $this->partialRootPaths;
+    }
 
-	/**
-	 * @param array $partialRootPaths
-	 * @return void
-	 */
-	public function setPartialRootPaths(array $partialRootPaths) {
-		$this->partialRootPaths = $this->sanitizePaths($partialRootPaths);
-		$this->clearResolvedIdentifiersAndTemplates(self::NAME_PARTIALS);
-	}
+    /**
+     * @param array $partialRootPaths
+     * @return void
+     */
+    public function setPartialRootPaths(array $partialRootPaths)
+    {
+        $this->partialRootPaths = $this->sanitizePaths($partialRootPaths);
+        $this->clearResolvedIdentifiersAndTemplates(self::NAME_PARTIALS);
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getFormat() {
-		return $this->format;
-	}
+    /**
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
 
-	/**
-	 * @param string $format
-	 * @return void
-	 */
-	public function setFormat($format) {
-		$this->format = $format;
-	}
+    /**
+     * @param string $format
+     * @return void
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+    }
 
-	/**
-	 * Attempts to resolve an absolute filename
-	 * of a template (i.e. `templateRootPaths`)
-	 * using a controller name, action and format.
-	 *
-	 * Works _backwards_ through template paths in
-	 * order to achieve an "overlay"-type behavior
-	 * where the last paths added are the first to
-	 * be checked and the first path added acts as
-	 * fallback if no other paths have the file.
-	 *
-	 * If the file does not exist in any path,
-	 * including fallback path, `NULL` is returned.
-	 *
-	 * Path configurations filled from TypoScript
-	 * is automatically recorded in the right
-	 * order (see `fillFromTypoScriptArray`), but
-	 * when manually setting the paths that should
-	 * be checked, you as user must be aware of
-	 * this reverse behavior (which you should
-	 * already be, given that it is the same way
-	 * TypoScript path configurations work).
-	 *
-	 * @param string $controller
-	 * @param string $action
-	 * @param string $format
-	 * @return string|NULL
-	 * @api
-	 */
-	public function resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format = self::DEFAULT_FORMAT) {
-		if ($this->templatePathAndFilename !== NULL) {
-			return $this->templatePathAndFilename;
-		}
-		$controller = str_replace('\\', '/', $controller);
-		$action = ucfirst($action);
-		$identifier = $controller . '/' . $action . '.' . $format;
-		if (!array_key_exists($identifier, self::$resolvedFiles['templates'])) {
-			$templateRootPaths = $this->getTemplateRootPaths();
-			foreach ([$controller . '/' . $action, $action] as $possibleRelativePath) {
-				try {
-					return self::$resolvedFiles['templates'][$identifier] = $this->resolveFileInPaths($templateRootPaths, $possibleRelativePath, $format);
-				} catch (InvalidTemplateResourceException $error) {
-					self::$resolvedFiles['templates'][$identifier] = NULL;
-				}
-			}
-		}
-		return isset(self::$resolvedFiles[self::NAME_TEMPLATES][$identifier]) ? self::$resolvedFiles[self::NAME_TEMPLATES][$identifier] : NULL;
-	}
+    /**
+     * Attempts to resolve an absolute filename
+     * of a template (i.e. `templateRootPaths`)
+     * using a controller name, action and format.
+     *
+     * Works _backwards_ through template paths in
+     * order to achieve an "overlay"-type behavior
+     * where the last paths added are the first to
+     * be checked and the first path added acts as
+     * fallback if no other paths have the file.
+     *
+     * If the file does not exist in any path,
+     * including fallback path, `NULL` is returned.
+     *
+     * Path configurations filled from TypoScript
+     * is automatically recorded in the right
+     * order (see `fillFromTypoScriptArray`), but
+     * when manually setting the paths that should
+     * be checked, you as user must be aware of
+     * this reverse behavior (which you should
+     * already be, given that it is the same way
+     * TypoScript path configurations work).
+     *
+     * @param string $controller
+     * @param string $action
+     * @param string $format
+     * @return string|NULL
+     * @api
+     */
+    public function resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format = self::DEFAULT_FORMAT)
+    {
+        if ($this->templatePathAndFilename !== null) {
+            return $this->templatePathAndFilename;
+        }
+        $controller = str_replace('\\', '/', $controller);
+        $action = ucfirst($action);
+        $identifier = $controller . '/' . $action . '.' . $format;
+        if (!array_key_exists($identifier, self::$resolvedFiles['templates'])) {
+            $templateRootPaths = $this->getTemplateRootPaths();
+            foreach ([$controller . '/' . $action, $action] as $possibleRelativePath) {
+                try {
+                    return self::$resolvedFiles['templates'][$identifier] = $this->resolveFileInPaths($templateRootPaths, $possibleRelativePath, $format);
+                } catch (InvalidTemplateResourceException $error) {
+                    self::$resolvedFiles['templates'][$identifier] = null;
+                }
+            }
+        }
+        return isset(self::$resolvedFiles[self::NAME_TEMPLATES][$identifier]) ? self::$resolvedFiles[self::NAME_TEMPLATES][$identifier] : null;
+    }
 
-	/**
-	 * @param string|NULL $controllerName
-	 * @param string $format
-	 * @return array
-	 */
-	public function resolveAvailableTemplateFiles($controllerName, $format = self::DEFAULT_FORMAT) {
-		$paths = $this->getTemplateRootPaths();
-		foreach ($paths as $index => $path) {
-			$paths[$index] = rtrim($path . $controllerName, '/') . '/';
-		}
-		return $this->resolveFilesInFolders($paths, $format);
-	}
+    /**
+     * @param string|NULL $controllerName
+     * @param string $format
+     * @return array
+     */
+    public function resolveAvailableTemplateFiles($controllerName, $format = self::DEFAULT_FORMAT)
+    {
+        $paths = $this->getTemplateRootPaths();
+        foreach ($paths as $index => $path) {
+            $paths[$index] = rtrim($path . $controllerName, '/') . '/';
+        }
+        return $this->resolveFilesInFolders($paths, $format);
+    }
 
-	/**
-	 * @param string $format
-	 * @return array
-	 */
-	public function resolveAvailablePartialFiles($format = self::DEFAULT_FORMAT) {
-		return $this->resolveFilesInFolders($this->getPartialRootPaths(), $format);
-	}
+    /**
+     * @param string $format
+     * @return array
+     */
+    public function resolveAvailablePartialFiles($format = self::DEFAULT_FORMAT)
+    {
+        return $this->resolveFilesInFolders($this->getPartialRootPaths(), $format);
+    }
 
-	/**
-	 * @param string $format
-	 * @return array
-	 */
-	public function resolveAvailableLayoutFiles($format = self::DEFAULT_FORMAT) {
-		return $this->resolveFilesInFolders($this->getLayoutRootPaths(), $format);
-	}
+    /**
+     * @param string $format
+     * @return array
+     */
+    public function resolveAvailableLayoutFiles($format = self::DEFAULT_FORMAT)
+    {
+        return $this->resolveFilesInFolders($this->getLayoutRootPaths(), $format);
+    }
 
-	/**
-	 * @param array $folders
-	 * @param string $format
-	 * @return array
-	 */
-	protected function resolveFilesInFolders(array $folders, $format) {
-		$files = array();
-		foreach ($folders as $folder) {
-			$files = array_merge($files, $this->resolveFilesInFolder($folder, $format));
-		}
-		return array_values($files);
-	}
+    /**
+     * @param array $folders
+     * @param string $format
+     * @return array
+     */
+    protected function resolveFilesInFolders(array $folders, $format)
+    {
+        $files = [];
+        foreach ($folders as $folder) {
+            $files = array_merge($files, $this->resolveFilesInFolder($folder, $format));
+        }
+        return array_values($files);
+    }
 
-	/**
-	 * @param string $folder
-	 * @param string $format
-	 * @return array
-	 */
-	protected function resolveFilesInFolder($folder, $format) {
-		$files = glob($folder . '*.' . $format);
-		return !$files ? array() : $files;
-	}
+    /**
+     * @param string $folder
+     * @param string $format
+     * @return array
+     */
+    protected function resolveFilesInFolder($folder, $format)
+    {
+        $files = glob($folder . '*.' . $format);
+        return !$files ? [] : $files;
+    }
 
-	/**
-	 * Fills path arrays based on a traditional
-	 * TypoScript array which may contain one or
-	 * more of the supported structures, in order
-	 * of priority:
-	 *
-	 * - `plugin.tx_yourext.view.templateRootPath` and siblings.
-	 * - `plugin.tx_yourext.view.templateRootPaths` and siblings.
-	 * - `plugin.tx_yourext.view.overlays.otherextension.templateRootPath` and siblings.
-	 *
-	 * The paths are treated as follows, using the
-	 * `template`-type paths as an example:
-	 *
-	 * - If `templateRootPath` is defined, it gets
-	 *   used as the _first_ path in the internal
-	 *   paths array.
-	 * - If `templateRootPaths` is defined, all
-	 *   values from it are _appended_ to the
-	 *   internal paths array.
-	 * - If `overlays.*` exists in the array it is
-	 *   iterated, each `templateRootPath` entry
-	 *   from it _appended_ to the internal array.
-	 *
-	 * The result is that after filling, the path
-	 * arrays will contain one or more entries in
-	 * the order described above, depending on how
-	 * many of the possible configurations were
-	 * present in the input array.
-	 *
-	 * Will replace any currently configured paths.
-	 *
-	 * @param array $paths
-	 * @return void
-	 * @api
-	 */
-	public function fillFromConfigurationArray(array $paths) {
-		list ($templateRootPaths, $layoutRootPaths, $partialRootPaths, $format) = $this->extractPathArrays($paths);
-		$this->setTemplateRootPaths($templateRootPaths);
-		$this->setLayoutRootPaths($layoutRootPaths);
-		$this->setPartialRootPaths($partialRootPaths);
-		$this->setFormat($format);
-	}
+    /**
+     * Fills path arrays based on a traditional
+     * TypoScript array which may contain one or
+     * more of the supported structures, in order
+     * of priority:
+     *
+     * - `plugin.tx_yourext.view.templateRootPath` and siblings.
+     * - `plugin.tx_yourext.view.templateRootPaths` and siblings.
+     * - `plugin.tx_yourext.view.overlays.otherextension.templateRootPath` and siblings.
+     *
+     * The paths are treated as follows, using the
+     * `template`-type paths as an example:
+     *
+     * - If `templateRootPath` is defined, it gets
+     *   used as the _first_ path in the internal
+     *   paths array.
+     * - If `templateRootPaths` is defined, all
+     *   values from it are _appended_ to the
+     *   internal paths array.
+     * - If `overlays.*` exists in the array it is
+     *   iterated, each `templateRootPath` entry
+     *   from it _appended_ to the internal array.
+     *
+     * The result is that after filling, the path
+     * arrays will contain one or more entries in
+     * the order described above, depending on how
+     * many of the possible configurations were
+     * present in the input array.
+     *
+     * Will replace any currently configured paths.
+     *
+     * @param array $paths
+     * @return void
+     * @api
+     */
+    public function fillFromConfigurationArray(array $paths)
+    {
+        list ($templateRootPaths, $layoutRootPaths, $partialRootPaths, $format) = $this->extractPathArrays($paths);
+        $this->setTemplateRootPaths($templateRootPaths);
+        $this->setLayoutRootPaths($layoutRootPaths);
+        $this->setPartialRootPaths($partialRootPaths);
+        $this->setFormat($format);
+    }
 
-	/**
-	 * Fills path arrays with default expected paths
-	 * based on package name (converted to extension
-	 * key automatically).
-	 *
-	 * Will replace any currently configured paths.
-	 *
-	 * @param string $packageName
-	 * @return void
-	 * @api
-	 */
-	public function fillDefaultsByPackageName($packageName) {
-		$path = $this->getPackagePath($packageName);
-		$this->setTemplateRootPaths(array($path . self::DEFAULT_TEMPLATES_DIRECTORY));
-		$this->setLayoutRootPaths(array($path . self::DEFAULT_LAYOUTS_DIRECTORY));
-		$this->setPartialRootPaths(array($path . self::DEFAULT_PARTIALS_DIRECTORY));
-	}
+    /**
+     * Fills path arrays with default expected paths
+     * based on package name (converted to extension
+     * key automatically).
+     *
+     * Will replace any currently configured paths.
+     *
+     * @param string $packageName
+     * @return void
+     * @api
+     */
+    public function fillDefaultsByPackageName($packageName)
+    {
+        $path = $this->getPackagePath($packageName);
+        $this->setTemplateRootPaths([$path . self::DEFAULT_TEMPLATES_DIRECTORY]);
+        $this->setLayoutRootPaths([$path . self::DEFAULT_LAYOUTS_DIRECTORY]);
+        $this->setPartialRootPaths([$path . self::DEFAULT_PARTIALS_DIRECTORY]);
+    }
 
-	/**
-	 * Sanitize a path, ensuring it is absolute and
-	 * if a directory, suffixed by a trailing slash.
-	 *
-	 * @param string|array $path
-	 * @return string
-	 */
-	protected function sanitizePath($path) {
-		if (strpos($path, 'php://') === 0) {
-			return $path;
-		} elseif (!empty($path)) {
-			$path = str_replace(array('\\', '//'), '/', $path);
-			$path = $this->ensureAbsolutePath($path);
-			if (is_dir($path)) {
-				$path = $this->ensureSuffixedPath($path);
-			}
-		}
-		return $path;
-	}
+    /**
+     * Sanitize a path, ensuring it is absolute and
+     * if a directory, suffixed by a trailing slash.
+     *
+     * @param string|array $path
+     * @return string
+     */
+    protected function sanitizePath($path)
+    {
+        if (strpos($path, 'php://') === 0) {
+            return $path;
+        } elseif (!empty($path)) {
+            $path = str_replace(['\\', '//'], '/', $path);
+            $path = $this->ensureAbsolutePath($path);
+            if (is_dir($path)) {
+                $path = $this->ensureSuffixedPath($path);
+            }
+        }
+        return $path;
+    }
 
-	/**
-	 * Sanitize paths passing each through sanitizePath().
-	 *
-	 * @param array $paths
-	 * @return array
-	 */
-	protected function sanitizePaths(array $paths) {
-		return array_unique(array_map(array($this, 'sanitizePath'), $paths));
-	}
+    /**
+     * Sanitize paths passing each through sanitizePath().
+     *
+     * @param array $paths
+     * @return array
+     */
+    protected function sanitizePaths(array $paths)
+    {
+        return array_unique(array_map([$this, 'sanitizePath'], $paths));
+    }
 
-	/**
-	 * Guarantees that $reference is turned into a
-	 * correct, absolute path.
-	 *
-	 * @param string $path
-	 * @return string
-	 */
-	protected function ensureAbsolutePath($path) {
-		return ((!empty($path) && $path{0} !== '/' && $path{1} !== ':') ? $this->sanitizePath(realpath($path)) : $path);
-	}
+    /**
+     * Guarantees that $reference is turned into a
+     * correct, absolute path.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function ensureAbsolutePath($path)
+    {
+        return ((!empty($path) && $path{0} !== '/' && $path{1} !== ':') ? $this->sanitizePath(realpath($path)) : $path);
+    }
 
-	/**
-	 * Guarantees that array $reference with paths
-	 * are turned into correct, absolute paths
-	 *
-	 * @param array $reference
-	 * @return array
-	 */
-	protected function ensureAbsolutePaths(array $reference) {
-		return array_map(array($this, 'ensureAbsolutePath'), $reference);
-	}
+    /**
+     * Guarantees that array $reference with paths
+     * are turned into correct, absolute paths
+     *
+     * @param array $reference
+     * @return array
+     */
+    protected function ensureAbsolutePaths(array $reference)
+    {
+        return array_map([$this, 'ensureAbsolutePath'], $reference);
+    }
 
-	/**
-	 * @param string $path
-	 * @return string
-	 */
-	protected function ensureSuffixedPath($path) {
-		return rtrim($path, '/') . '/';
-	}
+    /**
+     * @param string $path
+     * @return string
+     */
+    protected function ensureSuffixedPath($path)
+    {
+        return rtrim($path, '/') . '/';
+    }
 
-	/**
-	 * Extract an array of three arrays of paths, one
-	 * for each of the types of Fluid file resources.
-	 * Accepts one or both of the singular and plural
-	 * path definitions in the input - returns the
-	 * combined collections of paths based on both
-	 * the singular and plural entries with the singular
-	 * entries being recorded first and plurals second.
-	 *
-	 * Adds legacy singular name as last option, if set.
-	 *
-	 * @param array $paths
-	 * @return array
-	 */
-	protected function extractPathArrays(array $paths) {
-		$format = self::DEFAULT_FORMAT;
-		// pre-processing: if special parameters exist, extract them:
-		if (isset($paths[self::CONFIG_FORMAT])) {
-			$format = $paths[self::CONFIG_FORMAT];
-		}
-		$pathParts = array(
-			self::CONFIG_TEMPLATEROOTPATHS,
-			self::CONFIG_LAYOUTROOTPATHS,
-			self::CONFIG_PARTIALROOTPATHS
-		);
-		$pathCollections = array();
-		foreach ($pathParts as $pathPart) {
-			$partPaths = array();
-			if (isset($paths[$pathPart]) && is_array($paths[$pathPart])) {
-				$partPaths = array_merge($partPaths, array_values($paths[$pathPart]));
-			}
-			$pathCollections[] = array_values(array_unique(array_map(array($this, 'ensureSuffixedPath'), $partPaths)));
-		}
-		$pathCollections = array_map(array($this, 'ensureAbsolutePaths'), $pathCollections);
-		$pathCollections[] = $format;
-		return $pathCollections;
-	}
+    /**
+     * Extract an array of three arrays of paths, one
+     * for each of the types of Fluid file resources.
+     * Accepts one or both of the singular and plural
+     * path definitions in the input - returns the
+     * combined collections of paths based on both
+     * the singular and plural entries with the singular
+     * entries being recorded first and plurals second.
+     *
+     * Adds legacy singular name as last option, if set.
+     *
+     * @param array $paths
+     * @return array
+     */
+    protected function extractPathArrays(array $paths)
+    {
+        $format = self::DEFAULT_FORMAT;
+        // pre-processing: if special parameters exist, extract them:
+        if (isset($paths[self::CONFIG_FORMAT])) {
+            $format = $paths[self::CONFIG_FORMAT];
+        }
+        $pathParts = [
+            self::CONFIG_TEMPLATEROOTPATHS,
+            self::CONFIG_LAYOUTROOTPATHS,
+            self::CONFIG_PARTIALROOTPATHS
+        ];
+        $pathCollections = [];
+        foreach ($pathParts as $pathPart) {
+            $partPaths = [];
+            if (isset($paths[$pathPart]) && is_array($paths[$pathPart])) {
+                $partPaths = array_merge($partPaths, array_values($paths[$pathPart]));
+            }
+            $pathCollections[] = array_values(array_unique(array_map([$this, 'ensureSuffixedPath'], $partPaths)));
+        }
+        $pathCollections = array_map([$this, 'ensureAbsolutePaths'], $pathCollections);
+        $pathCollections[] = $format;
+        return $pathCollections;
+    }
 
-	/**
-	 * @param string $packageName
-	 * @return string
-	 */
-	protected function getPackagePath($packageName) {
-		return '';
-	}
+    /**
+     * @param string $packageName
+     * @return string
+     */
+    protected function getPackagePath($packageName)
+    {
+        return '';
+    }
 
-	/**
-	 * Returns a unique identifier for the resolved layout file.
-	 * This identifier is based on the template path and last modification date
-	 *
-	 * @param string $layoutName The name of the layout
-	 * @return string layout identifier
-	 */
-	public function getLayoutIdentifier($layoutName = 'Default') {
-		$filePathAndFilename = $this->getLayoutPathAndFilename($layoutName);
-		$layoutName = str_replace('.', '_', $layoutName);
-		$prefix = 'layout_' . $layoutName;
-		return $this->createIdentifierForFile($filePathAndFilename, $prefix);
-	}
+    /**
+     * Returns a unique identifier for the resolved layout file.
+     * This identifier is based on the template path and last modification date
+     *
+     * @param string $layoutName The name of the layout
+     * @return string layout identifier
+     */
+    public function getLayoutIdentifier($layoutName = 'Default')
+    {
+        $filePathAndFilename = $this->getLayoutPathAndFilename($layoutName);
+        $layoutName = str_replace('.', '_', $layoutName);
+        $prefix = 'layout_' . $layoutName;
+        return $this->createIdentifierForFile($filePathAndFilename, $prefix);
+    }
 
-	/**
-	 * Resolve the path and file name of the layout file, based on
-	 * $this->layoutPathAndFilename and $this->layoutPathAndFilenamePattern.
-	 *
-	 * In case a layout has already been set with setLayoutPathAndFilename(),
-	 * this method returns that path, otherwise a path and filename will be
-	 * resolved using the layoutPathAndFilenamePattern.
-	 *
-	 * @param string $layoutName Name of the layout to use. If none given, use "Default"
-	 * @return string Path and filename of layout file
-	 * @throws InvalidTemplateResourceException
-	 */
-	public function getLayoutSource($layoutName = 'Default') {
-		$layoutPathAndFilename = $this->getLayoutPathAndFilename($layoutName);
-		return file_get_contents($layoutPathAndFilename, FILE_TEXT);
-	}
+    /**
+     * Resolve the path and file name of the layout file, based on
+     * $this->layoutPathAndFilename and $this->layoutPathAndFilenamePattern.
+     *
+     * In case a layout has already been set with setLayoutPathAndFilename(),
+     * this method returns that path, otherwise a path and filename will be
+     * resolved using the layoutPathAndFilenamePattern.
+     *
+     * @param string $layoutName Name of the layout to use. If none given, use "Default"
+     * @return string Path and filename of layout file
+     * @throws InvalidTemplateResourceException
+     */
+    public function getLayoutSource($layoutName = 'Default')
+    {
+        $layoutPathAndFilename = $this->getLayoutPathAndFilename($layoutName);
+        return file_get_contents($layoutPathAndFilename, FILE_TEXT);
+    }
 
-	/**
-	 * Returns a unique identifier for the resolved template file
-	 * This identifier is based on the template path and last modification date
-	 *
-	 * @param string $controller
-	 * @param string $action Name of the action. If NULL, will be taken from request.
-	 * @return string template identifier
-	 */
-	public function getTemplateIdentifier($controller = 'Default', $action = 'Default') {
-		$format = $this->getFormat();
-		if ($this->templateSource !== NULL) {
-			return 'source_' . sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $format;
-		}
-		$templatePathAndFilename = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);
-		$prefix = $controller . '_action_' . $action;
-		return $this->createIdentifierForFile($templatePathAndFilename, $prefix);
-	}
+    /**
+     * Returns a unique identifier for the resolved template file
+     * This identifier is based on the template path and last modification date
+     *
+     * @param string $controller
+     * @param string $action Name of the action. If NULL, will be taken from request.
+     * @return string template identifier
+     */
+    public function getTemplateIdentifier($controller = 'Default', $action = 'Default')
+    {
+        $format = $this->getFormat();
+        if ($this->templateSource !== null) {
+            return 'source_' . sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $format;
+        }
+        $templatePathAndFilename = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);
+        $prefix = $controller . '_action_' . $action;
+        return $this->createIdentifierForFile($templatePathAndFilename, $prefix);
+    }
 
-	/**
-	 * @param mixed $source
-	 */
-	public function setTemplateSource($source) {
-		$this->templateSource = $source;
-	}
+    /**
+     * @param mixed $source
+     */
+    public function setTemplateSource($source)
+    {
+        $this->templateSource = $source;
+    }
 
-	/**
-	 * Resolve the template path and filename for the given action. If $actionName
-	 * is NULL, looks into the current request.
-	 *
-	 * @param string $controller
-	 * @param string $action Name of the action. If NULL, will be taken from request.
-	 * @return string Full path to template
-	 * @throws InvalidTemplateResourceException
-	 */
-	public function getTemplateSource($controller = 'Default', $action = 'Default') {
-		if (is_string($this->templateSource)) {
-			return $this->templateSource;
-		} elseif (is_resource($this->templateSource)) {
-			rewind($this->templateSource);
-			return $this->templateSource = stream_get_contents($this->templateSource);
-		}
-		$format = $this->getFormat();
-		$templateReference = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);
-		if (!file_exists($templateReference) && $templateReference !== 'php://stdin') {
-			throw new InvalidTemplateResourceException(
-				sprintf(
-					'Tried resolving a template file for controller action "%s->%s" in format ".%s", but none of the paths ' .
-					'contained the expected template file (%s). The following paths were checked: %s',
-					$controller,
-					$action,
-					$format,
-					$templateReference === NULL ? $controller . '/' . ucfirst($action) . '.' . $format : $templateReference,
-					implode(',', $this->getTemplateRootPaths())
-				),
-				1257246929
-			);
-		}
-		return file_get_contents($templateReference, FILE_TEXT);
-	}
+    /**
+     * Resolve the template path and filename for the given action. If $actionName
+     * is NULL, looks into the current request.
+     *
+     * @param string $controller
+     * @param string $action Name of the action. If NULL, will be taken from request.
+     * @return string Full path to template
+     * @throws InvalidTemplateResourceException
+     */
+    public function getTemplateSource($controller = 'Default', $action = 'Default')
+    {
+        if (is_string($this->templateSource)) {
+            return $this->templateSource;
+        } elseif (is_resource($this->templateSource)) {
+            rewind($this->templateSource);
+            return $this->templateSource = stream_get_contents($this->templateSource);
+        }
+        $format = $this->getFormat();
+        $templateReference = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, $format);
+        if (!file_exists($templateReference) && $templateReference !== 'php://stdin') {
+            throw new InvalidTemplateResourceException(
+                sprintf(
+                    'Tried resolving a template file for controller action "%s->%s" in format ".%s", but none of the paths ' .
+                    'contained the expected template file (%s). The following paths were checked: %s',
+                    $controller,
+                    $action,
+                    $format,
+                    $templateReference === null ? $controller . '/' . ucfirst($action) . '.' . $format : $templateReference,
+                    implode(',', $this->getTemplateRootPaths())
+                ),
+                1257246929
+            );
+        }
+        return file_get_contents($templateReference, FILE_TEXT);
+    }
 
-	/**
-	 * Returns a unique identifier for the given file in the format
-	 * <PackageKey>_<SubPackageKey>_<ControllerName>_<prefix>_<SHA1>
-	 * The SH1 hash is a checksum that is based on the file path and last modification date
-	 *
-	 * @param string $pathAndFilename
-	 * @param string $prefix
-	 * @return string
-	 */
-	protected function createIdentifierForFile($pathAndFilename, $prefix) {
-		$templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' ? filemtime($pathAndFilename) : 0;
-		return sprintf('%s_%s', $prefix, sha1($pathAndFilename . '|' . $templateModifiedTimestamp));
-	}
+    /**
+     * Returns a unique identifier for the given file in the format
+     * <PackageKey>_<SubPackageKey>_<ControllerName>_<prefix>_<SHA1>
+     * The SH1 hash is a checksum that is based on the file path and last modification date
+     *
+     * @param string $pathAndFilename
+     * @param string $prefix
+     * @return string
+     */
+    protected function createIdentifierForFile($pathAndFilename, $prefix)
+    {
+        $templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' ? filemtime($pathAndFilename) : 0;
+        return sprintf('%s_%s', $prefix, sha1($pathAndFilename . '|' . $templateModifiedTimestamp));
+    }
 
-	/**
-	 * Resolve the path and file name of the layout file, based on
-	 * $this->options['layoutPathAndFilename'] and $this->options['layoutPathAndFilenamePattern'].
-	 *
-	 * In case a layout has already been set with setLayoutPathAndFilename(),
-	 * this method returns that path, otherwise a path and filename will be
-	 * resolved using the layoutPathAndFilenamePattern.
-	 *
-	 * @param string $layoutName Name of the layout to use. If none given, use "Default"
-	 * @return string Path and filename of layout files
-	 * @throws Exception\InvalidTemplateResourceException
-	 */
-	public function getLayoutPathAndFilename($layoutName = 'Default') {
-		$format = $this->getFormat();
-		$layoutName = ucfirst($layoutName);
-		$layoutKey = $layoutName . '.' . $format;
-		if (!array_key_exists($layoutKey, self::$resolvedFiles[self::NAME_LAYOUTS])) {
-			$paths = $this->getLayoutRootPaths();
-			self::$resolvedFiles[self::NAME_LAYOUTS][$layoutKey] = $this->resolveFileInPaths($paths, $layoutName, $format);
-		}
-		return self::$resolvedFiles[self::NAME_LAYOUTS][$layoutKey];
-	}
+    /**
+     * Resolve the path and file name of the layout file, based on
+     * $this->options['layoutPathAndFilename'] and $this->options['layoutPathAndFilenamePattern'].
+     *
+     * In case a layout has already been set with setLayoutPathAndFilename(),
+     * this method returns that path, otherwise a path and filename will be
+     * resolved using the layoutPathAndFilenamePattern.
+     *
+     * @param string $layoutName Name of the layout to use. If none given, use "Default"
+     * @return string Path and filename of layout files
+     * @throws Exception\InvalidTemplateResourceException
+     */
+    public function getLayoutPathAndFilename($layoutName = 'Default')
+    {
+        $format = $this->getFormat();
+        $layoutName = ucfirst($layoutName);
+        $layoutKey = $layoutName . '.' . $format;
+        if (!array_key_exists($layoutKey, self::$resolvedFiles[self::NAME_LAYOUTS])) {
+            $paths = $this->getLayoutRootPaths();
+            self::$resolvedFiles[self::NAME_LAYOUTS][$layoutKey] = $this->resolveFileInPaths($paths, $layoutName, $format);
+        }
+        return self::$resolvedFiles[self::NAME_LAYOUTS][$layoutKey];
+    }
 
-	/**
-	 * Returns a unique identifier for the resolved partial file.
-	 * This identifier is based on the template path and last modification date
-	 *
-	 * @param string $partialName The name of the partial
-	 * @return string partial identifier
-	 */
-	public function getPartialIdentifier($partialName) {
-		$partialKey = $partialName . '.' . $this->getFormat();
-		if (!array_key_exists($partialKey, self::$resolvedIdentifiers[self::NAME_PARTIALS])) {
-			$partialPathAndFilename = $this->getPartialPathAndFilename($partialName);
-			$prefix = 'partial_' . $partialName;
-			self::$resolvedIdentifiers[self::NAME_PARTIALS][$partialKey] = $this->createIdentifierForFile($partialPathAndFilename, $prefix);
-		}
-		return self::$resolvedIdentifiers[self::NAME_PARTIALS][$partialKey];
-	}
+    /**
+     * Returns a unique identifier for the resolved partial file.
+     * This identifier is based on the template path and last modification date
+     *
+     * @param string $partialName The name of the partial
+     * @return string partial identifier
+     */
+    public function getPartialIdentifier($partialName)
+    {
+        $partialKey = $partialName . '.' . $this->getFormat();
+        if (!array_key_exists($partialKey, self::$resolvedIdentifiers[self::NAME_PARTIALS])) {
+            $partialPathAndFilename = $this->getPartialPathAndFilename($partialName);
+            $prefix = 'partial_' . $partialName;
+            self::$resolvedIdentifiers[self::NAME_PARTIALS][$partialKey] = $this->createIdentifierForFile($partialPathAndFilename, $prefix);
+        }
+        return self::$resolvedIdentifiers[self::NAME_PARTIALS][$partialKey];
+    }
 
-	/**
-	 * Figures out which partial to use.
-	 *
-	 * @param string $partialName The name of the partial
-	 * @return string contents of the partial template
-	 * @throws InvalidTemplateResourceException
-	 */
-	public function getPartialSource($partialName) {
-		$partialPathAndFilename = $this->getPartialPathAndFilename($partialName);
-		return file_get_contents($partialPathAndFilename, FILE_TEXT);
-	}
+    /**
+     * Figures out which partial to use.
+     *
+     * @param string $partialName The name of the partial
+     * @return string contents of the partial template
+     * @throws InvalidTemplateResourceException
+     */
+    public function getPartialSource($partialName)
+    {
+        $partialPathAndFilename = $this->getPartialPathAndFilename($partialName);
+        return file_get_contents($partialPathAndFilename, FILE_TEXT);
+    }
 
-	/**
-	 * Resolve the partial path and filename based on $this->options['partialPathAndFilenamePattern'].
-	 *
-	 * @param string $partialName The name of the partial
-	 * @return string the full path which should be used. The path definitely exists.
-	 * @throws InvalidTemplateResourceException
-	 */
-	public function getPartialPathAndFilename($partialName) {
-		$format = $this->getFormat();
-		$partialKey = $partialName . '.' . $format;
-		if (!array_key_exists($partialKey, self::$resolvedFiles[self::NAME_PARTIALS])) {
-			$paths = $this->getPartialRootPaths();
-			$partialName = ucfirst($partialName);
-			self::$resolvedFiles[self::NAME_PARTIALS][$partialKey] = $this->resolveFileInPaths($paths, $partialName, $format);
-		}
-		return self::$resolvedFiles[self::NAME_PARTIALS][$partialKey];
-	}
+    /**
+     * Resolve the partial path and filename based on $this->options['partialPathAndFilenamePattern'].
+     *
+     * @param string $partialName The name of the partial
+     * @return string the full path which should be used. The path definitely exists.
+     * @throws InvalidTemplateResourceException
+     */
+    public function getPartialPathAndFilename($partialName)
+    {
+        $format = $this->getFormat();
+        $partialKey = $partialName . '.' . $format;
+        if (!array_key_exists($partialKey, self::$resolvedFiles[self::NAME_PARTIALS])) {
+            $paths = $this->getPartialRootPaths();
+            $partialName = ucfirst($partialName);
+            self::$resolvedFiles[self::NAME_PARTIALS][$partialKey] = $this->resolveFileInPaths($paths, $partialName, $format);
+        }
+        return self::$resolvedFiles[self::NAME_PARTIALS][$partialKey];
+    }
 
-	/**
-	 * @param array $paths
-	 * @param string $relativePathAndFilename
-	 * @return string
-	 * @throws \TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException
-	 */
-	protected function resolveFileInPaths(array $paths, $relativePathAndFilename, $format = self::DEFAULT_FORMAT) {
-		$tried = array();
-		// Note about loop: iteration with while + array_pop causes paths to be checked in opposite
-		// order, which is intentional. Paths are considered overlays, e.g. adding a path to the
-		// array means you want that path checked first.
-		while (null !== ($path = array_pop($paths))) {
-			$pathAndFilenameWithoutFormat = $path . $relativePathAndFilename;
-			$pathAndFilename = $pathAndFilenameWithoutFormat . '.' . $format;
-			if (is_file($pathAndFilename)) {
-				return $pathAndFilename;
-			}
-			$tried[] = $pathAndFilename;
-			if (is_file($pathAndFilenameWithoutFormat)) {
-				return $pathAndFilenameWithoutFormat;
-			}
-			$tried[] = $pathAndFilenameWithoutFormat;
-		}
-		throw new InvalidTemplateResourceException(
-			'The Fluid template files "' . implode('", "', $tried) . '" could not be loaded.',
-			1225709595
-		);
-	}
+    /**
+     * @param array $paths
+     * @param string $relativePathAndFilename
+     * @return string
+     * @throws \TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException
+     */
+    protected function resolveFileInPaths(array $paths, $relativePathAndFilename, $format = self::DEFAULT_FORMAT)
+    {
+        $tried = [];
+        // Note about loop: iteration with while + array_pop causes paths to be checked in opposite
+        // order, which is intentional. Paths are considered overlays, e.g. adding a path to the
+        // array means you want that path checked first.
+        while (null !== ($path = array_pop($paths))) {
+            $pathAndFilenameWithoutFormat = $path . $relativePathAndFilename;
+            $pathAndFilename = $pathAndFilenameWithoutFormat . '.' . $format;
+            if (is_file($pathAndFilename)) {
+                return $pathAndFilename;
+            }
+            $tried[] = $pathAndFilename;
+            if (is_file($pathAndFilenameWithoutFormat)) {
+                return $pathAndFilenameWithoutFormat;
+            }
+            $tried[] = $pathAndFilenameWithoutFormat;
+        }
+        throw new InvalidTemplateResourceException(
+            'The Fluid template files "' . implode('", "', $tried) . '" could not be loaded.',
+            1225709595
+        );
+    }
 
-	/**
-	 * @param string|NULL $type
-	 * @return void
-	 */
-	protected function clearResolvedIdentifiersAndTemplates($type = NULL) {
-		if ($type) {
-			self::$resolvedIdentifiers[$type] = self::$resolvedFiles[$type] = array();
-		} else {
-			self::$resolvedIdentifiers = self::$resolvedFiles = array(
-				self::NAME_TEMPLATES => array(),
-				self::NAME_LAYOUTS => array(),
-				self::NAME_PARTIALS => array()
-			);
-		}
-	}
+    /**
+     * @param string|NULL $type
+     * @return void
+     */
+    protected function clearResolvedIdentifiersAndTemplates($type = null)
+    {
+        if ($type) {
+            self::$resolvedIdentifiers[$type] = self::$resolvedFiles[$type] = [];
+        } else {
+            self::$resolvedIdentifiers = self::$resolvedFiles = [
+                self::NAME_TEMPLATES => [],
+                self::NAME_LAYOUTS => [],
+                self::NAME_PARTIALS => []
+            ];
+        }
+    }
 }

--- a/src/View/TemplateView.php
+++ b/src/View/TemplateView.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class TemplateView extends AbstractTemplateView {
+class TemplateView extends AbstractTemplateView
+{
 
 }

--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -11,55 +11,56 @@ namespace TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-interface ViewInterface {
+interface ViewInterface
+{
 
-	/**
-	 * Add a variable to the view data collection.
-	 * Can be chained, so $this->view->assign(..., ...)->assign(..., ...); is possible
-	 *
-	 * @param string $key Key of variable
-	 * @param mixed $value Value of object
-	 * @return ViewInterface an instance of $this, to enable chaining
-	 * @api
-	 */
-	public function assign($key, $value);
+    /**
+     * Add a variable to the view data collection.
+     * Can be chained, so $this->view->assign(..., ...)->assign(..., ...); is possible
+     *
+     * @param string $key Key of variable
+     * @param mixed $value Value of object
+     * @return ViewInterface an instance of $this, to enable chaining
+     * @api
+     */
+    public function assign($key, $value);
 
-	/**
-	 * Add multiple variables to the view data collection
-	 *
-	 * @param array $values array in the format array(key1 => value1, key2 => value2)
-	 * @return \TYPO3Fluid\Flow\Mvc\View\ViewInterface an instance of $this, to enable chaining
-	 * @api
-	 */
-	public function assignMultiple(array $values);
+    /**
+     * Add multiple variables to the view data collection
+     *
+     * @param array $values array in the format array(key1 => value1, key2 => value2)
+     * @return \TYPO3Fluid\Flow\Mvc\View\ViewInterface an instance of $this, to enable chaining
+     * @api
+     */
+    public function assignMultiple(array $values);
 
-	/**
-	 * Renders the view
-	 *
-	 * @return string The rendered view
-	 * @api
-	 */
-	public function render();
+    /**
+     * Renders the view
+     *
+     * @return string The rendered view
+     * @api
+     */
+    public function render();
 
-	/**
-	 * Renders a given section.
-	 *
-	 * @param string $sectionName Name of section to render
-	 * @param array $variables The variables to use
-	 * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
-	 * @return string rendered template for the section
-	 * @throws InvalidSectionException
-	 */
-	public function renderSection($sectionName, array $variables = array(), $ignoreUnknown = FALSE);
+    /**
+     * Renders a given section.
+     *
+     * @param string $sectionName Name of section to render
+     * @param array $variables The variables to use
+     * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
+     * @return string rendered template for the section
+     * @throws InvalidSectionException
+     */
+    public function renderSection($sectionName, array $variables = [], $ignoreUnknown = false);
 
-	/**
-	 * Renders a partial.
-	 *
-	 * @param string $partialName
-	 * @param string $sectionName
-	 * @param array $variables
-	 * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
-	 * @return string
-	 */
-	public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = FALSE);
+    /**
+     * Renders a partial.
+     *
+     * @param string $partialName
+     * @param string $sectionName
+     * @param array $variables
+     * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
+     * @return string
+     */
+    public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = false);
 }

--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -41,41 +41,42 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * @api
  */
-class AliasViewHelper extends AbstractViewHelper {
+class AliasViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithRenderStatic;
+    use CompileWithRenderStatic;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('map', 'array', 'Array that specifies which variables should be mapped to which alias', TRUE);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('map', 'array', 'Array that specifies which variables should be mapped to which alias', true);
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
-	{
-		$templateVariableContainer = $renderingContext->getVariableProvider();
-		$map = $arguments['map'];
-		foreach ($map as $aliasName => $value) {
-			$templateVariableContainer->add($aliasName, $value);
-		}
-		$output = $renderChildrenClosure();
-		foreach ($map as $aliasName => $value) {
-			$templateVariableContainer->remove($aliasName);
-		}
-		return $output;
-	}
-
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $templateVariableContainer = $renderingContext->getVariableProvider();
+        $map = $arguments['map'];
+        foreach ($map as $aliasName => $value) {
+            $templateVariableContainer->add($aliasName, $value);
+        }
+        $output = $renderChildrenClosure();
+        foreach ($map as $aliasName => $value) {
+            $templateVariableContainer->remove($aliasName);
+        }
+        return $output;
+    }
 }

--- a/src/ViewHelpers/Cache/DisableViewHelper.php
+++ b/src/ViewHelpers/Cache/DisableViewHelper.php
@@ -47,39 +47,41 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class DisableViewHelper extends AbstractViewHelper {
+class DisableViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return string
-	 */
-	public function render() {
-		return $this->renderChildren();
-	}
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return $this->renderChildren();
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 */
-	public function compile(
-		$argumentsName,
-		$closureName,
-		&$initializationPhpCode,
-		ViewHelperNode $node,
-		TemplateCompiler $compiler
-	) {
-		$compiler->disable();
-	}
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ) {
+        $compiler->disable();
+    }
 }

--- a/src/ViewHelpers/Cache/StaticViewHelper.php
+++ b/src/ViewHelpers/Cache/StaticViewHelper.php
@@ -62,42 +62,44 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class StaticViewHelper extends AbstractViewHelper {
+class StaticViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return string
-	 */
-	public function render() {
-		return $this->renderChildren();
-	}
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return $this->renderChildren();
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 */
-	public function compile(
-		$argumentsName,
-		$closureName,
-		&$initializationPhpCode,
-		ViewHelperNode $node,
-		TemplateCompiler $compiler
-	) {
-		$renderedString = $node->evaluateChildNodes($this->renderingContext);
-		$stopCompilingChildrenException = new StopCompilingChildrenException();
-		$stopCompilingChildrenException->setReplacementString($renderedString);
-		throw $stopCompilingChildrenException;
-	}
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ) {
+        $renderedString = $node->evaluateChildNodes($this->renderingContext);
+        $stopCompilingChildrenException = new StopCompilingChildrenException();
+        $stopCompilingChildrenException->setReplacementString($renderedString);
+        throw $stopCompilingChildrenException;
+    }
 }

--- a/src/ViewHelpers/Cache/WarmupViewHelper.php
+++ b/src/ViewHelpers/Cache/WarmupViewHelper.php
@@ -56,102 +56,105 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class WarmupViewHelper extends AbstractViewHelper {
+class WarmupViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument(
-			'variables',
-			'array',
-			'Array of variables to assign ONLY when compiling. See main class documentation.',
-			FALSE,
-			array()
-		);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument(
+            'variables',
+            'array',
+            'Array of variables to assign ONLY when compiling. See main class documentation.',
+            false,
+            []
+        );
+    }
 
-	/**
-	 * Render this ViewHelper
-	 *
-	 * Makes a decision based on whether or not warmup mode is
-	 * currently active - if it is NOT ACTIVE the ViewHelper
-	 * returns the result of `renderChildren` without any further
-	 * operations. If ACTIVE the ViewHelper will assign/overlay
-	 * replacement variables, call `renderChildren`, restore the
-	 * original variable provider and finally return the content.
-	 *
-	 * @return string
-	 */
-	public function render() {
-		if (!$this->renderingContext->getTemplateCompiler()->isWarmupMode()) {
-			return $this->renderChildren();
-		}
-		$originalVariableProvider = static::overlayVariablesIfNotSet(
-			$this->renderingContext,
-			$this->arguments['variables']
-		);
-		$content = $this->renderChildren();
-		$this->renderingContext->setVariableProvider($originalVariableProvider);
-		return $content;
-	}
+    /**
+     * Render this ViewHelper
+     *
+     * Makes a decision based on whether or not warmup mode is
+     * currently active - if it is NOT ACTIVE the ViewHelper
+     * returns the result of `renderChildren` without any further
+     * operations. If ACTIVE the ViewHelper will assign/overlay
+     * replacement variables, call `renderChildren`, restore the
+     * original variable provider and finally return the content.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        if (!$this->renderingContext->getTemplateCompiler()->isWarmupMode()) {
+            return $this->renderChildren();
+        }
+        $originalVariableProvider = static::overlayVariablesIfNotSet(
+            $this->renderingContext,
+            $this->arguments['variables']
+        );
+        $content = $this->renderChildren();
+        $this->renderingContext->setVariableProvider($originalVariableProvider);
+        return $content;
+    }
 
-	/**
-	 * Custom implementation of compile method. Performns variable
-	 * provider overlaying, calls renderChildren and throws a
-	 * StopCompilingChildren with a static replacement string attached.
-	 *
-	 * TemplateCompiler then inserts this string as a static string in
-	 * the compiled template (and stops compiling all child nodes).
-	 *
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 */
-	public function compile(
-		$argumentsName,
-		$closureName,
-		&$initializationPhpCode,
-		ViewHelperNode $node,
-		TemplateCompiler $compiler
-	) {
-		$originalVariableProvider = static::overlayVariablesIfNotSet($this->renderingContext, $this->arguments);
-		$stopCompilingChildrenException = new StopCompilingChildrenException();
-		$stopCompilingChildrenException->setReplacementString($this->renderChildren());
-		$this->renderingContext->setVariableProvider($originalVariableProvider);
-		throw $stopCompilingChildrenException;
-	}
+    /**
+     * Custom implementation of compile method. Performns variable
+     * provider overlaying, calls renderChildren and throws a
+     * StopCompilingChildren with a static replacement string attached.
+     *
+     * TemplateCompiler then inserts this string as a static string in
+     * the compiled template (and stops compiling all child nodes).
+     *
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ) {
+        $originalVariableProvider = static::overlayVariablesIfNotSet($this->renderingContext, $this->arguments);
+        $stopCompilingChildrenException = new StopCompilingChildrenException();
+        $stopCompilingChildrenException->setReplacementString($this->renderChildren());
+        $this->renderingContext->setVariableProvider($originalVariableProvider);
+        throw $stopCompilingChildrenException;
+    }
 
-	/**
-	 * Overlay variables by replacing the VariableProvider with a
-	 * ChainedVariableProvider using dual data sources. Returns the
-	 * original VariableProvider which must replace the temporary
-	 * one again once the rendering/compiling is done.
-	 *
-	 * @param RenderingContextInterface $renderingContext
-	 * @param array $variables
-	 * @return VariableProviderInterface
-	 */
-	protected static function overlayVariablesIfNotSet(RenderingContextInterface $renderingContext, array $variables) {
-		$currentProvider = $renderingContext->getVariableProvider();
-		$chainedVariableProvider = new ChainedVariableProvider(array(
-			$currentProvider,
-			new StandardVariableProvider($variables)
-		));
-		$renderingContext->setVariableProvider($chainedVariableProvider);
-		return $currentProvider;
-	}
-
+    /**
+     * Overlay variables by replacing the VariableProvider with a
+     * ChainedVariableProvider using dual data sources. Returns the
+     * original VariableProvider which must replace the temporary
+     * one again once the rendering/compiling is done.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @param array $variables
+     * @return VariableProviderInterface
+     */
+    protected static function overlayVariablesIfNotSet(RenderingContextInterface $renderingContext, array $variables)
+    {
+        $currentProvider = $renderingContext->getVariableProvider();
+        $chainedVariableProvider = new ChainedVariableProvider([
+            $currentProvider,
+            new StandardVariableProvider($variables)
+        ]);
+        $renderingContext->setVariableProvider($chainedVariableProvider);
+        return $currentProvider;
+    }
 }

--- a/src/ViewHelpers/CaseViewHelper.php
+++ b/src/ViewHelpers/CaseViewHelper.php
@@ -17,51 +17,55 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class CaseViewHelper extends AbstractViewHelper {
+class CaseViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('value', 'mixed', 'Value to match in this case', TRUE);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('value', 'mixed', 'Value to match in this case', true);
+    }
 
-	/**
-	 * @return string the contents of this view helper if $value equals the expression of the surrounding switch view helper, otherwise an empty string
-	 * @throws ViewHelper\Exception
-	 * @api
-	 */
-	public function render() {
-		$value = $this->arguments['value'];
-		$viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
-		if (!$viewHelperVariableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
-			throw new ViewHelper\Exception('The "case" View helper can only be used within a switch View helper', 1368112037);
-		}
-		$switchExpression = $viewHelperVariableContainer->get(SwitchViewHelper::class, 'switchExpression');
+    /**
+     * @return string the contents of this view helper if $value equals the expression of the surrounding switch view helper, otherwise an empty string
+     * @throws ViewHelper\Exception
+     * @api
+     */
+    public function render()
+    {
+        $value = $this->arguments['value'];
+        $viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
+        if (!$viewHelperVariableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
+            throw new ViewHelper\Exception('The "case" View helper can only be used within a switch View helper', 1368112037);
+        }
+        $switchExpression = $viewHelperVariableContainer->get(SwitchViewHelper::class, 'switchExpression');
 
-		// non-type-safe comparison by intention
-		if ($switchExpression == $value) {
-			$viewHelperVariableContainer->addOrUpdate(SwitchViewHelper::class, 'break', TRUE);
-			return $this->renderChildren();
-		}
-		return '';
-	}
+        // non-type-safe comparison by intention
+        if ($switchExpression == $value) {
+            $viewHelperVariableContainer->addOrUpdate(SwitchViewHelper::class, 'break', true);
+            return $this->renderChildren();
+        }
+        return '';
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return '\'\'';
-	}
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '\'\'';
+    }
 }

--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -45,38 +45,39 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class CommentViewHelper extends AbstractViewHelper {
+class CommentViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * Comments out the tag content
-	 *
-	 * @return string
-	 * @api
-	 */
-	public function render() {
-	}
+    /**
+     * Comments out the tag content
+     *
+     * @return string
+     * @api
+     */
+    public function render()
+    {
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return null
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return NULL;
-	}
-
-
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return null
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return null;
+    }
 }

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -32,37 +32,38 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  *
  * @api
  */
-class CountViewHelper extends AbstractViewHelper {
+class CountViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithContentArgumentAndRenderStatic;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('subject', 'array', 'Countable subject, array or \Countable');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('subject', 'array', 'Countable subject, array or \Countable');
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return integer
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
-	{
-		return count($renderChildrenClosure());
-	}
-
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return integer
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        return count($renderChildrenClosure());
+    }
 }

--- a/src/ViewHelpers/CycleViewHelper.php
+++ b/src/ViewHelpers/CycleViewHelper.php
@@ -45,81 +45,85 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class CycleViewHelper extends AbstractViewHelper {
+class CycleViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * The values to be iterated through
-	 *
-	 * @var array|\SplObjectStorage
-	 */
-	protected $values = NULL;
+    /**
+     * The values to be iterated through
+     *
+     * @var array|\SplObjectStorage
+     */
+    protected $values = null;
 
-	/**
-	 * Current values index
-	 *
-	 * @var integer
-	 */
-	protected $currentCycleIndex = NULL;
+    /**
+     * Current values index
+     *
+     * @var integer
+     */
+    protected $currentCycleIndex = null;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('values', 'array', 'The array or object implementing \ArrayAccess (for example \SplObjectStorage) to iterated over', FALSE);
-		$this->registerArgument('as', 'strong', 'The name of the iteration variable', TRUE);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('values', 'array', 'The array or object implementing \ArrayAccess (for example \SplObjectStorage) to iterated over', false);
+        $this->registerArgument('as', 'strong', 'The name of the iteration variable', true);
+    }
 
-	/**
-	 * Renders cycle view helper
-	 *
-	 * @return string Rendered result
-	 * @api
-	 */
-	public function render() {
-		$values = $this->arguments['values'];
-		$as = $this->arguments['as'];
-		if ($values === NULL) {
-			return $this->renderChildren();
-		}
-		if ($this->values === NULL) {
-			$this->initializeValues($values);
-		}
-		if ($this->currentCycleIndex === NULL || $this->currentCycleIndex >= count($this->values)) {
-			$this->currentCycleIndex = 0;
-		}
+    /**
+     * Renders cycle view helper
+     *
+     * @return string Rendered result
+     * @api
+     */
+    public function render()
+    {
+        $values = $this->arguments['values'];
+        $as = $this->arguments['as'];
+        if ($values === null) {
+            return $this->renderChildren();
+        }
+        if ($this->values === null) {
+            $this->initializeValues($values);
+        }
+        if ($this->currentCycleIndex === null || $this->currentCycleIndex >= count($this->values)) {
+            $this->currentCycleIndex = 0;
+        }
 
-		$currentValue = isset($this->values[$this->currentCycleIndex]) ? $this->values[$this->currentCycleIndex] : NULL;
-		$this->templateVariableContainer->add($as, $currentValue);
-		$output = $this->renderChildren();
-		$this->templateVariableContainer->remove($as);
+        $currentValue = isset($this->values[$this->currentCycleIndex]) ? $this->values[$this->currentCycleIndex] : null;
+        $this->templateVariableContainer->add($as, $currentValue);
+        $output = $this->renderChildren();
+        $this->templateVariableContainer->remove($as);
 
-		$this->currentCycleIndex++;
+        $this->currentCycleIndex++;
 
-		return $output;
-	}
+        return $output;
+    }
 
-	/**
-	 * Sets this->values to the current values argument and resets $this->currentCycleIndex.
-	 *
-	 * @param array|\Traversable $values The array or \SplObjectStorage to be stored in $this->values
-	 * @return void
-	 * @throws ViewHelper\Exception
-	 */
-	protected function initializeValues($values) {
-		if (is_object($values)) {
-			if (!$values instanceof \Traversable) {
-				throw new ViewHelper\Exception('CycleViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
-			}
-			$this->values = iterator_to_array($values, FALSE);
-		} else {
-			$this->values = array_values($values);
-		}
-		$this->currentCycleIndex = 0;
-	}
+    /**
+     * Sets this->values to the current values argument and resets $this->currentCycleIndex.
+     *
+     * @param array|\Traversable $values The array or \SplObjectStorage to be stored in $this->values
+     * @return void
+     * @throws ViewHelper\Exception
+     */
+    protected function initializeValues($values)
+    {
+        if (is_object($values)) {
+            if (!$values instanceof \Traversable) {
+                throw new ViewHelper\Exception('CycleViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
+            }
+            $this->values = iterator_to_array($values, false);
+        } else {
+            $this->values = array_values($values);
+        }
+        $this->currentCycleIndex = 0;
+    }
 }

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -32,137 +32,141 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * @api
  */
-class DebugViewHelper extends AbstractViewHelper {
+class DebugViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithRenderStatic;
+    use CompileWithRenderStatic;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('typeOnly', 'boolean', 'If TRUE, debugs only the type of variables', FALSE, FALSE);
-		$this->registerArgument('levels', 'integer', 'Levels to render when rendering nested objects/arrays', FALSE, 5);
-		$this->registerArgument('html', 'boolean', 'Render HTML. If FALSE, output is indented plaintext', FALSE, FALSE);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('typeOnly', 'boolean', 'If TRUE, debugs only the type of variables', false, false);
+        $this->registerArgument('levels', 'integer', 'Levels to render when rendering nested objects/arrays', false, 5);
+        $this->registerArgument('html', 'boolean', 'Render HTML. If FALSE, output is indented plaintext', false, false);
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		$typeOnly = $arguments['typeOnly'];
-		$expressionToExamine = $renderChildrenClosure();
-		if ($typeOnly === TRUE) {
-			return (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
-		}
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $typeOnly = $arguments['typeOnly'];
+        $expressionToExamine = $renderChildrenClosure();
+        if ($typeOnly === true) {
+            return (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
+        }
 
-		$html = $arguments['html'];
-		$levels = $arguments['levels'];
-		return static::dumpVariable($expressionToExamine, $html, 1, $levels);
-	}
+        $html = $arguments['html'];
+        $levels = $arguments['levels'];
+        return static::dumpVariable($expressionToExamine, $html, 1, $levels);
+    }
 
 
-	/**
-	 * @param mixed $variable
-	 * @param boolean $html
-	 * @param integer $level
-	 * @param integer $levels
-	 * @return string
-	 */
-	protected static function dumpVariable($variable, $html, $level, $levels) {
-		$typeLabel = is_object($variable) ? get_class($variable) : gettype($variable);
+    /**
+     * @param mixed $variable
+     * @param boolean $html
+     * @param integer $level
+     * @param integer $levels
+     * @return string
+     */
+    protected static function dumpVariable($variable, $html, $level, $levels)
+    {
+        $typeLabel = is_object($variable) ? get_class($variable) : gettype($variable);
 
-		if (!$html) {
-			if (is_scalar($variable)) {
-				$string = sprintf('%s %s', $typeLabel, var_export($variable, TRUE)) . PHP_EOL;
-			} elseif (is_null($variable)) {
-				$string = 'null' . PHP_EOL;
-			} else {
-				$string = sprintf('%s: ', $typeLabel);
-				if ($level > $levels) {
-					$string .= '*Recursion limited*';
-				} else {
-					$string .= PHP_EOL;
-					foreach (static::getValuesOfNonScalarVariable($variable) as $property => $value) {
-						$string .= sprintf(
-							'%s"%s": %s',
-							str_repeat('  ', $level),
-							$property,
-							static::dumpVariable($value, $html, $level + 1, $levels)
-						);
-					}
-				}
-			}
-		} else {
-			if (is_scalar($variable) || is_null($variable)) {
-				$string = sprintf(
-					'<code>%s = %s</code>',
-					$typeLabel,
-					htmlspecialchars(var_export($variable, TRUE), ENT_COMPAT, 'UTF-8', FALSE)
-				);
-			} elseif (is_null($variable)) {
-				$string = 'null' . PHP_EOL;
-			} else {
-				$string = sprintf('<code>%s</code>', $typeLabel);
-				if ($level > $levels) {
-					$string .= '<i>Recursion limited</i>';
-				} else {
-					$string .= '<ul>';
-					foreach (static::getValuesOfNonScalarVariable($variable) as $property => $value) {
-						$string .= sprintf(
-							'<li>%s: %s</li>',
-							$property,
-							static::dumpVariable($value, $html, $level + 1, $levels)
-						);
-					}
-					$string .= '</ul>';
-				}
-			}
-		}
+        if (!$html) {
+            if (is_scalar($variable)) {
+                $string = sprintf('%s %s', $typeLabel, var_export($variable, true)) . PHP_EOL;
+            } elseif (is_null($variable)) {
+                $string = 'null' . PHP_EOL;
+            } else {
+                $string = sprintf('%s: ', $typeLabel);
+                if ($level > $levels) {
+                    $string .= '*Recursion limited*';
+                } else {
+                    $string .= PHP_EOL;
+                    foreach (static::getValuesOfNonScalarVariable($variable) as $property => $value) {
+                        $string .= sprintf(
+                            '%s"%s": %s',
+                            str_repeat('  ', $level),
+                            $property,
+                            static::dumpVariable($value, $html, $level + 1, $levels)
+                        );
+                    }
+                }
+            }
+        } else {
+            if (is_scalar($variable) || is_null($variable)) {
+                $string = sprintf(
+                    '<code>%s = %s</code>',
+                    $typeLabel,
+                    htmlspecialchars(var_export($variable, true), ENT_COMPAT, 'UTF-8', false)
+                );
+            } elseif (is_null($variable)) {
+                $string = 'null' . PHP_EOL;
+            } else {
+                $string = sprintf('<code>%s</code>', $typeLabel);
+                if ($level > $levels) {
+                    $string .= '<i>Recursion limited</i>';
+                } else {
+                    $string .= '<ul>';
+                    foreach (static::getValuesOfNonScalarVariable($variable) as $property => $value) {
+                        $string .= sprintf(
+                            '<li>%s: %s</li>',
+                            $property,
+                            static::dumpVariable($value, $html, $level + 1, $levels)
+                        );
+                    }
+                    $string .= '</ul>';
+                }
+            }
+        }
 
-		return $string;
-	}
+        return $string;
+    }
 
-	/**
-	 * @param mixed $variable
-	 * @retrurn array
-	 */
-	protected static function getValuesOfNonScalarVariable($variable) {
-		if ($variable instanceof \ArrayObject || is_array($variable)) {
-			return (array) $variable;
-		} elseif ($variable instanceof \Iterator) {
-			return iterator_to_array($variable);
-		} elseif (is_resource($variable)) {
-			return stream_get_meta_data($variable);
-		} elseif ($variable instanceof \DateTimeInterface) {
-			return [
-				'class' => get_class($variable),
-				'ISO8601' => $variable->format(\DateTime::ISO8601),
-				'UNIXTIME' => (integer) $variable->format('U')
-			];
-		} else {
-			$reflection = new \ReflectionObject($variable);
-			$properties = $reflection->getProperties();
-			$output = array();
-			foreach ($properties as $property) {
-				$propertyName = $property->getName();
-				$output[$propertyName] = VariableExtractor::extract($variable, $propertyName);
-			}
-			return $output;
-		}
-	}
-
+    /**
+     * @param mixed $variable
+     * @retrurn array
+     */
+    protected static function getValuesOfNonScalarVariable($variable)
+    {
+        if ($variable instanceof \ArrayObject || is_array($variable)) {
+            return (array) $variable;
+        } elseif ($variable instanceof \Iterator) {
+            return iterator_to_array($variable);
+        } elseif (is_resource($variable)) {
+            return stream_get_meta_data($variable);
+        } elseif ($variable instanceof \DateTimeInterface) {
+            return [
+                'class' => get_class($variable),
+                'ISO8601' => $variable->format(\DateTime::ISO8601),
+                'UNIXTIME' => (integer) $variable->format('U')
+            ];
+        } else {
+            $reflection = new \ReflectionObject($variable);
+            $properties = $reflection->getProperties();
+            $output = [];
+            foreach ($properties as $property) {
+                $propertyName = $property->getName();
+                $output[$propertyName] = VariableExtractor::extract($variable, $propertyName);
+            }
+            return $output;
+        }
+    }
 }

--- a/src/ViewHelpers/DefaultCaseViewHelper.php
+++ b/src/ViewHelpers/DefaultCaseViewHelper.php
@@ -17,35 +17,38 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class DefaultCaseViewHelper extends AbstractViewHelper {
+class DefaultCaseViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return string the contents of this view helper if no other "Case" view helper of the surrounding switch view helper matches
-	 * @throws ViewHelper\Exception
-	 * @api
-	 */
-	public function render() {
-		$viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
-		if (!$viewHelperVariableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
-			throw new ViewHelper\Exception('The "default case" View helper can only be used within a switch View helper', 1368112037);
-		}
-		return $this->renderChildren();
-	}
+    /**
+     * @return string the contents of this view helper if no other "Case" view helper of the surrounding switch view helper matches
+     * @throws ViewHelper\Exception
+     * @api
+     */
+    public function render()
+    {
+        $viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
+        if (!$viewHelperVariableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
+            throw new ViewHelper\Exception('The "default case" View helper can only be used within a switch View helper', 1368112037);
+        }
+        return $this->renderChildren();
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return '\'\'';
-	}
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '\'\'';
+    }
 }

--- a/src/ViewHelpers/ElseViewHelper.php
+++ b/src/ViewHelpers/ElseViewHelper.php
@@ -30,38 +30,41 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @see TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
  * @api
  */
-class ElseViewHelper extends AbstractViewHelper {
+class ElseViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('if', 'boolean', 'Condition expression conforming to Fluid boolean rules');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('if', 'boolean', 'Condition expression conforming to Fluid boolean rules');
+    }
 
-	/**
-	 * @return string the rendered string
-	 * @api
-	 */
-	public function render() {
-		return $this->renderChildren();
-	}
+    /**
+     * @return string the rendered string
+     * @api
+     */
+    public function render()
+    {
+        return $this->renderChildren();
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string|NULL
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return '\'\'';
-	}
-
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string|NULL
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '\'\'';
+    }
 }

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -60,82 +60,85 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * @api
  */
-class ForViewHelper extends AbstractViewHelper {
+class ForViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithRenderStatic;
-	
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    use CompileWithRenderStatic;
+    
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', TRUE);
-		$this->registerArgument('as', 'string', 'The name of the iteration variable', TRUE);
-		$this->registerArgument('key', 'string', 'Variable to assign array key to', FALSE);
-		$this->registerArgument('reverse', 'boolean', 'If TRUE, iterates in reverse', FALSE, FALSE);
-		$this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, isFirst, isLast, isEven, isOdd)');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', true);
+        $this->registerArgument('as', 'string', 'The name of the iteration variable', true);
+        $this->registerArgument('key', 'string', 'Variable to assign array key to', false);
+        $this->registerArgument('reverse', 'boolean', 'If TRUE, iterates in reverse', false, false);
+        $this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, isFirst, isLast, isEven, isOdd)');
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 * @throws ViewHelper\Exception
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		$templateVariableContainer = $renderingContext->getVariableProvider();
-		if ($arguments['each'] === NULL) {
-			return '';
-		}
-		if (is_object($arguments['each']) && !$arguments['each'] instanceof \Traversable) {
-			throw new ViewHelper\Exception('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
-		}
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     * @throws ViewHelper\Exception
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $templateVariableContainer = $renderingContext->getVariableProvider();
+        if ($arguments['each'] === null) {
+            return '';
+        }
+        if (is_object($arguments['each']) && !$arguments['each'] instanceof \Traversable) {
+            throw new ViewHelper\Exception('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
+        }
 
-		if ($arguments['reverse'] === TRUE) {
-			// array_reverse only supports arrays
-			if (is_object($arguments['each'])) {
-				/** @var $each \Traversable */
-				$each = $arguments['each'];
-				$arguments['each'] = iterator_to_array($each);
-			}
-			$arguments['each'] = array_reverse($arguments['each']);
-		}
-		$iterationData = array(
-			'index' => 0,
-			'cycle' => 1,
-			'total' => count($arguments['each'])
-		);
+        if ($arguments['reverse'] === true) {
+            // array_reverse only supports arrays
+            if (is_object($arguments['each'])) {
+                /** @var $each \Traversable */
+                $each = $arguments['each'];
+                $arguments['each'] = iterator_to_array($each);
+            }
+            $arguments['each'] = array_reverse($arguments['each']);
+        }
+        $iterationData = [
+            'index' => 0,
+            'cycle' => 1,
+            'total' => count($arguments['each'])
+        ];
 
-		$output = '';
-		foreach ($arguments['each'] as $keyValue => $singleElement) {
-			$templateVariableContainer->add($arguments['as'], $singleElement);
-			if ($arguments['key'] !== NULL) {
-				$templateVariableContainer->add($arguments['key'], $keyValue);
-			}
-			if ($arguments['iteration'] !== NULL) {
-				$iterationData['isFirst'] = $iterationData['cycle'] === 1;
-				$iterationData['isLast'] = $iterationData['cycle'] === $iterationData['total'];
-				$iterationData['isEven'] = $iterationData['cycle'] % 2 === 0;
-				$iterationData['isOdd'] = !$iterationData['isEven'];
-				$templateVariableContainer->add($arguments['iteration'], $iterationData);
-				$iterationData['index']++;
-				$iterationData['cycle']++;
-			}
-			$output .= $renderChildrenClosure();
-			$templateVariableContainer->remove($arguments['as']);
-			if ($arguments['key'] !== NULL) {
-				$templateVariableContainer->remove($arguments['key']);
-			}
-			if ($arguments['iteration'] !== NULL) {
-				$templateVariableContainer->remove($arguments['iteration']);
-			}
-		}
-		return $output;
-	}
+        $output = '';
+        foreach ($arguments['each'] as $keyValue => $singleElement) {
+            $templateVariableContainer->add($arguments['as'], $singleElement);
+            if ($arguments['key'] !== null) {
+                $templateVariableContainer->add($arguments['key'], $keyValue);
+            }
+            if ($arguments['iteration'] !== null) {
+                $iterationData['isFirst'] = $iterationData['cycle'] === 1;
+                $iterationData['isLast'] = $iterationData['cycle'] === $iterationData['total'];
+                $iterationData['isEven'] = $iterationData['cycle'] % 2 === 0;
+                $iterationData['isOdd'] = !$iterationData['isEven'];
+                $templateVariableContainer->add($arguments['iteration'], $iterationData);
+                $iterationData['index']++;
+                $iterationData['cycle']++;
+            }
+            $output .= $renderChildrenClosure();
+            $templateVariableContainer->remove($arguments['as']);
+            if ($arguments['key'] !== null) {
+                $templateVariableContainer->remove($arguments['key']);
+            }
+            if ($arguments['iteration'] !== null) {
+                $templateVariableContainer->remove($arguments['iteration']);
+            }
+        }
+        return $output;
+    }
 }

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -41,39 +41,40 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  *
  * @api
  */
-class CdataViewHelper extends AbstractViewHelper {
+class CdataViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithContentArgumentAndRenderStatic;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('value', 'mixed', 'The value to output');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('value', 'mixed', 'The value to output');
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param callable $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return string
-	 */
-	public static function renderStatic(
-		array $arguments,
-		\Closure $renderChildrenClosure,
-		RenderingContextInterface $renderingContext
-	) {
-		return sprintf('<![CDATA[%s]]>', $renderChildrenClosure());
-	}
-
+    /**
+     * @param array $arguments
+     * @param callable $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        return sprintf('<![CDATA[%s]]>', $renderChildrenClosure());
+    }
 }

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -33,71 +33,78 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class HtmlspecialcharsViewHelper extends AbstractViewHelper {
+class HtmlspecialcharsViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * Disable the output escaping interceptor so that the value is not htmlspecialchar'd twice
-	 *
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * Disable the output escaping interceptor so that the value is not htmlspecialchar'd twice
+     *
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('value', 'string', 'Value to format');
-		$this->registerArgument('keepQuotes', 'boolean', 'If TRUE quotes will not be replaced (ENT_NOQUOTES)', FALSE, FALSE);
-		$this->registerArgument('encoding', 'string', 'Encoding', FALSE, 'UTF-8');
-		$this->registerArgument('doubleEncode', 'boolean', 'If FALSE html entities will not be encoded', FALSE, TRUE);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('value', 'string', 'Value to format');
+        $this->registerArgument('keepQuotes', 'boolean', 'If TRUE quotes will not be replaced (ENT_NOQUOTES)', false, false);
+        $this->registerArgument('encoding', 'string', 'Encoding', false, 'UTF-8');
+        $this->registerArgument('doubleEncode', 'boolean', 'If FALSE html entities will not be encoded', false, true);
+    }
 
-	/**
-	 * Escapes special characters with their escaped counterparts as needed using PHPs htmlspecialchars() function.
-	 *
-	 * @return string the altered string
-	 * @see http://www.php.net/manual/function.htmlspecialchars.php
-	 * @api
-	 */
-	public function render() {
-		$value = $this->arguments['value'];
-		$keepQuotes = $this->arguments['keepQuotes'];
-		$encoding = $this->arguments['encoding'];
-		$doubleEncode = $this->arguments['doubleEncode'];
-		if ($value === NULL) {
-			$value = $this->renderChildren();
-		}
+    /**
+     * Escapes special characters with their escaped counterparts as needed using PHPs htmlspecialchars() function.
+     *
+     * @return string the altered string
+     * @see http://www.php.net/manual/function.htmlspecialchars.php
+     * @api
+     */
+    public function render()
+    {
+        $value = $this->arguments['value'];
+        $keepQuotes = $this->arguments['keepQuotes'];
+        $encoding = $this->arguments['encoding'];
+        $doubleEncode = $this->arguments['doubleEncode'];
+        if ($value === null) {
+            $value = $this->renderChildren();
+        }
 
-		if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
-			return $value;
-		}
-		$flags = $keepQuotes ? ENT_NOQUOTES : ENT_QUOTES;
+        if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            return $value;
+        }
+        $flags = $keepQuotes ? ENT_NOQUOTES : ENT_QUOTES;
 
-		return htmlspecialchars($value, $flags, $encoding, $doubleEncode);
-	}
+        return htmlspecialchars($value, $flags, $encoding, $doubleEncode);
+    }
 
-	/**
-	 * This ViewHelper is used a *lot* because it is used by the escape interceptor.
-	 * Therefore we render it to raw PHP code during compilation
-	 *
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		$valueVariableName = $compiler->variableName('value');
-		$initializationPhpCode .= sprintf('%1$s = (%2$s[\'value\'] !== NULL ? %2$s[\'value\'] : %3$s());', $valueVariableName, $argumentsName, $closureName) . chr(10);
+    /**
+     * This ViewHelper is used a *lot* because it is used by the escape interceptor.
+     * Therefore we render it to raw PHP code during compilation
+     *
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        $valueVariableName = $compiler->variableName('value');
+        $initializationPhpCode .= sprintf('%1$s = (%2$s[\'value\'] !== NULL ? %2$s[\'value\'] : %3$s());', $valueVariableName, $argumentsName, $closureName) . chr(10);
 
-		return sprintf('!is_string(%1$s) && !(is_object(%1$s) && method_exists(%1$s, \'__toString\')) ? %1$s : htmlspecialchars(%1$s, (%2$s[\'keepQuotes\'] ? ENT_NOQUOTES : ENT_QUOTES), %2$s[\'encoding\'], %2$s[\'doubleEncode\'])',
-			$valueVariableName, $argumentsName);
-	}
+        return sprintf(
+            '!is_string(%1$s) && !(is_object(%1$s) && method_exists(%1$s, \'__toString\')) ? %1$s : htmlspecialchars(%1$s, (%2$s[\'keepQuotes\'] ? ENT_NOQUOTES : ENT_QUOTES), %2$s[\'encoding\'], %2$s[\'doubleEncode\'])',
+            $valueVariableName,
+            $argumentsName
+        );
+    }
 }

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -47,28 +47,31 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  *
  * @api
  */
-class PrintfViewHelper extends AbstractViewHelper {
+class PrintfViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithContentArgumentAndRenderStatic;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('value', 'string', 'String to format');
-		$this->registerArgument('arguments', 'array', 'The arguments for vsprintf', FALSE, array());
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('value', 'string', 'String to format');
+        $this->registerArgument('arguments', 'array', 'The arguments for vsprintf', false, []);
+    }
 
-	/**
-	 * Applies vsprintf() on the specified value.
-	 *
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param \TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
-	 * @return string
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		return vsprintf($renderChildrenClosure(), $arguments['arguments']);
-	}
+    /**
+     * Applies vsprintf() on the specified value.
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param \TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        return vsprintf($renderChildrenClosure(), $arguments['arguments']);
+    }
 }

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -44,47 +44,50 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  *
  * @api
  */
-class RawViewHelper extends AbstractViewHelper {
+class RawViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithContentArgumentAndRenderStatic;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeChildren = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('value', 'mixed', 'The value to output');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('value', 'mixed', 'The value to output');
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		return $renderChildrenClosure();
-	}
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        return $renderChildrenClosure();
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return mixed
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return sprintf('%s()', $closureName);
-	}
-
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return mixed
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return sprintf('%s()', $closureName);
+    }
 }

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -73,91 +73,94 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * @api
  */
-class GroupedForViewHelper extends AbstractViewHelper {
+class GroupedForViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithRenderStatic;
+    use CompileWithRenderStatic;
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', TRUE);
-		$this->registerArgument('as', 'string', 'The name of the iteration variable', TRUE);
-		$this->registerArgument('groupBy', 'string', 'Group by this property', TRUE);
-		$this->registerArgument('groupKey', 'string', 'The name of the variable to store the current group', FALSE, 'groupKey');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', true);
+        $this->registerArgument('as', 'string', 'The name of the iteration variable', true);
+        $this->registerArgument('groupBy', 'string', 'Group by this property', true);
+        $this->registerArgument('groupKey', 'string', 'The name of the variable to store the current group', false, 'groupKey');
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
-	{
-		$each = $arguments['each'];
-		$as = $arguments['as'];
-		$groupBy = $arguments['groupBy'];
-		$groupKey = $arguments['groupKey'];
-		$output = '';
-		if ($each === NULL) {
-			return '';
-		}
-		if (is_object($each)) {
-			if (!$each instanceof \Traversable) {
-				throw new ViewHelper\Exception('GroupedForViewHelper only supports arrays and objects implementing \Traversable interface', 1253108907);
-			}
-			$each = iterator_to_array($each);
-		}
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $each = $arguments['each'];
+        $as = $arguments['as'];
+        $groupBy = $arguments['groupBy'];
+        $groupKey = $arguments['groupKey'];
+        $output = '';
+        if ($each === null) {
+            return '';
+        }
+        if (is_object($each)) {
+            if (!$each instanceof \Traversable) {
+                throw new ViewHelper\Exception('GroupedForViewHelper only supports arrays and objects implementing \Traversable interface', 1253108907);
+            }
+            $each = iterator_to_array($each);
+        }
 
-		$groups = static::groupElements($each, $groupBy);
+        $groups = static::groupElements($each, $groupBy);
 
-		$templateVariableContainer = $renderingContext->getVariableProvider();
-		foreach ($groups['values'] as $currentGroupIndex => $group) {
-			$templateVariableContainer->add($groupKey, $groups['keys'][$currentGroupIndex]);
-			$templateVariableContainer->add($as, $group);
-			$output .= $renderChildrenClosure();
-			$templateVariableContainer->remove($groupKey);
-			$templateVariableContainer->remove($as);
-		}
-		return $output;
-	}
+        $templateVariableContainer = $renderingContext->getVariableProvider();
+        foreach ($groups['values'] as $currentGroupIndex => $group) {
+            $templateVariableContainer->add($groupKey, $groups['keys'][$currentGroupIndex]);
+            $templateVariableContainer->add($as, $group);
+            $output .= $renderChildrenClosure();
+            $templateVariableContainer->remove($groupKey);
+            $templateVariableContainer->remove($as);
+        }
+        return $output;
+    }
 
 
-	/**
-	 * Groups the given array by the specified groupBy property.
-	 *
-	 * @param array $elements The array / traversable object to be grouped
-	 * @param string $groupBy Group by this property
-	 * @return array The grouped array in the form array('keys' => array('key1' => [key1value], 'key2' => [key2value], ...), 'values' => array('key1' => array([key1value] => [element1]), ...), ...)
-	 * @throws ViewHelper\Exception
-	 */
-	protected static function groupElements(array $elements, $groupBy) {
-		$extractor = new VariableExtractor();
-		$groups = array('keys' => array(), 'values' => array());
-		foreach ($elements as $key => $value) {
-			if (is_array($value)) {
-				$currentGroupIndex = isset($value[$groupBy]) ? $value[$groupBy] : NULL;
-			} elseif (is_object($value)) {
-				$currentGroupIndex = $extractor->getByPath($value, $groupBy);
-			} else {
-				throw new ViewHelper\Exception('GroupedForViewHelper only supports multi-dimensional arrays and objects', 1253120365);
-			}
-			$currentGroupKeyValue = $currentGroupIndex;
-			if ($currentGroupIndex instanceof \DateTime) {
-				$currentGroupIndex = $currentGroupIndex->format(\DateTime::RFC850);
-			} elseif (is_object($currentGroupIndex)) {
-				$currentGroupIndex = spl_object_hash($currentGroupIndex);
-			}
-			$groups['keys'][$currentGroupIndex] = $currentGroupKeyValue;
-			$groups['values'][$currentGroupIndex][$key] = $value;
-		}
-		return $groups;
-	}
+    /**
+     * Groups the given array by the specified groupBy property.
+     *
+     * @param array $elements The array / traversable object to be grouped
+     * @param string $groupBy Group by this property
+     * @return array The grouped array in the form array('keys' => array('key1' => [key1value], 'key2' => [key2value], ...), 'values' => array('key1' => array([key1value] => [element1]), ...), ...)
+     * @throws ViewHelper\Exception
+     */
+    protected static function groupElements(array $elements, $groupBy)
+    {
+        $extractor = new VariableExtractor();
+        $groups = ['keys' => [], 'values' => []];
+        foreach ($elements as $key => $value) {
+            if (is_array($value)) {
+                $currentGroupIndex = isset($value[$groupBy]) ? $value[$groupBy] : null;
+            } elseif (is_object($value)) {
+                $currentGroupIndex = $extractor->getByPath($value, $groupBy);
+            } else {
+                throw new ViewHelper\Exception('GroupedForViewHelper only supports multi-dimensional arrays and objects', 1253120365);
+            }
+            $currentGroupKeyValue = $currentGroupIndex;
+            if ($currentGroupIndex instanceof \DateTime) {
+                $currentGroupIndex = $currentGroupIndex->format(\DateTime::RFC850);
+            } elseif (is_object($currentGroupIndex)) {
+                $currentGroupIndex = spl_object_hash($currentGroupIndex);
+            }
+            $groups['keys'][$currentGroupIndex] = $currentGroupKeyValue;
+            $groups['values'][$currentGroupIndex][$key] = $value;
+        }
+        return $groups;
+    }
 }

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -79,20 +79,21 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  *
  * @api
  */
-class IfViewHelper extends AbstractConditionViewHelper {
+class IfViewHelper extends AbstractConditionViewHelper
+{
 
-	/**
-	 * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
-	 *
-	 * @return string the rendered string
-	 * @api
-	 */
-	public function render() {
-		if ($this->arguments['condition']) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
-	}
-
+    /**
+     * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+     *
+     * @return string the rendered string
+     * @api
+     */
+    public function render()
+    {
+        if ($this->arguments['condition']) {
+            return $this->renderThenChild();
+        } else {
+            return $this->renderElseChild();
+        }
+    }
 }

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -26,46 +26,49 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
  *
  * @api
  */
-class LayoutViewHelper extends AbstractViewHelper {
+class LayoutViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * Initialize arguments
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('name', 'string', 'Name of layout to use. If none given, "Default" is used.');
-	}
+    /**
+     * Initialize arguments
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('name', 'string', 'Name of layout to use. If none given, "Default" is used.');
+    }
 
-	/**
-	 * On the post parse event, add the "layoutName" variable to the variable container so it can be used by the TemplateView.
-	 *
-	 * @param ViewHelperNode $node
-	 * @param array $arguments
-	 * @param VariableProviderInterface $variableContainer
-	 * @return void
-	 */
-	public static function postParseEvent(
-		ViewHelperNode $node,
-		array $arguments,
-		VariableProviderInterface $variableContainer
-	) {
-		if (isset($arguments['name'])) {
-			$layoutNameNode = $arguments['name'];
-		} else {
-			$layoutNameNode = 'Default';
-		}
+    /**
+     * On the post parse event, add the "layoutName" variable to the variable container so it can be used by the TemplateView.
+     *
+     * @param ViewHelperNode $node
+     * @param array $arguments
+     * @param VariableProviderInterface $variableContainer
+     * @return void
+     */
+    public static function postParseEvent(
+        ViewHelperNode $node,
+        array $arguments,
+        VariableProviderInterface $variableContainer
+    ) {
+        if (isset($arguments['name'])) {
+            $layoutNameNode = $arguments['name'];
+        } else {
+            $layoutNameNode = 'Default';
+        }
 
-		$variableContainer->add('layoutName', $layoutNameNode);
-	}
+        $variableContainer->add('layoutName', $layoutNameNode);
+    }
 
-	/**
-	 * This tag will not be rendered at all.
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function render() {
-	}
+    /**
+     * This tag will not be rendered at all.
+     *
+     * @return void
+     * @api
+     */
+    public function render()
+    {
+    }
 }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -13,47 +13,48 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
 /**
  * If content is empty use alternative text
  */
-class OrViewHelper extends AbstractViewHelper {
+class OrViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithContentArgumentAndRenderStatic;
 
-	/**
-	 * Initialize
-	 *
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('content', 'mixed', 'Content to check if empty');
-		$this->registerArgument('alternative', 'mixed', 'Alternative if content is empty');
-		$this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf');
-	}
+    /**
+     * Initialize
+     *
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('content', 'mixed', 'Content to check if empty');
+        $this->registerArgument('alternative', 'mixed', 'Alternative if content is empty');
+        $this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf');
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $renderChildrenClosure
-	 * @param RenderingContextInterface $renderingContext
-	 * @return mixed
-	 */
-	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
-		$alternative = $arguments['alternative'];
-		$arguments = (array) $arguments['arguments'];
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $alternative = $arguments['alternative'];
+        $arguments = (array) $arguments['arguments'];
 
-		if (empty($arguments)) {
-			$arguments = NULL;
-		}
+        if (empty($arguments)) {
+            $arguments = null;
+        }
 
-		$content = $renderChildrenClosure();
+        $content = $renderChildrenClosure();
 
-		if (NULL === $content) {
-			$content = $alternative;
-		}
+        if (null === $content) {
+            $content = $alternative;
+        }
 
-		if (FALSE === empty($content)) {
-			$content = NULL !== $arguments ? vsprintf($content, $arguments) : $content;
-		}
+        if (false === empty($content)) {
+            $content = null !== $arguments ? vsprintf($content, $arguments) : $content;
+        }
 
-		return $content;
-	}
-
-
+        return $content;
+    }
 }

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -81,69 +81,71 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class RenderViewHelper extends AbstractViewHelper {
+class RenderViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('section', 'string', 'Section to render - combine with partial to render section in partial');
-		$this->registerArgument('partial', 'string', 'Partial to render, with or without section');
-		$this->registerArgument('delegate', 'string', 'Optional PHP class name of a permanent, included-in-app ParsedTemplateInterface implementation to override partial/section');
-		$this->registerArgument('arguments', 'array', 'Array of variables to be transferred. Use {_all} for all variables', FALSE, array());
-		$this->registerArgument('optional', 'boolean', 'If TRUE, considers the *section* optional. Partial never is.', FALSE, FALSE);
-		$this->registerArgument('default', 'mixed', 'Value (usually string) to be displayed if the section or partial does not exist');
-		$this->registerArgument('contentAs', 'string', 'If used, renders the child content and adds it as a template variable with this name for use in the partial/section');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('section', 'string', 'Section to render - combine with partial to render section in partial');
+        $this->registerArgument('partial', 'string', 'Partial to render, with or without section');
+        $this->registerArgument('delegate', 'string', 'Optional PHP class name of a permanent, included-in-app ParsedTemplateInterface implementation to override partial/section');
+        $this->registerArgument('arguments', 'array', 'Array of variables to be transferred. Use {_all} for all variables', false, []);
+        $this->registerArgument('optional', 'boolean', 'If TRUE, considers the *section* optional. Partial never is.', false, false);
+        $this->registerArgument('default', 'mixed', 'Value (usually string) to be displayed if the section or partial does not exist');
+        $this->registerArgument('contentAs', 'string', 'If used, renders the child content and adds it as a template variable with this name for use in the partial/section');
+    }
 
-	/**
-	 * Renders the content.
-	 *
-	 * @return string
-	 * @throws \InvalidArgumentException
-	 * @api
-	 */
-	public function render() {
-		$section = $this->arguments['section'];
-		$partial = $this->arguments['partial'];
-		$arguments = (array) $this->arguments['arguments'];
-		$optional = (boolean) $this->arguments['optional'];
-		$contentAs = $this->arguments['contentAs'];
-		$delegate = $this->arguments['delegate'];
-		$tagContent = $this->renderChildren();
+    /**
+     * Renders the content.
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     * @api
+     */
+    public function render()
+    {
+        $section = $this->arguments['section'];
+        $partial = $this->arguments['partial'];
+        $arguments = (array) $this->arguments['arguments'];
+        $optional = (boolean) $this->arguments['optional'];
+        $contentAs = $this->arguments['contentAs'];
+        $delegate = $this->arguments['delegate'];
+        $tagContent = $this->renderChildren();
 
-		if ($contentAs !== NULL) {
-			$arguments[$contentAs] = $tagContent;
-		}
+        if ($contentAs !== null) {
+            $arguments[$contentAs] = $tagContent;
+        }
 
-		$content = '';
-		if ($delegate !== NULL) {
-			if (!is_a($delegate, ParsedTemplateInterface::class, TRUE)) {
-				throw new \InvalidArgumentException(sprintf('Cannot render %s - must implement ParsedTemplateInterface!', $delegate));
-			}
-			$renderingContext = clone $this->renderingContext;
-			$renderingContext->getVariableProvider()->setSource($arguments);
-			$content = (new $delegate())->render($renderingContext);
-		} elseif ($partial !== NULL) {
-			$content = $this->viewHelperVariableContainer->getView()->renderPartial($partial, $section, $arguments, $optional);
-		} elseif ($section !== NULL) {
-			$content = $this->viewHelperVariableContainer->getView()->renderSection($section, $arguments, $optional);
-		} elseif (!$optional) {
-			throw new \InvalidArgumentException('ViewHelper f:render called without either argument section, partial or delegate and optional flag is false');
-		}
-		// Replace empty content with default value. If default is
-		// not set, NULL is returned and cast to a new, empty string
-		// outside of this ViewHelper.
-		if ($content === '') {
-			$content = isset($this->arguments['default']) ? $this->arguments['default'] : $tagContent;
-		}
-		return $content;
-	}
-
+        $content = '';
+        if ($delegate !== null) {
+            if (!is_a($delegate, ParsedTemplateInterface::class, true)) {
+                throw new \InvalidArgumentException(sprintf('Cannot render %s - must implement ParsedTemplateInterface!', $delegate));
+            }
+            $renderingContext = clone $this->renderingContext;
+            $renderingContext->getVariableProvider()->setSource($arguments);
+            $content = (new $delegate())->render($renderingContext);
+        } elseif ($partial !== null) {
+            $content = $this->viewHelperVariableContainer->getView()->renderPartial($partial, $section, $arguments, $optional);
+        } elseif ($section !== null) {
+            $content = $this->viewHelperVariableContainer->getView()->renderSection($section, $arguments, $optional);
+        } elseif (!$optional) {
+            throw new \InvalidArgumentException('ViewHelper f:render called without either argument section, partial or delegate and optional flag is false');
+        }
+        // Replace empty content with default value. If default is
+        // not set, NULL is returned and cast to a new, empty string
+        // outside of this ViewHelper.
+        if ($content === '') {
+            $content = isset($this->arguments['default']) ? $this->arguments['default'] : $tagContent;
+        }
+        return $content;
+    }
 }

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -55,67 +55,72 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
  *
  * @api
  */
-class SectionViewHelper extends AbstractViewHelper {
+class SectionViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * Initialize the arguments.
-	 *
-	 * @return void
-	 * @api
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('name', 'string', 'Name of the section', TRUE);
-	}
+    /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('name', 'string', 'Name of the section', true);
+    }
 
-	/**
-	 * Save the associated ViewHelper node in a static public class variable.
-	 * called directly after the ViewHelper was built.
-	 *
-	 * @param ViewHelperNode $node
-	 * @param TextNode[] $arguments
-	 * @param VariableProviderInterface $variableContainer
-	 * @return void
-	 */
-	public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer) {
-		/** @var $nameArgument TextNode */
-		$nameArgument = $arguments['name'];
-		$sectionName = $nameArgument->getText();
-		$sections = $variableContainer['1457379500_sections'] ? $variableContainer['1457379500_sections'] : array();
-		$sections[$sectionName] = $node;
-		$variableContainer['1457379500_sections'] = $sections;
-	}
+    /**
+     * Save the associated ViewHelper node in a static public class variable.
+     * called directly after the ViewHelper was built.
+     *
+     * @param ViewHelperNode $node
+     * @param TextNode[] $arguments
+     * @param VariableProviderInterface $variableContainer
+     * @return void
+     */
+    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer)
+    {
+        /** @var $nameArgument TextNode */
+        $nameArgument = $arguments['name'];
+        $sectionName = $nameArgument->getText();
+        $sections = $variableContainer['1457379500_sections'] ? $variableContainer['1457379500_sections'] : [];
+        $sections[$sectionName] = $node;
+        $variableContainer['1457379500_sections'] = $sections;
+    }
 
-	/**
-	 * Rendering directly returns all child nodes.
-	 *
-	 * @return string HTML String of all child nodes.
-	 * @api
-	 */
-	public function render() {
-		$content = '';
-		if ($this->viewHelperVariableContainer->exists(SectionViewHelper::class, 'isCurrentlyRenderingSection')) {
-			$this->viewHelperVariableContainer->remove(SectionViewHelper::class, 'isCurrentlyRenderingSection');
-			$content = $this->renderChildren();
-		}
-		return $content;
-	}
+    /**
+     * Rendering directly returns all child nodes.
+     *
+     * @return string HTML String of all child nodes.
+     * @api
+     */
+    public function render()
+    {
+        $content = '';
+        if ($this->viewHelperVariableContainer->exists(SectionViewHelper::class, 'isCurrentlyRenderingSection')) {
+            $this->viewHelperVariableContainer->remove(SectionViewHelper::class, 'isCurrentlyRenderingSection');
+            $content = $this->renderChildren();
+        }
+        return $content;
+    }
 
-	/**
-	 * The inner contents of a section should not be rendered.
-	 *
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return '\'\'';
-	}
+    /**
+     * The inner contents of a section should not be rendered.
+     *
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '\'\'';
+    }
 }

--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -35,17 +35,18 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  * text</div></div></div>
  * </output>
  */
-class SpacelessViewHelper extends AbstractViewHelper {
+class SpacelessViewHelper extends AbstractViewHelper
+{
 
-	use CompileWithRenderStatic;
+    use CompileWithRenderStatic;
 
-	/**
-	 * @param array $arguments
-	 * @param \Closure $childClosure
-	 * @param RenderingContextInterface $renderingContext
-	 */
-	public static function renderStatic(array $arguments, \Closure $childClosure, RenderingContextInterface $renderingContext) {
-		return trim(preg_replace('/\\>\\s+\\</', '><', $childClosure()));
-	}
-
+    /**
+     * @param array $arguments
+     * @param \Closure $childClosure
+     * @param RenderingContextInterface $renderingContext
+     */
+    public static function renderStatic(array $arguments, \Closure $childClosure, RenderingContextInterface $renderingContext)
+    {
+        return trim(preg_replace('/\\>\\s+\\</', '><', $childClosure()));
+    }
 }

--- a/src/ViewHelpers/SwitchViewHelper.php
+++ b/src/ViewHelpers/SwitchViewHelper.php
@@ -38,162 +38,170 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class SwitchViewHelper extends AbstractViewHelper {
+class SwitchViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * @var mixed
-	 */
-	protected $backupSwitchExpression = NULL;
+    /**
+     * @var mixed
+     */
+    protected $backupSwitchExpression = null;
 
-	/**
-	 * @var boolean
-	 */
-	protected $backupBreakState = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $backupBreakState = false;
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		parent::initializeArguments();
-		$this->registerArgument('expression', 'mixed', 'Expression to switch', TRUE);
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('expression', 'mixed', 'Expression to switch', true);
+    }
 
-	/**
-	 * @return string the rendered string
-	 * @api
-	 */
-	public function render() {
-		$expression = $this->arguments['expression'];
-		$this->backupSwitchState();
-		$variableContainer = $this->renderingContext->getViewHelperVariableContainer();
+    /**
+     * @return string the rendered string
+     * @api
+     */
+    public function render()
+    {
+        $expression = $this->arguments['expression'];
+        $this->backupSwitchState();
+        $variableContainer = $this->renderingContext->getViewHelperVariableContainer();
 
-		$variableContainer->addOrUpdate(SwitchViewHelper::class, 'switchExpression', $expression);
-		$variableContainer->addOrUpdate(SwitchViewHelper::class, 'break', FALSE);
+        $variableContainer->addOrUpdate(SwitchViewHelper::class, 'switchExpression', $expression);
+        $variableContainer->addOrUpdate(SwitchViewHelper::class, 'break', false);
 
-		$content = $this->retrieveContentFromChildNodes($this->childNodes);
+        $content = $this->retrieveContentFromChildNodes($this->childNodes);
 
-		if ($variableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
-			$variableContainer->remove(SwitchViewHelper::class, 'switchExpression');
-		}
-		if ($variableContainer->exists(SwitchViewHelper::class, 'break')) {
-			$variableContainer->remove(SwitchViewHelper::class, 'break');
-		}
+        if ($variableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
+            $variableContainer->remove(SwitchViewHelper::class, 'switchExpression');
+        }
+        if ($variableContainer->exists(SwitchViewHelper::class, 'break')) {
+            $variableContainer->remove(SwitchViewHelper::class, 'break');
+        }
 
-		$this->restoreSwitchState();
-		return $content;
-	}
+        $this->restoreSwitchState();
+        return $content;
+    }
 
-	/**
-	 * @param NodeInterface[] $childNodes
-	 * @return mixed
-	 */
-	protected function retrieveContentFromChildNodes(array $childNodes) {
-		$content = NULL;
-		$defaultCaseViewHelperNode = NULL;
-		foreach ($childNodes as $childNode) {
-			if ($this->isDefaultCaseNode($childNode)) {
-				$defaultCaseViewHelperNode = $childNode;
-			}
-			if (!$this->isCaseNode($childNode)) {
-				continue;
-			}
-			$content = $childNode->evaluate($this->renderingContext);
-			if ($this->viewHelperVariableContainer->get(SwitchViewHelper::class, 'break') === TRUE) {
-				$defaultCaseViewHelperNode = NULL;
-				break;
-			}
-		}
+    /**
+     * @param NodeInterface[] $childNodes
+     * @return mixed
+     */
+    protected function retrieveContentFromChildNodes(array $childNodes)
+    {
+        $content = null;
+        $defaultCaseViewHelperNode = null;
+        foreach ($childNodes as $childNode) {
+            if ($this->isDefaultCaseNode($childNode)) {
+                $defaultCaseViewHelperNode = $childNode;
+            }
+            if (!$this->isCaseNode($childNode)) {
+                continue;
+            }
+            $content = $childNode->evaluate($this->renderingContext);
+            if ($this->viewHelperVariableContainer->get(SwitchViewHelper::class, 'break') === true) {
+                $defaultCaseViewHelperNode = null;
+                break;
+            }
+        }
 
-		if ($defaultCaseViewHelperNode !== NULL) {
-			$content = $defaultCaseViewHelperNode->evaluate($this->renderingContext);
-		}
-		return $content;
-	}
+        if ($defaultCaseViewHelperNode !== null) {
+            $content = $defaultCaseViewHelperNode->evaluate($this->renderingContext);
+        }
+        return $content;
+    }
 
-	/**
-	 * @param NodeInterface $node
-	 * @return boolean
-	 */
-	protected function isDefaultCaseNode(NodeInterface $node) {
-		return ($node instanceof ViewHelperNode && $node->getViewHelperClassName() === DefaultCaseViewHelper::class);
-	}
+    /**
+     * @param NodeInterface $node
+     * @return boolean
+     */
+    protected function isDefaultCaseNode(NodeInterface $node)
+    {
+        return ($node instanceof ViewHelperNode && $node->getViewHelperClassName() === DefaultCaseViewHelper::class);
+    }
 
-	/**
-	 * @param NodeInterface $node
-	 * @return boolean
-	 */
-	protected function isCaseNode(NodeInterface $node) {
-		return ($node instanceof ViewHelperNode && $node->getViewHelperClassName() === CaseViewHelper::class);
-	}
+    /**
+     * @param NodeInterface $node
+     * @return boolean
+     */
+    protected function isCaseNode(NodeInterface $node)
+    {
+        return ($node instanceof ViewHelperNode && $node->getViewHelperClassName() === CaseViewHelper::class);
+    }
 
-	/**
-	 * Backups "switch expression" and "break" state of a possible parent switch ViewHelper to support nesting
-	 *
-	 * @return void
-	 */
-	protected function backupSwitchState() {
-		if ($this->renderingContext->getViewHelperVariableContainer()->exists(SwitchViewHelper::class, 'switchExpression')) {
-			$this->backupSwitchExpression = $this->renderingContext->getViewHelperVariableContainer()->get(SwitchViewHelper::class, 'switchExpression');
-		}
-		if ($this->renderingContext->getViewHelperVariableContainer()->exists(SwitchViewHelper::class, 'break')) {
-			$this->backupBreakState = $this->renderingContext->getViewHelperVariableContainer()->get(SwitchViewHelper::class, 'break');
-		}
-	}
+    /**
+     * Backups "switch expression" and "break" state of a possible parent switch ViewHelper to support nesting
+     *
+     * @return void
+     */
+    protected function backupSwitchState()
+    {
+        if ($this->renderingContext->getViewHelperVariableContainer()->exists(SwitchViewHelper::class, 'switchExpression')) {
+            $this->backupSwitchExpression = $this->renderingContext->getViewHelperVariableContainer()->get(SwitchViewHelper::class, 'switchExpression');
+        }
+        if ($this->renderingContext->getViewHelperVariableContainer()->exists(SwitchViewHelper::class, 'break')) {
+            $this->backupBreakState = $this->renderingContext->getViewHelperVariableContainer()->get(SwitchViewHelper::class, 'break');
+        }
+    }
 
-	/**
-	 * Restores "switch expression" and "break" states that might have been backed up in backupSwitchState() before
-	 *
-	 * @return void
-	 */
-	protected function restoreSwitchState() {
-		if ($this->backupSwitchExpression !== NULL) {
-			$this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'switchExpression', $this->backupSwitchExpression);
-		}
-		if ($this->backupBreakState !== FALSE) {
-			$this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', TRUE);
-		}
-	}
+    /**
+     * Restores "switch expression" and "break" states that might have been backed up in backupSwitchState() before
+     *
+     * @return void
+     */
+    protected function restoreSwitchState()
+    {
+        if ($this->backupSwitchExpression !== null) {
+            $this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'switchExpression', $this->backupSwitchExpression);
+        }
+        if ($this->backupBreakState !== false) {
+            $this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', true);
+        }
+    }
 
-	/**
-	 * Compiles the node structure to a native switch
-	 * statement which evaluates closures for each
-	 * case comparison and renders child node closures
-	 * only when value matches.
-	 *
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		$phpCode = 'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
-			'switch ($arguments[\'expression\']) {' . PHP_EOL;
-		$expressionEvaluationClosureName = $compiler->variableName('switchExpressionClosure');
-		foreach ($node->getChildNodes() as $childNode) {
-			if ($this->isDefaultCaseNode($childNode)) {
-				$childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
-				$phpCode .= sprintf('default: return call_user_func(%s);', $childrenClosure) . PHP_EOL;
-			} elseif ($this->isCaseNode($childNode)) {
-				$valueClosure = $compiler->wrapViewHelperNodeArgumentEvaluationInClosure($childNode, 'value');
-				$childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
-				$phpCode .= sprintf(
-					'case call_user_func(%s): return call_user_func(%s);',
-					$valueClosure,
-					$childrenClosure,
-					$compiler->getNodeConverter()->convert($childNode)
-				) . PHP_EOL;
-			}
-		}
-		$phpCode .= '}' . PHP_EOL;
-		$phpCode .= sprintf('}, array(%s))', $argumentsName);
-		return $phpCode;
-	}
-
+    /**
+     * Compiles the node structure to a native switch
+     * statement which evaluates closures for each
+     * case comparison and renders child node closures
+     * only when value matches.
+     *
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        $phpCode = 'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+            'switch ($arguments[\'expression\']) {' . PHP_EOL;
+        $expressionEvaluationClosureName = $compiler->variableName('switchExpressionClosure');
+        foreach ($node->getChildNodes() as $childNode) {
+            if ($this->isDefaultCaseNode($childNode)) {
+                $childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
+                $phpCode .= sprintf('default: return call_user_func(%s);', $childrenClosure) . PHP_EOL;
+            } elseif ($this->isCaseNode($childNode)) {
+                $valueClosure = $compiler->wrapViewHelperNodeArgumentEvaluationInClosure($childNode, 'value');
+                $childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
+                $phpCode .= sprintf(
+                    'case call_user_func(%s): return call_user_func(%s);',
+                    $valueClosure,
+                    $childrenClosure,
+                    $compiler->getNodeConverter()->convert($childNode)
+                ) . PHP_EOL;
+            }
+        }
+        $phpCode .= '}' . PHP_EOL;
+        $phpCode .= sprintf('}, array(%s))', $argumentsName);
+        return $phpCode;
+    }
 }

--- a/src/ViewHelpers/ThenViewHelper.php
+++ b/src/ViewHelpers/ThenViewHelper.php
@@ -16,33 +16,35 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @see \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
  * @api
  */
-class ThenViewHelper extends AbstractViewHelper {
+class ThenViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @var boolean
-	 */
-	protected $escapeOutput = FALSE;
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
-	/**
-	 * Just render everything.
-	 *
-	 * @return string the rendered string
-	 * @api
-	 */
-	public function render() {
-		return $this->renderChildren();
-	}
+    /**
+     * Just render everything.
+     *
+     * @return string the rendered string
+     * @api
+     */
+    public function render()
+    {
+        return $this->renderChildren();
+    }
 
-	/**
-	 * @param string $argumentsName
-	 * @param string $closureName
-	 * @param string $initializationPhpCode
-	 * @param ViewHelperNode $node
-	 * @param TemplateCompiler $compiler
-	 * @return string
-	 */
-	public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler) {
-		return '\'\'';
-	}
-
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '\'\'';
+    }
 }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -14,62 +14,66 @@ namespace TYPO3Fluid\Fluid\Tests;
  *
  * @api
  */
-abstract class BaseTestCase extends \PHPUnit_Framework_TestCase {
+abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+{
 
-	/**
-	 * Enable or disable the backup and restoration of static attributes.
-	 * @var boolean
-	 */
-	protected $backupStaticAttributes = FALSE;
+    /**
+     * Enable or disable the backup and restoration of static attributes.
+     * @var boolean
+     */
+    protected $backupStaticAttributes = false;
 
-	/**
-	 * Returns a mock object which allows for calling protected methods and access
-	 * of protected properties.
-	 *
-	 * @param string $originalClassName Full qualified name of the original class
-	 * @param array $methods
-	 * @param array $arguments
-	 * @param string $mockClassName
-	 * @param boolean $callOriginalConstructor
-	 * @param boolean $callOriginalClone
-	 * @param boolean $callAutoload
-	 * @return \PHPUnit_Framework_MockObject_MockObject
-	 * @api
-	 */
-	protected function getAccessibleMock($originalClassName, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE) {
-		return $this->getMock($this->buildAccessibleProxy($originalClassName), $methods, $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload);
-	}
+    /**
+     * Returns a mock object which allows for calling protected methods and access
+     * of protected properties.
+     *
+     * @param string $originalClassName Full qualified name of the original class
+     * @param array $methods
+     * @param array $arguments
+     * @param string $mockClassName
+     * @param boolean $callOriginalConstructor
+     * @param boolean $callOriginalClone
+     * @param boolean $callAutoload
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @api
+     */
+    protected function getAccessibleMock($originalClassName, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true)
+    {
+        return $this->getMock($this->buildAccessibleProxy($originalClassName), $methods, $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload);
+    }
 
-	/**
-	 * Returns a mock object which allows for calling protected methods and access
-	 * of protected properties.
-	 *
-	 * @param string $originalClassName Full qualified name of the original class
-	 * @param array $arguments
-	 * @param string $mockClassName
-	 * @param boolean $callOriginalConstructor
-	 * @param boolean $callOriginalClone
-	 * @param boolean $callAutoload
-	 * @return \PHPUnit_Framework_MockObject_MockObject
-	 * @api
-	 */
-	protected function getAccessibleMockForAbstractClass($originalClassName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE) {
-		return $this->getMockForAbstractClass($this->buildAccessibleProxy($originalClassName), $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload);
-	}
+    /**
+     * Returns a mock object which allows for calling protected methods and access
+     * of protected properties.
+     *
+     * @param string $originalClassName Full qualified name of the original class
+     * @param array $arguments
+     * @param string $mockClassName
+     * @param boolean $callOriginalConstructor
+     * @param boolean $callOriginalClone
+     * @param boolean $callAutoload
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @api
+     */
+    protected function getAccessibleMockForAbstractClass($originalClassName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true)
+    {
+        return $this->getMockForAbstractClass($this->buildAccessibleProxy($originalClassName), $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload);
+    }
 
-	/**
-	 * Creates a proxy class of the specified class which allows
-	 * for calling even protected methods and access of protected properties.
-	 *
-	 * @param string $className Full qualified name of the original class
-	 * @return string Full qualified name of the built class
-	 * @api
-	 */
-	protected function buildAccessibleProxy($className) {
-		$accessibleClassName = 'AccessibleTestProxy' . md5(uniqid(mt_rand(), TRUE));
-		$class = new \ReflectionClass($className);
-		$abstractModifier = $class->isAbstract() ? 'abstract ' : '';
-		eval('
+    /**
+     * Creates a proxy class of the specified class which allows
+     * for calling even protected methods and access of protected properties.
+     *
+     * @param string $className Full qualified name of the original class
+     * @return string Full qualified name of the built class
+     * @api
+     */
+    protected function buildAccessibleProxy($className)
+    {
+        $accessibleClassName = 'AccessibleTestProxy' . md5(uniqid(mt_rand(), true));
+        $class = new \ReflectionClass($className);
+        $abstractModifier = $class->isAbstract() ? 'abstract ' : '';
+        eval('
 			' . $abstractModifier . 'class ' . $accessibleClassName . ' extends ' . $className . ' {
 				public function _call($methodName) {
 					return call_user_func_array(array($this, $methodName), array_slice(func_get_args(), 1));
@@ -99,42 +103,42 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase {
 				}
 			}
 		');
-		return $accessibleClassName;
-	}
+        return $accessibleClassName;
+    }
 
-	/**
-	 * Injects $dependency into property $name of $target
-	 *
-	 * This is a convenience method for setting a protected or private property in
-	 * a test subject for the purpose of injecting a dependency.
-	 *
-	 * @param object $target The instance which needs the dependency
-	 * @param string $name Name of the property to be injected
-	 * @param object $dependency The dependency to inject – usually an object but can also be any other type
-	 * @return void
-	 * @throws \RuntimeException
-	 * @throws \InvalidArgumentException
-	 */
-	protected function inject($target, $name, $dependency) {
-		if (!is_object($target)) {
-			throw new \InvalidArgumentException('Wrong type for argument $target, must be object.');
-		}
+    /**
+     * Injects $dependency into property $name of $target
+     *
+     * This is a convenience method for setting a protected or private property in
+     * a test subject for the purpose of injecting a dependency.
+     *
+     * @param object $target The instance which needs the dependency
+     * @param string $name Name of the property to be injected
+     * @param object $dependency The dependency to inject – usually an object but can also be any other type
+     * @return void
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    protected function inject($target, $name, $dependency)
+    {
+        if (!is_object($target)) {
+            throw new \InvalidArgumentException('Wrong type for argument $target, must be object.');
+        }
 
-		$objectReflection = new \ReflectionObject($target);
-		$methodNamePart = strtoupper($name[0]) . substr($name, 1);
-		if ($objectReflection->hasMethod('set' . $methodNamePart)) {
-			$methodName = 'set' . $methodNamePart;
-			$target->$methodName($dependency);
-		} elseif ($objectReflection->hasMethod('inject' . $methodNamePart)) {
-			$methodName = 'inject' . $methodNamePart;
-			$target->$methodName($dependency);
-		} elseif ($objectReflection->hasProperty($name)) {
-			$property = $objectReflection->getProperty($name);
-			$property->setAccessible(TRUE);
-			$property->setValue($target, $dependency);
-		} else {
-			throw new \RuntimeException('Could not inject ' . $name . ' into object of type ' . get_class($target));
-		}
-	}
-
+        $objectReflection = new \ReflectionObject($target);
+        $methodNamePart = strtoupper($name[0]) . substr($name, 1);
+        if ($objectReflection->hasMethod('set' . $methodNamePart)) {
+            $methodName = 'set' . $methodNamePart;
+            $target->$methodName($dependency);
+        } elseif ($objectReflection->hasMethod('inject' . $methodNamePart)) {
+            $methodName = 'inject' . $methodNamePart;
+            $target->$methodName($dependency);
+        } elseif ($objectReflection->hasProperty($name)) {
+            $property = $objectReflection->getProperty($name);
+            $property->setAccessible(true);
+            $property->setValue($target, $dependency);
+        } else {
+            throw new \RuntimeException('Could not inject ' . $name . ' into object of type ' . get_class($target));
+        }
+    }
 }

--- a/tests/Functional/BaseConditionalFunctionalTestCase.php
+++ b/tests/Functional/BaseConditionalFunctionalTestCase.php
@@ -9,117 +9,122 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
 /**
  * Class BaseFunctionalTestCase
  */
-abstract class BaseConditionalFunctionalTestCase extends UnitTestCase {
+abstract class BaseConditionalFunctionalTestCase extends UnitTestCase
+{
 
-	/**
-	 * If your test case requires a cache, override this
-	 * method and return an instance.
-	 *
-	 * @return FluidCacheInterface
-	 */
-	protected function getCache() {
-		return NULL;
-	}
+    /**
+     * If your test case requires a cache, override this
+     * method and return an instance.
+     *
+     * @return FluidCacheInterface
+     */
+    protected function getCache()
+    {
+        return null;
+    }
 
-	/**
-	 * If your test case requires a custom View instance
-	 * return the instance from this method.
-	 *
-	 * @return ViewInterface
-	 */
-	protected function getView($withCache = FALSE) {
-		$view = new TemplateView();
-		$cache = $this->getCache();
-		if ($cache && $withCache) {
-			$view->getRenderingContext()->setCache($cache);
-		}
-		return $view;
-	}
+    /**
+     * If your test case requires a custom View instance
+     * return the instance from this method.
+     *
+     * @return ViewInterface
+     */
+    protected function getView($withCache = false)
+    {
+        $view = new TemplateView();
+        $cache = $this->getCache();
+        if ($cache && $withCache) {
+            $view->getRenderingContext()->setCache($cache);
+        }
+        return $view;
+    }
 
-	/**
-	 * Data sets used by the standard function test in test case.
-	 *
-	 * Override this method and return an array of arrays
-	 * which each must contain, in order:
-	 *
-	 * array(
-	 *     'template {code} piece', // the template code as string; or an (open) stream
-	 *     array('code' => 'test'), // the variables that will be assigned
-	 *     array('template test', 'test piece'), // list of values that MUST all be present
-	 *     array('negative test', 'test bad') // list of values that MUST NOT be present
-	 * )
-	 *
-	 * Name your sets in order to improve the error reporting:
-	 *
-	 * return array(
-	 *     'Outputs foobar and baz' => array(
-	 *          // ...
-	 *     ),
-	 *     'Outputs not foobar' => array(
-	 *          // ...
-	 *     ),
-	 *     'Outputs baz but not foobar' => array(
-	 *          // ...
-	 *     )
-	 * );
-	 *
-	 * This will clearly report *which* of the sets caused failure
-	 * when you run the test case.
-	 *
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array();
-	}
+    /**
+     * Data sets used by the standard function test in test case.
+     *
+     * Override this method and return an array of arrays
+     * which each must contain, in order:
+     *
+     * array(
+     *     'template {code} piece', // the template code as string; or an (open) stream
+     *     array('code' => 'test'), // the variables that will be assigned
+     *     array('template test', 'test piece'), // list of values that MUST all be present
+     *     array('negative test', 'test bad') // list of values that MUST NOT be present
+     * )
+     *
+     * Name your sets in order to improve the error reporting:
+     *
+     * return array(
+     *     'Outputs foobar and baz' => array(
+     *          // ...
+     *     ),
+     *     'Outputs not foobar' => array(
+     *          // ...
+     *     ),
+     *     'Outputs baz but not foobar' => array(
+     *          // ...
+     *     )
+     * );
+     *
+     * This will clearly report *which* of the sets caused failure
+     * when you run the test case.
+     *
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [];
+    }
 
-	/**
-	 * Perform a standard test on the source or stream provided,
-	 * rendering it with $variables assigned and checking the
-	 * output for presense of $expected values and confirming
-	 * that none of the $notExpected values are present.
-	 *
-	 * @param string|resource $source
-	 * @param boolean $expected
-	 * @param array $variables
-	 * @param boolean $withCache
-	 * @test
-	 * @dataProvider getTemplateCodeFixturesAndExpectations
-	 */
-	public function testTemplateCodeFixture($source, $expected, array $variables = array(), $withCache = FALSE) {
-		$source = '<f:if condition="' . $source . '" then="yes" else="no" />';
-		$view = $this->getView(FALSE);
-		$view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
-		$view->assignMultiple($variables);
-		$output = $view->render();
-		$this->assertNotEquals($view->getRenderingContext()->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
+    /**
+     * Perform a standard test on the source or stream provided,
+     * rendering it with $variables assigned and checking the
+     * output for presense of $expected values and confirming
+     * that none of the $notExpected values are present.
+     *
+     * @param string|resource $source
+     * @param boolean $expected
+     * @param array $variables
+     * @param boolean $withCache
+     * @test
+     * @dataProvider getTemplateCodeFixturesAndExpectations
+     */
+    public function testTemplateCodeFixture($source, $expected, array $variables = [], $withCache = false)
+    {
+        $source = '<f:if condition="' . $source . '" then="yes" else="no" />';
+        $view = $this->getView(false);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->assignMultiple($variables);
+        $output = $view->render();
+        $this->assertNotEquals($view->getRenderingContext()->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
 
-		if ($expected === TRUE) {
-			$this->assertEquals('yes', $output);
-		} else {
-			$this->assertEquals('no', $output);
-		}
-	}
+        if ($expected === true) {
+            $this->assertEquals('yes', $output);
+        } else {
+            $this->assertEquals('no', $output);
+        }
+    }
 
-	/**
-	 * Perform a standard test on the source or stream provided,
-	 * rendering it with $variables assigned and checking the
-	 * output for presense of $expected values and confirming
-	 * that none of the $notExpected values are present.
-	 *
-	 * Same as testTemplateCodeFixture() but includes a cache
-	 * in the tests. Silently skipped if the test case does not
-	 * return a valid cache.
-	 *
-	 * @param string|resource $sourceOrStream
-	 * @param boolean $expected
-	 * @param array $variables
-	 * @test
-	 * @dataProvider getTemplateCodeFixturesAndExpectations
-	 */
-	public function testTemplateCodeFixtureWithCache($sourceOrStream, $expectation, array $variables = array()) {
-		if ($this->getCache()) {
-			$this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, TRUE);
-		}
-	}
-
+    /**
+     * Perform a standard test on the source or stream provided,
+     * rendering it with $variables assigned and checking the
+     * output for presense of $expected values and confirming
+     * that none of the $notExpected values are present.
+     *
+     * Same as testTemplateCodeFixture() but includes a cache
+     * in the tests. Silently skipped if the test case does not
+     * return a valid cache.
+     *
+     * @param string|resource $sourceOrStream
+     * @param boolean $expected
+     * @param array $variables
+     * @test
+     * @dataProvider getTemplateCodeFixturesAndExpectations
+     */
+    public function testTemplateCodeFixtureWithCache($sourceOrStream, $expectation, array $variables = [])
+    {
+        if ($this->getCache()) {
+            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, true);
+        }
+    }
 }

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -9,138 +9,143 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
 /**
  * Class BaseFunctionalTestCase
  */
-abstract class BaseFunctionalTestCase extends UnitTestCase {
+abstract class BaseFunctionalTestCase extends UnitTestCase
+{
 
-	/**
-	 * If your test case requires a cache, override this
-	 * method and return an instance.
-	 *
-	 * @return FluidCacheInterface
-	 */
-	protected function getCache() {
-		return NULL;
-	}
+    /**
+     * If your test case requires a cache, override this
+     * method and return an instance.
+     *
+     * @return FluidCacheInterface
+     */
+    protected function getCache()
+    {
+        return null;
+    }
 
-	/**
-	 * If your test case requires a custom View instance
-	 * return the instance from this method.
-	 *
-	 * @return ViewInterface
-	 */
-	protected function getView($withCache = FALSE) {
-		$view = new TemplateView();
-		$cache = $this->getCache();
-		if ($cache && $withCache) {
-			$view->getRenderingContext()->setCache($cache);
-		}
-		return $view;
-	}
+    /**
+     * If your test case requires a custom View instance
+     * return the instance from this method.
+     *
+     * @return ViewInterface
+     */
+    protected function getView($withCache = false)
+    {
+        $view = new TemplateView();
+        $cache = $this->getCache();
+        if ($cache && $withCache) {
+            $view->getRenderingContext()->setCache($cache);
+        }
+        return $view;
+    }
 
-	/**
-	 * Data sets used by the standard function test in test case.
-	 *
-	 * Override this method and return an array of arrays
-	 * which each must contain, in order:
-	 *
-	 * array(
-	 *     'template {code} piece', // the template code as string; or an (open) stream
-	 *     array('code' => 'test'), // the variables that will be assigned
-	 *     array('template test', 'test piece'), // list of values that MUST all be present
-	 *     array('negative test', 'test bad') // list of values that MUST NOT be present
-	 *     $exceptionClass, // NULL or a class name of an exception that is expected when executing the snippet
-	 *     $withCache // TRUE or FALSE depending on whether or not you wish to test the snippet with caching
-	 * )
-	 *
-	 * Name your sets in order to improve the error reporting:
-	 *
-	 * return array(
-	 *     'Outputs foobar and baz' => array(
-	 *          // ...
-	 *     ),
-	 *     'Outputs not foobar' => array(
-	 *          // ...
-	 *     ),
-	 *     'Outputs baz but not foobar' => array(
-	 *          // ...
-	 *     )
-	 * );
-	 *
-	 * This will clearly report *which* of the sets caused failure
-	 * when you run the test case.
-	 *
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array();
-	}
+    /**
+     * Data sets used by the standard function test in test case.
+     *
+     * Override this method and return an array of arrays
+     * which each must contain, in order:
+     *
+     * array(
+     *     'template {code} piece', // the template code as string; or an (open) stream
+     *     array('code' => 'test'), // the variables that will be assigned
+     *     array('template test', 'test piece'), // list of values that MUST all be present
+     *     array('negative test', 'test bad') // list of values that MUST NOT be present
+     *     $exceptionClass, // NULL or a class name of an exception that is expected when executing the snippet
+     *     $withCache // TRUE or FALSE depending on whether or not you wish to test the snippet with caching
+     * )
+     *
+     * Name your sets in order to improve the error reporting:
+     *
+     * return array(
+     *     'Outputs foobar and baz' => array(
+     *          // ...
+     *     ),
+     *     'Outputs not foobar' => array(
+     *          // ...
+     *     ),
+     *     'Outputs baz but not foobar' => array(
+     *          // ...
+     *     )
+     * );
+     *
+     * This will clearly report *which* of the sets caused failure
+     * when you run the test case.
+     *
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [];
+    }
 
-	/**
-	 * Perform a standard test on the source or stream provided,
-	 * rendering it with $variables assigned and checking the
-	 * output for presense of $expected values and confirming
-	 * that none of the $notExpected values are present.
-	 *
-	 * @param string|resource $source
-	 * @param array $variables
-	 * @param array $expected
-	 * @param array $notExpected
-	 * @param string|NULL $expectedException
-	 * @param boolean $withCache
-	 * @test
-	 * @dataProvider getTemplateCodeFixturesAndExpectations
-	 */
-	public function testTemplateCodeFixture($source, array $variables, array $expected, array $notExpected, $expectedException = NULL, $withCache = FALSE) {
-		if (!empty($expectedException)) {
-			$this->setExpectedException($expectedException);
-		}
-		$view = $this->getView(FALSE);
-		$view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
-		$view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
-		$view->assignMultiple($variables);
-		$output = trim($view->render());
-		$this->assertNotEquals($view->getRenderingContext()->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
-		if (empty($expected) && empty($notExpected)) {
-			$this->fail('Test performs no assertions!');
-		}
-		foreach ($expected as $expectedValue) {
-			if (is_string($expectedValue) === TRUE) {
-				$this->assertContains($expectedValue, $output);
-			} else {
-				$this->assertEquals($expectedValue, $output);
-			}
-		}
-		foreach ($notExpected as $notExpectedValue) {
-			if (is_string($notExpectedValue) === TRUE) {
-				$this->assertNotContains($notExpectedValue, $output);
-			} else {
-				$this->assertNotEquals($notExpectedValue, $output);
-			}
-		}
-	}
+    /**
+     * Perform a standard test on the source or stream provided,
+     * rendering it with $variables assigned and checking the
+     * output for presense of $expected values and confirming
+     * that none of the $notExpected values are present.
+     *
+     * @param string|resource $source
+     * @param array $variables
+     * @param array $expected
+     * @param array $notExpected
+     * @param string|NULL $expectedException
+     * @param boolean $withCache
+     * @test
+     * @dataProvider getTemplateCodeFixturesAndExpectations
+     */
+    public function testTemplateCodeFixture($source, array $variables, array $expected, array $notExpected, $expectedException = null, $withCache = false)
+    {
+        if (!empty($expectedException)) {
+            $this->setExpectedException($expectedException);
+        }
+        $view = $this->getView(false);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->assignMultiple($variables);
+        $output = trim($view->render());
+        $this->assertNotEquals($view->getRenderingContext()->getTemplatePaths()->getTemplateSource(), $output, 'Input and output were the same');
+        if (empty($expected) && empty($notExpected)) {
+            $this->fail('Test performs no assertions!');
+        }
+        foreach ($expected as $expectedValue) {
+            if (is_string($expectedValue) === true) {
+                $this->assertContains($expectedValue, $output);
+            } else {
+                $this->assertEquals($expectedValue, $output);
+            }
+        }
+        foreach ($notExpected as $notExpectedValue) {
+            if (is_string($notExpectedValue) === true) {
+                $this->assertNotContains($notExpectedValue, $output);
+            } else {
+                $this->assertNotEquals($notExpectedValue, $output);
+            }
+        }
+    }
 
-	/**
-	 * Perform a standard test on the source or stream provided,
-	 * rendering it with $variables assigned and checking the
-	 * output for presense of $expected values and confirming
-	 * that none of the $notExpected values are present.
-	 *
-	 * Same as testTemplateCodeFixture() but includes a cache
-	 * in the tests. Silently skipped if the test case does not
-	 * return a valid cache.
-	 *
-	 * @param string|resource $sourceOrStream
-	 * @param array $variables
-	 * @param array $expected
-	 * @param array $notExpected
-	 * @param string|NULL $expectedException
-	 * @test
-	 * @dataProvider getTemplateCodeFixturesAndExpectations
-	 */
-	public function testTemplateCodeFixtureWithCache($sourceOrStream, array $variables, array $expected, array $notExpected, $expectedException = NULL) {
-		if ($this->getCache()) {
-			$this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, TRUE);
-			$this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, TRUE);
-		}
-	}
-
+    /**
+     * Perform a standard test on the source or stream provided,
+     * rendering it with $variables assigned and checking the
+     * output for presense of $expected values and confirming
+     * that none of the $notExpected values are present.
+     *
+     * Same as testTemplateCodeFixture() but includes a cache
+     * in the tests. Silently skipped if the test case does not
+     * return a valid cache.
+     *
+     * @param string|resource $sourceOrStream
+     * @param array $variables
+     * @param array $expected
+     * @param array $notExpected
+     * @param string|NULL $expectedException
+     * @test
+     * @dataProvider getTemplateCodeFixturesAndExpectations
+     */
+    public function testTemplateCodeFixtureWithCache($sourceOrStream, array $variables, array $expected, array $notExpected, $expectedException = null)
+    {
+        if ($this->getCache()) {
+            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
+            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
+        }
+    }
 }

--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -6,39 +6,40 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseConditionalFunctionalTestCase;
 /**
  * Class BasicConditionsTest
  */
-class BasicConditionsTest extends BaseConditionalFunctionalTestCase {
+class BasicConditionsTest extends BaseConditionalFunctionalTestCase
+{
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array(
-			array('1 == 1', TRUE),
-			array('1 != 2', TRUE),
-			array('1 == 2', FALSE),
-			array('1 === 1', TRUE),
-			array('\'foo\' == 0', TRUE),
-			array('1.1 >= \'foo\'', TRUE),
-			array('\'String containing word \"false\" in text\'', TRUE),
-			array('\'  FALSE  \'', TRUE),
-			array('\'foo\' > 0', FALSE),
-			array('FALSE', FALSE),
-			array('(FALSE || (FALSE || 1)', TRUE),
-			array('(FALSE || (FALSE || 1)', TRUE),
-			array('(FALSE || (FALSE || 1)', TRUE),
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            ['1 == 1', true],
+            ['1 != 2', true],
+            ['1 == 2', false],
+            ['1 === 1', true],
+            ['\'foo\' == 0', true],
+            ['1.1 >= \'foo\'', true],
+            ['\'String containing word \"false\" in text\'', true],
+            ['\'  FALSE  \'', true],
+            ['\'foo\' > 0', false],
+            ['FALSE', false],
+            ['(FALSE || (FALSE || 1)', true],
+            ['(FALSE || (FALSE || 1)', true],
+            ['(FALSE || (FALSE || 1)', true],
 
-			// integers
-			array('13 == \'13\'', TRUE),
-			array('13 === \'13\'', FALSE),
+            // integers
+            ['13 == \'13\'', true],
+            ['13 === \'13\'', false],
 
-			// floats
-			array('13.37 == \'13.37\'', TRUE),
-			array('13.37 === \'13.37\'', FALSE),
+            // floats
+            ['13.37 == \'13.37\'', true],
+            ['13.37 === \'13.37\'', false],
 
-			// groups
-			array('(1 && (\'foo\' == \'foo\') && (TRUE || 1)) && 0 != 1', TRUE),
-			array('(1 && (\'foo\' == \'foo\') && (TRUE || 1)) && 0 != 1 && FALSE', FALSE)
-		);
-	}
-
+            // groups
+            ['(1 && (\'foo\' == \'foo\') && (TRUE || 1)) && 0 != 1', true],
+            ['(1 && (\'foo\' == \'foo\') && (TRUE || 1)) && 0 != 1 && FALSE', false]
+        ];
+    }
 }

--- a/tests/Functional/Cases/Conditions/TernaryConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/TernaryConditionsTest.php
@@ -6,130 +6,131 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class VariableConditionsTest
  */
-class TernaryConditionsTest extends BaseFunctionalTestCase {
+class TernaryConditionsTest extends BaseFunctionalTestCase
+{
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		$someObject = new \stdClass();
-		$someObject->someString = 'bar';
-		$someObject->someInt = 1337;
-		$someObject->someFloat = 13.37;
-		$someObject->someBoolean = TRUE;
-		$someArray = array(
-			'foo' => 'bar'
-		);
-		return array(
-			array(
-				'{true ? \'yes\' : \'no\'}',
-				array(),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{true ? 1 : 2}',
-				array(),
-				array(1),
-				array(2)
-			),
-			array(
-				'{true ? foo : \'bar\'}',
-				array('foo' => 'bar'),
-				array('bar'),
-				array('foo')
-			),
-			array(
-				'{(true) ? \'yes\' : \'no\'}',
-				array(),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(true || false) ? \'yes\' : \'no\'}',
-				array(),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(false || false) ? \'yes\' : \'no\'}',
-				array(),
-				array('no'),
-				array('yes')
-			),
-			array(
-				'{foo ? \'yes\' : \'no\'}',
-				array('foo' => TRUE),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{foo ? \'yes\' : \'no\'}',
-				array('foo' => FALSE),
-				array('no'),
-				array('yes')
-			),
-			array(
-				'{!foo ? \'yes\' : \'no\'}',
-				array('foo' => FALSE),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(foo || false) ? \'yes\' : \'no\'}',
-				array('foo' => TRUE),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(foo || false) ? \'yes\' : \'no\'}',
-				array('foo' => FALSE),
-				array('no'),
-				array('yes')
-			),
-			array(
-				'{(foo.bar || false) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => true)),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(foo.bar && false) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => true)),
-				array('no'),
-				array('yes')
-			),
-			array(
-				'{(foo.bar > 10) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => 11)),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(foo.bar < 10) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => 11)),
-				array('no'),
-				array('yes')
-			),
-			array(
-				'{(foo.bar < 10) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => 11)),
-				array('no'),
-				array('yes')
-			),
-			array(
-				'{(foo.bar % 10) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => 11)),
-				array('yes'),
-				array('no')
-			),
-			array(
-				'{(foo.bar % 10) ? \'yes\' : \'no\'}',
-				array('foo' => array('bar' => 10)),
-				array('no'),
-				array('yes')
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        $someObject = new \stdClass();
+        $someObject->someString = 'bar';
+        $someObject->someInt = 1337;
+        $someObject->someFloat = 13.37;
+        $someObject->someBoolean = true;
+        $someArray = [
+            'foo' => 'bar'
+        ];
+        return [
+            [
+                '{true ? \'yes\' : \'no\'}',
+                [],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{true ? 1 : 2}',
+                [],
+                [1],
+                [2]
+            ],
+            [
+                '{true ? foo : \'bar\'}',
+                ['foo' => 'bar'],
+                ['bar'],
+                ['foo']
+            ],
+            [
+                '{(true) ? \'yes\' : \'no\'}',
+                [],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(true || false) ? \'yes\' : \'no\'}',
+                [],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(false || false) ? \'yes\' : \'no\'}',
+                [],
+                ['no'],
+                ['yes']
+            ],
+            [
+                '{foo ? \'yes\' : \'no\'}',
+                ['foo' => true],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{foo ? \'yes\' : \'no\'}',
+                ['foo' => false],
+                ['no'],
+                ['yes']
+            ],
+            [
+                '{!foo ? \'yes\' : \'no\'}',
+                ['foo' => false],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(foo || false) ? \'yes\' : \'no\'}',
+                ['foo' => true],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(foo || false) ? \'yes\' : \'no\'}',
+                ['foo' => false],
+                ['no'],
+                ['yes']
+            ],
+            [
+                '{(foo.bar || false) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => true]],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(foo.bar && false) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => true]],
+                ['no'],
+                ['yes']
+            ],
+            [
+                '{(foo.bar > 10) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => 11]],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(foo.bar < 10) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => 11]],
+                ['no'],
+                ['yes']
+            ],
+            [
+                '{(foo.bar < 10) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => 11]],
+                ['no'],
+                ['yes']
+            ],
+            [
+                '{(foo.bar % 10) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => 11]],
+                ['yes'],
+                ['no']
+            ],
+            [
+                '{(foo.bar % 10) ? \'yes\' : \'no\'}',
+                ['foo' => ['bar' => 10]],
+                ['no'],
+                ['yes']
+            ],
+        ];
+    }
 }

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -7,69 +7,70 @@ use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 /**
  * Class VariableConditionsTest
  */
-class VariableConditionsTest extends BaseConditionalFunctionalTestCase {
+class VariableConditionsTest extends BaseConditionalFunctionalTestCase
+{
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		$user1 = new UserWithToString('foobar');
-		$user2 = new UserWithToString('foobar');
-		$someObject = new \stdClass();
-		$someObject->someString = 'bar';
-		$someObject->someInt = 1337;
-		$someObject->someFloat = 13.37;
-		$someObject->someBoolean = TRUE;
-		$someArray = array(
-			'foo' => 'bar'
-		);
-		return array(
-			// simple assignments
-			array('{test}', TRUE, array('test' => 1)),
-			array('{test}', TRUE, array('test' => '\'  FALSE  \'')),
-			array('{test}', TRUE, array('test' => '\'  0  \'')),
-			array('{test}', FALSE, array('test' => 0)),
-			array('1 == {test}', TRUE, array('test' => 1)),
-			array('1 != {test}', TRUE, array('test' => 2)),
-			array('{test1} == {test2}', TRUE, array('test1' => 'abc', 'test2' => 'abc')),
-			array('{test1} === {test2}', TRUE, array('test1' => 'abc', 'test2' => 'abc')),
-			array('{test1} === {test2}', FALSE, array('test1' => 1, 'test2' => TRUE)),
-			array('{test1} == {test2}', TRUE, array('test1' => 1, 'test2' => TRUE)),
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        $user1 = new UserWithToString('foobar');
+        $user2 = new UserWithToString('foobar');
+        $someObject = new \stdClass();
+        $someObject->someString = 'bar';
+        $someObject->someInt = 1337;
+        $someObject->someFloat = 13.37;
+        $someObject->someBoolean = true;
+        $someArray = [
+            'foo' => 'bar'
+        ];
+        return [
+            // simple assignments
+            ['{test}', true, ['test' => 1]],
+            ['{test}', true, ['test' => '\'  FALSE  \'']],
+            ['{test}', true, ['test' => '\'  0  \'']],
+            ['{test}', false, ['test' => 0]],
+            ['1 == {test}', true, ['test' => 1]],
+            ['1 != {test}', true, ['test' => 2]],
+            ['{test1} == {test2}', true, ['test1' => 'abc', 'test2' => 'abc']],
+            ['{test1} === {test2}', true, ['test1' => 'abc', 'test2' => 'abc']],
+            ['{test1} === {test2}', false, ['test1' => 1, 'test2' => true]],
+            ['{test1} == {test2}', true, ['test1' => 1, 'test2' => true]],
 
-			// conditions with objects
-			array('{user1} == {user1}', TRUE, array('user1' => $user1)),
-			array('{user1} === {user1}',TRUE, array('user1' => $user1)),
-			array('{user1} == {user2}', FALSE, array('user1' => $user1, 'user2' => $user2)),
-			array('{user1} === {user2}', FALSE, array('user1' => $user1, 'user2' => $user2)),
+            // conditions with objects
+            ['{user1} == {user1}', true, ['user1' => $user1]],
+            ['{user1} === {user1}',true, ['user1' => $user1]],
+            ['{user1} == {user2}', false, ['user1' => $user1, 'user2' => $user2]],
+            ['{user1} === {user2}', false, ['user1' => $user1, 'user2' => $user2]],
 
-			// condition with object properties
-			array('{someObject.someString} == \'bar\'', TRUE, array('someObject' => $someObject)),
-			array('{someObject.someString} === \'bar\'', TRUE, array('someObject' => $someObject)),
+            // condition with object properties
+            ['{someObject.someString} == \'bar\'', true, ['someObject' => $someObject]],
+            ['{someObject.someString} === \'bar\'', true, ['someObject' => $someObject]],
 
-			array('{someObject.someInt} == \'1337\'', TRUE, array('someObject' => $someObject)),
-			array('{someObject.someInt} === \'1337\'', FALSE, array('someObject' => $someObject)),
-			array('{someObject.someInt} === 1337', TRUE, array('someObject' => $someObject)),
+            ['{someObject.someInt} == \'1337\'', true, ['someObject' => $someObject]],
+            ['{someObject.someInt} === \'1337\'', false, ['someObject' => $someObject]],
+            ['{someObject.someInt} === 1337', true, ['someObject' => $someObject]],
 
-			array('{someObject.someFloat} == \'13.37\'', TRUE, array('someObject' => $someObject)),
-			array('{someObject.someFloat} === \'13.37\'', FALSE, array('someObject' => $someObject)),
-			array('{someObject.someFloat} === 13.37', TRUE, array('someObject' => $someObject)),
+            ['{someObject.someFloat} == \'13.37\'', true, ['someObject' => $someObject]],
+            ['{someObject.someFloat} === \'13.37\'', false, ['someObject' => $someObject]],
+            ['{someObject.someFloat} === 13.37', true, ['someObject' => $someObject]],
 
-			array('{someObject.someBoolean} == 1', TRUE, array('someObject' => $someObject)),
-			array('{someObject.someBoolean} === 1', FALSE, array('someObject' => $someObject)),
-			array('{someObject.someBoolean} == TRUE', TRUE, array('someObject' => $someObject)),
-			array('{someObject.someBoolean} === TRUE', TRUE, array('someObject' => $someObject)),
+            ['{someObject.someBoolean} == 1', true, ['someObject' => $someObject]],
+            ['{someObject.someBoolean} === 1', false, ['someObject' => $someObject]],
+            ['{someObject.someBoolean} == TRUE', true, ['someObject' => $someObject]],
+            ['{someObject.someBoolean} === TRUE', true, ['someObject' => $someObject]],
 
-			// array conditions
-			array('{someArray} == {foo: \'bar\'}', TRUE, array('someArray' => $someArray)),
-			array('{someArray} === {foo: \'bar\'}', TRUE, array('someArray' => $someArray)),
-			array('{someArray.foo} == \'bar\'', TRUE, array('someArray' => $someArray)),
-			array('({someArray.foo} == \'bar\') && (TRUE || 0)', TRUE, array('someArray' => $someArray)),
-			array('({foo.someArray.foo} == \'bar\') && (TRUE || 0)', TRUE, array('foo' => array('someArray' => $someArray))),
+            // array conditions
+            ['{someArray} == {foo: \'bar\'}', true, ['someArray' => $someArray]],
+            ['{someArray} === {foo: \'bar\'}', true, ['someArray' => $someArray]],
+            ['{someArray.foo} == \'bar\'', true, ['someArray' => $someArray]],
+            ['({someArray.foo} == \'bar\') && (TRUE || 0)', true, ['someArray' => $someArray]],
+            ['({foo.someArray.foo} == \'bar\') && (TRUE || 0)', true, ['foo' => ['someArray' => $someArray]]],
 
-			// inline viewHelpers
-			array('(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 1)', TRUE),
-			array('(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 0)', FALSE)
-		);
-	}
-
+            // inline viewHelpers
+            ['(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 1)', true],
+            ['(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 0)', false]
+        ];
+    }
 }

--- a/tests/Functional/Cases/CycleTest.php
+++ b/tests/Functional/Cases/CycleTest.php
@@ -6,20 +6,21 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class CycleTest
  */
-class CycleTest extends BaseFunctionalTestCase {
+class CycleTest extends BaseFunctionalTestCase
+{
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array(
-			'Cycles values in array' => array(
-				'<f:for each="{items}" as="item"><f:cycle values="{cycles}" as="cycled">{cycled}</f:cycle></f:for>',
-				array('items' => array(0, 1, 2, 3), 'cycles' => array('a', 'b')),
-				array('abab'),
-				array('aa', 'bb')
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'Cycles values in array' => [
+                '<f:for each="{items}" as="item"><f:cycle values="{cycles}" as="cycled">{cycled}</f:cycle></f:for>',
+                ['items' => [0, 1, 2, 3], 'cycles' => ['a', 'b']],
+                ['abab'],
+                ['aa', 'bb']
+            ],
+        ];
+    }
 }

--- a/tests/Functional/Cases/Errors/ParsingErrorsTest.php
+++ b/tests/Functional/Cases/Errors/ParsingErrorsTest.php
@@ -7,35 +7,36 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class ParsingErrorsTest
  */
-class ParsingErrorsTest extends BaseFunctionalTestCase {
+class ParsingErrorsTest extends BaseFunctionalTestCase
+{
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array(
-			'Unclosed ViewHelperNode' => array(
-				'<f:section name="Test"></div>',
-				array(),
-				array(),
-				array(),
-				Exception::class
-			),
-			'Missing required argument' => array(
-				'<f:section></f:section>',
-				array(),
-				array(),
-				array(),
-				Exception::class
-			),
-			'Uses invalid namespace' => array(
-				'<invalid:section></invalid:section>',
-				array(),
-				array(),
-				array(),
-				Exception::class
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'Unclosed ViewHelperNode' => [
+                '<f:section name="Test"></div>',
+                [],
+                [],
+                [],
+                Exception::class
+            ],
+            'Missing required argument' => [
+                '<f:section></f:section>',
+                [],
+                [],
+                [],
+                Exception::class
+            ],
+            'Uses invalid namespace' => [
+                '<invalid:section></invalid:section>',
+                [],
+                [],
+                [],
+                Exception::class
+            ],
+        ];
+    }
 }

--- a/tests/Functional/Cases/Escaping/EscapingTest.php
+++ b/tests/Functional/Cases/Escaping/EscapingTest.php
@@ -6,134 +6,135 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class EscapingTest
  */
-class EscapingTest extends BaseFunctionalTestCase {
+class EscapingTest extends BaseFunctionalTestCase
+{
 
-	/**
-	 * @var array
-	 */
-	protected $variables = array('settings' => array('test' => '<strong>Bla</strong>'));
+    /**
+     * @var array
+     */
+    protected $variables = ['settings' => ['test' => '<strong>Bla</strong>']];
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array(
-			'escapeChildren can be disabled in template' => array(
-				'{escapingEnabled=false}<test:escapeChildrenEnabledAndEscapeOutputDisabled>{settings.test}</test:escapeChildrenEnabledAndEscapeOutputDisabled>',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'escapeOutput can be disabled in template' => array(
-				'{escapingEnabled=false}<test:escapeChildrenDisabledAndEscapeOutputEnabled>{settings.test}</test:escapeChildrenDisabledAndEscapeOutputEnabled>',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'Disabling escaping twice in template throws parsing exception' => array(
-				'{escapingEnabled=false}<test:escapeChildrenDisabledAndEscapeOutputEnabled>{settings.test}</test:escapeChildrenDisabledAndEscapeOutputEnabled>{escapingEnabled=false}',
-				array(),
-				array(),
-				array(),
-				'TYPO3Fluid\\Fluid\\Core\\Parser\\Exception'
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with children, properly encodes variable value' => array(
-				'<test:escapeChildrenEnabledAndEscapeOutputDisabled>{settings.test}</test:escapeChildrenEnabledAndEscapeOutputDisabled>',
-				$this->variables,
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-				array('<strong>Bla</strong>'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with children, properly encodes variable value' => array(
-				'{settings.test -> test:escapeChildrenEnabledAndEscapeOutputDisabled()}',
-				$this->variables,
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-				array('<strong>Bla</strong>'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with argument, does not encode variable value' => array(
-				'<test:escapeChildrenEnabledAndEscapeOutputDisabled content="{settings.test}" />',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with argument, does not encode variable value' => array(
-				'{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: settings.test)}',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with string, does not encode string value' => array(
-				'{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: \'<strong>Bla</strong>\')}',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with argument in quotes, does encode variable value (encoded before passed to VH)' => array(
-				'{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: \'{settings.test}\')}',
-				$this->variables,
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-				array('<strong>Bla</strong>'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and children rendering, does not encode variable value' => array(
-				'<test:escapeChildrenEnabledAndEscapeOutputDisabled content="{settings.test -> test:escapeChildrenEnabledAndEscapeOutputDisabled()}" />',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and argument in inline, does not encode variable value' => array(
-				'<test:escapeChildrenEnabledAndEscapeOutputDisabled content="{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: settings.test)}" />',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with children, properly encodes variable value' => array(
-				'<test:escapeChildrenDisabledAndEscapeOutputDisabled>{settings.test}</test:escapeChildrenDisabledAndEscapeOutputDisabled>',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with children, properly encodes variable value' => array(
-				'{settings.test -> test:escapeChildrenDisabledAndEscapeOutputDisabled()}',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with argument, does not encode variable value' => array(
-				'<test:escapeChildrenDisabledAndEscapeOutputDisabled content="{settings.test}" />',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with argument, does not encode variable value' => array(
-				'{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: settings.test)}',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with string, does not encode string value' => array(
-				'{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: \'<strong>Bla</strong>\')}',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with argument in quotes, does encode variable value (encoded before passed to VH)' => array(
-				'{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: \'{settings.test}\')}',
-				$this->variables,
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-				array('<strong>Bla</strong>'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and children rendering, does not encode variable value' => array(
-				'<test:escapeChildrenDisabledAndEscapeOutputDisabled content="{settings.test -> test:escapeChildrenDisabledAndEscapeOutputDisabled()}" />',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-			'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and argument in inline, does not encode variable value' => array(
-				'<test:escapeChildrenDisabledAndEscapeOutputDisabled content="{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: settings.test)}" />',
-				$this->variables,
-				array('<strong>Bla</strong>'),
-				array('&lt;strong&gt;Bla&lt;/strong&gt;'),
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'escapeChildren can be disabled in template' => [
+                '{escapingEnabled=false}<test:escapeChildrenEnabledAndEscapeOutputDisabled>{settings.test}</test:escapeChildrenEnabledAndEscapeOutputDisabled>',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'escapeOutput can be disabled in template' => [
+                '{escapingEnabled=false}<test:escapeChildrenDisabledAndEscapeOutputEnabled>{settings.test}</test:escapeChildrenDisabledAndEscapeOutputEnabled>',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'Disabling escaping twice in template throws parsing exception' => [
+                '{escapingEnabled=false}<test:escapeChildrenDisabledAndEscapeOutputEnabled>{settings.test}</test:escapeChildrenDisabledAndEscapeOutputEnabled>{escapingEnabled=false}',
+                [],
+                [],
+                [],
+                'TYPO3Fluid\\Fluid\\Core\\Parser\\Exception'
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with children, properly encodes variable value' => [
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled>{settings.test}</test:escapeChildrenEnabledAndEscapeOutputDisabled>',
+                $this->variables,
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+                ['<strong>Bla</strong>'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with children, properly encodes variable value' => [
+                '{settings.test -> test:escapeChildrenEnabledAndEscapeOutputDisabled()}',
+                $this->variables,
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+                ['<strong>Bla</strong>'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with argument, does not encode variable value' => [
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="{settings.test}" />',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with argument, does not encode variable value' => [
+                '{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: settings.test)}',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with string, does not encode string value' => [
+                '{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: \'<strong>Bla</strong>\')}',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Inline syntax with argument in quotes, does encode variable value (encoded before passed to VH)' => [
+                '{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: \'{settings.test}\')}',
+                $this->variables,
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+                ['<strong>Bla</strong>'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and children rendering, does not encode variable value' => [
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="{settings.test -> test:escapeChildrenEnabledAndEscapeOutputDisabled()}" />',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenEnabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and argument in inline, does not encode variable value' => [
+                '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="{test:escapeChildrenEnabledAndEscapeOutputDisabled(content: settings.test)}" />',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with children, properly encodes variable value' => [
+                '<test:escapeChildrenDisabledAndEscapeOutputDisabled>{settings.test}</test:escapeChildrenDisabledAndEscapeOutputDisabled>',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with children, properly encodes variable value' => [
+                '{settings.test -> test:escapeChildrenDisabledAndEscapeOutputDisabled()}',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with argument, does not encode variable value' => [
+                '<test:escapeChildrenDisabledAndEscapeOutputDisabled content="{settings.test}" />',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with argument, does not encode variable value' => [
+                '{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: settings.test)}',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with string, does not encode string value' => [
+                '{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: \'<strong>Bla</strong>\')}',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Inline syntax with argument in quotes, does encode variable value (encoded before passed to VH)' => [
+                '{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: \'{settings.test}\')}',
+                $this->variables,
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+                ['<strong>Bla</strong>'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and children rendering, does not encode variable value' => [
+                '<test:escapeChildrenDisabledAndEscapeOutputDisabled content="{settings.test -> test:escapeChildrenDisabledAndEscapeOutputDisabled()}" />',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+            'EscapeChildrenDisabledAndEscapeOutputDisabled: Tag syntax with nested inline syntax and argument in inline, does not encode variable value' => [
+                '<test:escapeChildrenDisabledAndEscapeOutputDisabled content="{test:escapeChildrenDisabledAndEscapeOutputDisabled(content: settings.test)}" />',
+                $this->variables,
+                ['<strong>Bla</strong>'],
+                ['&lt;strong&gt;Bla&lt;/strong&gt;'],
+            ],
+        ];
+    }
 }

--- a/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
+++ b/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
@@ -6,73 +6,74 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class WhitespaceToleranceTest
  */
-class WhitespaceToleranceTest extends BaseFunctionalTestCase {
+class WhitespaceToleranceTest extends BaseFunctionalTestCase
+{
 
     /**
      * @var array
      */
-    protected $variables = array();
+    protected $variables = [];
 
     /**
      * @return array
      */
-    public function getTemplateCodeFixturesAndExpectations() {
-        return array(
-            'Normal expected whitespace tolerance' => array(
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'Normal expected whitespace tolerance' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'No whitespace before self-close of tag' => array(
+                ['works'],
+                [],
+            ],
+            'No whitespace before self-close of tag' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works"/>',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace before self-close of tag' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace before self-close of tag' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works"      />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace before argument name' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace before argument name' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content="works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace after argument name' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace after argument name' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content    ="works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace before argument value' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace before argument value' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content= "works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace after argument name and before argument value' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace after argument name and before argument value' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled content = "works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace before and after argument name' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace before and after argument name' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled  content ="works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-            'Extra whitespace before argument name and after argument name and before argument value' => array(
+                ['works'],
+                [],
+            ],
+            'Extra whitespace before argument name and after argument name and before argument value' => [
                 '<test:escapeChildrenEnabledAndEscapeOutputDisabled  content = "works" />',
                 $this->variables,
-                array('works'),
-                array(),
-            ),
-        );
+                ['works'],
+                [],
+            ],
+        ];
     }
-
 }

--- a/tests/Functional/Cases/Rendering/RecursiveSectionRenderingTest.php
+++ b/tests/Functional/Cases/Rendering/RecursiveSectionRenderingTest.php
@@ -6,51 +6,52 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class RecursiveSectionRendering
  */
-class RecursiveSectionRenderingTest extends BaseFunctionalTestCase {
+class RecursiveSectionRenderingTest extends BaseFunctionalTestCase
+{
 
-	/**
-	 * Variables array constructed to expect exactly three
-	 * recursive renderings followed by a single rendering.
-	 *
-	 * @var array
-	 */
-	protected $variables = array(
-		'settings' => array(
-			'test' => '<strong>Bla</strong>'
-		),
-		'items' => array(
-			array(
-				'id' => 1,
-				'items' => array(
-					array(
-						'id' => 2,
-						'items' => array(
-							array(
-								'id' => 3,
-								'items' => array()
-							)
-						)
-					)
-				)
-			),
-			array(
-				'id' => 4
-			)
-		)
-	);
+    /**
+     * Variables array constructed to expect exactly three
+     * recursive renderings followed by a single rendering.
+     *
+     * @var array
+     */
+    protected $variables = [
+        'settings' => [
+            'test' => '<strong>Bla</strong>'
+        ],
+        'items' => [
+            [
+                'id' => 1,
+                'items' => [
+                    [
+                        'id' => 2,
+                        'items' => [
+                            [
+                                'id' => 3,
+                                'items' => []
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'id' => 4
+            ]
+        ]
+    ];
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array(
-			'Recursive section rendering clones variable storage and restores after loop ends' => array(
-				file_get_contents(__DIR__ . '/../../Fixtures/Templates/RecursiveSectionRendering.html'),
-				$this->variables,
-				array('Item: 1.', 'Item: 2.', 'Item: 3.', 'Item: 4.'),
-				array(),
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'Recursive section rendering clones variable storage and restores after loop ends' => [
+                file_get_contents(__DIR__ . '/../../Fixtures/Templates/RecursiveSectionRendering.html'),
+                $this->variables,
+                ['Item: 1.', 'Item: 2.', 'Item: 3.', 'Item: 4.'],
+                [],
+            ],
+        ];
+    }
 }

--- a/tests/Functional/Cases/SwitchTest.php
+++ b/tests/Functional/Cases/SwitchTest.php
@@ -7,42 +7,44 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
 /**
  * Class SwitchTest
  */
-class SwitchTest extends BaseFunctionalTestCase {
+class SwitchTest extends BaseFunctionalTestCase
+{
 
-	/**
-	 * If your test case requires a cache, override this
-	 * method and return an instance.
-	 *
-	 * @return FluidCacheInterface
-	 */
-	protected function getCache() {
-		return new SimpleFileCache(sys_get_temp_dir());
-	}
+    /**
+     * If your test case requires a cache, override this
+     * method and return an instance.
+     *
+     * @return FluidCacheInterface
+     */
+    protected function getCache()
+    {
+        return new SimpleFileCache(sys_get_temp_dir());
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getTemplateCodeFixturesAndExpectations() {
-		return array(
-			'Ignores whitespace inside parent switch outside case children' => array(
-				'<f:switch expression="1">   <f:case value="2">NO</f:case>   <f:case value="1">YES</f:case>   </f:switch>',
-				array(),
-				array(),
-				array('   ')
-			),
-			'Ignores text inside parent switch outside case children' => array(
-				'<f:switch expression="1">TEXT<f:case value="2">NO</f:case><f:case value="1">YES</f:case></f:switch>',
-				array(),
-				array(),
-				array('TEXT')
-			),
-			'Ignores text and whitespace inside parent switch outside case children' => array(
-				'<f:switch expression="1">   TEXT   <f:case value="2">NO</f:case><f:case value="1">YES</f:case></f:switch>',
-				array(),
-				array(),
-				array('TEXT', '   ')
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'Ignores whitespace inside parent switch outside case children' => [
+                '<f:switch expression="1">   <f:case value="2">NO</f:case>   <f:case value="1">YES</f:case>   </f:switch>',
+                [],
+                [],
+                ['   ']
+            ],
+            'Ignores text inside parent switch outside case children' => [
+                '<f:switch expression="1">TEXT<f:case value="2">NO</f:case><f:case value="1">YES</f:case></f:switch>',
+                [],
+                [],
+                ['TEXT']
+            ],
+            'Ignores text and whitespace inside parent switch outside case children' => [
+                '<f:switch expression="1">   TEXT   <f:case value="2">NO</f:case><f:case value="1">YES</f:case></f:switch>',
+                [],
+                [],
+                ['TEXT', '   ']
+            ],
+        ];
+    }
 }

--- a/tests/Functional/CommandTest.php
+++ b/tests/Functional/CommandTest.php
@@ -12,43 +12,46 @@ use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 /**
  * Class CommandTest
  */
-class CommandTest extends BaseTestCase {
+class CommandTest extends BaseTestCase
+{
 
-	/**
-	 * @return void
-	 */
-	public static function setUpBeforeClass() {
-		vfsStream::setup('fakecache/');
-	}
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        vfsStream::setup('fakecache/');
+    }
 
-	/**
-	 * @param string $argumentString
-	 * @param array $mustContain
-	 * @param array $mustNotContain
-	 * @dataProvider getCommandTestValues
-	 */
-	public function testCommand($argumentString, array $mustContain, array $mustNotContain) {
-		$bin = realpath(__DIR__ . '/../../bin/fluid');
-		$command = sprintf($argumentString, $bin);
-		$output = shell_exec($command);
-		foreach ($mustContain as $mustContainString) {
-			$this->assertContains($mustContainString, $output);
-		}
-		foreach ($mustNotContain as $mustNotContainString) {
-			$this->assertNotContains($mustNotContainString, $output);
-		}
-	}
+    /**
+     * @param string $argumentString
+     * @param array $mustContain
+     * @param array $mustNotContain
+     * @dataProvider getCommandTestValues
+     */
+    public function testCommand($argumentString, array $mustContain, array $mustNotContain)
+    {
+        $bin = realpath(__DIR__ . '/../../bin/fluid');
+        $command = sprintf($argumentString, $bin);
+        $output = shell_exec($command);
+        foreach ($mustContain as $mustContainString) {
+            $this->assertContains($mustContainString, $output);
+        }
+        foreach ($mustNotContain as $mustNotContainString) {
+            $this->assertNotContains($mustNotContainString, $output);
+        }
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getCommandTestValues() {
-		$dummyVariablesFile = realpath(__DIR__ . '/Fixtures/Variables/DummyVariables.json');
-		return array(
-			array('%s --help', array('Use the CLI utility in the following modes'), array('Exception')),
-			array('echo "Hello world!" | %s', array('Hello world!'), array('Exeption')),
-			array('echo "{foo}" | %s --variables "{\\"foo\\": \\"bar\\"}"', array('bar'), array('Exception', 'foo')),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getCommandTestValues()
+    {
+        $dummyVariablesFile = realpath(__DIR__ . '/Fixtures/Variables/DummyVariables.json');
+        return [
+            ['%s --help', ['Use the CLI utility in the following modes'], ['Exception']],
+            ['echo "Hello world!" | %s', ['Hello world!'], ['Exeption']],
+            ['echo "{foo}" | %s --variables "{\\"foo\\": \\"bar\\"}"', ['bar'], ['Exception', 'foo']],
+        ];
+    }
 }

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -12,218 +12,223 @@ use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 /**
  * Class ExamplesTest
  */
-class ExamplesTest extends BaseTestCase {
+class ExamplesTest extends BaseTestCase
+{
 
-	/**
-	 * @return void
-	 */
-	public static function setUpBeforeClass() {
-		vfsStream::setup('fakecache/');
-	}
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        vfsStream::setup('fakecache/');
+    }
 
-	/**
-	 * @dataProvider getExampleScriptTestValues
-	 * @param string $script
-	 * @param array $expectedOutputs
-	 * @param string $expectedException
-	 */
-	public function testExampleScriptFileWithoutCache($script, array $expectedOutputs, $expectedException = NULL) {
-		if ($expectedException !== NULL) {
-			$this->setExpectedException($expectedException);
-		}
-		$this->runExampleScriptTest($script, $expectedOutputs, FALSE);
-	}
+    /**
+     * @dataProvider getExampleScriptTestValues
+     * @param string $script
+     * @param array $expectedOutputs
+     * @param string $expectedException
+     */
+    public function testExampleScriptFileWithoutCache($script, array $expectedOutputs, $expectedException = null)
+    {
+        if ($expectedException !== null) {
+            $this->setExpectedException($expectedException);
+        }
+        $this->runExampleScriptTest($script, $expectedOutputs, false);
+    }
 
-	/**
-	 * @dataProvider getExampleScriptTestValues
-	 * @param string $script
-	 * @param array $expectedOutputs
-	 * @param string $expectedException
-	 */
-	public function testExampleScriptFileWithCache($script, array $expectedOutputs, $expectedException = NULL) {
-		if ($expectedException !== NULL) {
-			$this->setExpectedException($expectedException);
-		}
-		$cache = vfsStream::url('fakecache/');
-		$this->runExampleScriptTest($script, $expectedOutputs, $cache);
-		$this->runExampleScriptTest($script, $expectedOutputs, $cache);
-	}
+    /**
+     * @dataProvider getExampleScriptTestValues
+     * @param string $script
+     * @param array $expectedOutputs
+     * @param string $expectedException
+     */
+    public function testExampleScriptFileWithCache($script, array $expectedOutputs, $expectedException = null)
+    {
+        if ($expectedException !== null) {
+            $this->setExpectedException($expectedException);
+        }
+        $cache = vfsStream::url('fakecache/');
+        $this->runExampleScriptTest($script, $expectedOutputs, $cache);
+        $this->runExampleScriptTest($script, $expectedOutputs, $cache);
+    }
 
-	/**
-	 * @param string $script
-	 * @param array $expectedOutputs
-	 * @param string $FLUID_CACHE_DIRECTORY
-	 */
-	protected function runExampleScriptTest($script, array $expectedOutputs, $FLUID_CACHE_DIRECTORY) {
-		$scriptFile = __DIR__ . '/../../examples/' . $script;
-		$self = $this;
-		$this->setOutputCallback(function($output) use ($self, $expectedOutputs) {
-			foreach ($expectedOutputs as $expectedOutput) {
-				$self->assertContains($expectedOutput, $output);
-			}
-		});
-		include $scriptFile;
-		unset($FLUID_CACHE_DIRECTORY);
-	}
+    /**
+     * @param string $script
+     * @param array $expectedOutputs
+     * @param string $FLUID_CACHE_DIRECTORY
+     */
+    protected function runExampleScriptTest($script, array $expectedOutputs, $FLUID_CACHE_DIRECTORY)
+    {
+        $scriptFile = __DIR__ . '/../../examples/' . $script;
+        $self = $this;
+        $this->setOutputCallback(function ($output) use ($self, $expectedOutputs) {
+            foreach ($expectedOutputs as $expectedOutput) {
+                $self->assertContains($expectedOutput, $output);
+            }
+        });
+        include $scriptFile;
+        unset($FLUID_CACHE_DIRECTORY);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getExampleScriptTestValues() {
-		return array(
-			'example_conditions.php' => array(
-				'example_conditions.php',
-				array(
-					'1 === TRUE',
-					'(0) === FALSE',
-					'(1) === TRUE',
-					'0 && 0 === FALSE',
-					'0 || 0 === FALSE',
-					'1 && 0 === FALSE',
-					'0 && 1 === FALSE',
-					'1 || 0 === TRUE',
-					'0 || 1 === TRUE',
-					'0 || 1 && 0 === FALSE',
-					'0 || 1 && 1 === TRUE',
-					'$varfalse === FALSE',
-					'$vartrue === TRUE',
-					'$vararray1 == $vararray2 === FALSE',
-					'($vararray1 == $vararray1) && $vartrue === TRUE',
-					'$varfalse == $varfalse === TRUE',
-					'$varfalse != $varfalse === FALSE',
-					'$vararray1 == $vararray1 === TRUE',
-					'\'thisstring\' != \'thatstring\' === TRUE'
-				)
-			),
-			'example_customresolving.php' => array(
-				'example_customresolving.php',
-				array(
-					var_export(array('foo' => 'bar'), TRUE),
-					var_export(array('bar' => 'foo'), TRUE),
-				)
-			),
-			'example_format.php' => array(
-				'example_format.php',
-				array(
-					'"layout": "Default.json",',
-					'"foobar": "Variable foobar"'
-				)
-			),
-			'example_layoutless.php' => array(
-				'example_layoutless.php',
-				array(
-					'This section is rendered below',
-					'This text is rendered because it is outside the section'
-				)
-			),
-			'example_math.php' => array(
-				'example_math.php',
-				array(
-					'Expression: $numberten % 4 = 2',
-					'Expression: 4 * $numberten = 40',
-					'Expression: 4 / $numberten = 0.4',
-					'Expression: $numberone / $numberten = 0.1',
-					'Expression: 10 ^ $numberten = 10000000000'
-				)
-			),
-			'example_multiplepaths.php' => array(
-				'example_multiplepaths.php',
-				array(
-					'Rendered via overridden Layout, section "Main":',
-					'Overridden Default template.',
-					'Value of "foobar": This is foobar.',
-					'Contents of FirstPartial.html',
-					'Overridden contents of SecondPartial.html',
-				)
-			),
-			'example_mvc.php' => array(
-				'example_mvc.php',
-				array(
-					'I am the template belonging to the "Default" controller, action "Default".',
-					'I am the template belonging to the "Other" controller, action "Default".',
-					'I am the template belonging to the "Other" controller, action "List".',
-					'Value of "foobar": MVC template.'
-				)
-			),
-			'example_namespaces.php' => array(
-				'example_namespaces.php',
-				array(
-					'Namespaces template',
-					'<invalid:vh>This tag will be shown</invalid:vh>'
-				)
-			),
-			'example_namespaceresolving.php' => array(
-				'example_namespaceresolving.php',
-				array(
-					'NamespaceResolving template from Singles.',
-					'Argument passed to CustomViewHelper:',
-					'123'
-				)
-			),
-			'example_single.php' => array(
-				'example_single.php',
-				array(
-					'Value of "foobar": Single template'
-				)
-			),
-			'example_structures.php' => array(
-				'example_structures.php',
-				array(
-					'This section exists and is rendered: Valid section',
-					'Expects no output because section name is invalid: ' . "\n",
-					'Dynamic section name: Dynamically suffixed section',
-					'Bad dynamic section name, expects fallback: Just a section',
-					'Will render: Just a section',
-					'Will render, clause reversed: Just a section',
-					'Will not render: ' . "\n",
-					'This `f:else` was rendered',
-					'The value was "3"',
-					'The unmatched value case triggered',
-					'The "b" nested switch case was triggered'
-				)
-			),
-			'example_variables.php' => array(
-				'example_variables.php',
-				array(
-					'Simple variable: string foo',
-					'A string with numbers in it: 132',
-					'Ditto, with type name stored in variable: 132',
-					'A comma-separated value iterated as array:' . "\n\t- one\n\t- two",
-					'String variable name with dynamic1 part: String using $dynamic1.',
-					'String variable name with dynamic2 part: String using $dynamic2.',
-					'Array member in $array[$dynamic1]: Dynamic key in $array[$dynamic1]',
-					'Array member in $array[$dynamic2]: Dynamic key in $array[$dynamic2]',
-					'Direct access of numeric prefixed variable: Numeric prefixed variable',
-					'Aliased access of numeric prefixed variable: Numeric prefixed variable',
-					'Received $array.foobar with value <b>Unescaped string</b>',
-					'Received $array.printf with formatted string Formatted string, value: formatted',
-					'Received $array.baz with value 42',
-					'Received $array.xyz.foobar with value Escaped sub-string',
-					'Received $myVariable with value Nice string'
-				)
-			),
-			'example_variableprovider.php' => array(
-				'example_variableprovider.php',
-				array(
-					'VariableProvider template from Singles.',
-					'Random: random',
-				)
-			),
-			'example_dynamiclayout.php' => array(
-				'example_dynamiclayout.php',
-				array(
-					'Rendered via DynamicLayout, section "Main":',
-				)
-			),
-			'example_cachestatic.php' => array(
-				'example_cachestatic.php',
-				array(
-					'Cached as static text 1',
-					'Cached as static text 2',
-					'Cached as static text 3',
-				)
-			)
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getExampleScriptTestValues()
+    {
+        return [
+            'example_conditions.php' => [
+                'example_conditions.php',
+                [
+                    '1 === TRUE',
+                    '(0) === FALSE',
+                    '(1) === TRUE',
+                    '0 && 0 === FALSE',
+                    '0 || 0 === FALSE',
+                    '1 && 0 === FALSE',
+                    '0 && 1 === FALSE',
+                    '1 || 0 === TRUE',
+                    '0 || 1 === TRUE',
+                    '0 || 1 && 0 === FALSE',
+                    '0 || 1 && 1 === TRUE',
+                    '$varfalse === FALSE',
+                    '$vartrue === TRUE',
+                    '$vararray1 == $vararray2 === FALSE',
+                    '($vararray1 == $vararray1) && $vartrue === TRUE',
+                    '$varfalse == $varfalse === TRUE',
+                    '$varfalse != $varfalse === FALSE',
+                    '$vararray1 == $vararray1 === TRUE',
+                    '\'thisstring\' != \'thatstring\' === TRUE'
+                ]
+            ],
+            'example_customresolving.php' => [
+                'example_customresolving.php',
+                [
+                    var_export(['foo' => 'bar'], true),
+                    var_export(['bar' => 'foo'], true),
+                ]
+            ],
+            'example_format.php' => [
+                'example_format.php',
+                [
+                    '"layout": "Default.json",',
+                    '"foobar": "Variable foobar"'
+                ]
+            ],
+            'example_layoutless.php' => [
+                'example_layoutless.php',
+                [
+                    'This section is rendered below',
+                    'This text is rendered because it is outside the section'
+                ]
+            ],
+            'example_math.php' => [
+                'example_math.php',
+                [
+                    'Expression: $numberten % 4 = 2',
+                    'Expression: 4 * $numberten = 40',
+                    'Expression: 4 / $numberten = 0.4',
+                    'Expression: $numberone / $numberten = 0.1',
+                    'Expression: 10 ^ $numberten = 10000000000'
+                ]
+            ],
+            'example_multiplepaths.php' => [
+                'example_multiplepaths.php',
+                [
+                    'Rendered via overridden Layout, section "Main":',
+                    'Overridden Default template.',
+                    'Value of "foobar": This is foobar.',
+                    'Contents of FirstPartial.html',
+                    'Overridden contents of SecondPartial.html',
+                ]
+            ],
+            'example_mvc.php' => [
+                'example_mvc.php',
+                [
+                    'I am the template belonging to the "Default" controller, action "Default".',
+                    'I am the template belonging to the "Other" controller, action "Default".',
+                    'I am the template belonging to the "Other" controller, action "List".',
+                    'Value of "foobar": MVC template.'
+                ]
+            ],
+            'example_namespaces.php' => [
+                'example_namespaces.php',
+                [
+                    'Namespaces template',
+                    '<invalid:vh>This tag will be shown</invalid:vh>'
+                ]
+            ],
+            'example_namespaceresolving.php' => [
+                'example_namespaceresolving.php',
+                [
+                    'NamespaceResolving template from Singles.',
+                    'Argument passed to CustomViewHelper:',
+                    '123'
+                ]
+            ],
+            'example_single.php' => [
+                'example_single.php',
+                [
+                    'Value of "foobar": Single template'
+                ]
+            ],
+            'example_structures.php' => [
+                'example_structures.php',
+                [
+                    'This section exists and is rendered: Valid section',
+                    'Expects no output because section name is invalid: ' . "\n",
+                    'Dynamic section name: Dynamically suffixed section',
+                    'Bad dynamic section name, expects fallback: Just a section',
+                    'Will render: Just a section',
+                    'Will render, clause reversed: Just a section',
+                    'Will not render: ' . "\n",
+                    'This `f:else` was rendered',
+                    'The value was "3"',
+                    'The unmatched value case triggered',
+                    'The "b" nested switch case was triggered'
+                ]
+            ],
+            'example_variables.php' => [
+                'example_variables.php',
+                [
+                    'Simple variable: string foo',
+                    'A string with numbers in it: 132',
+                    'Ditto, with type name stored in variable: 132',
+                    'A comma-separated value iterated as array:' . "\n\t- one\n\t- two",
+                    'String variable name with dynamic1 part: String using $dynamic1.',
+                    'String variable name with dynamic2 part: String using $dynamic2.',
+                    'Array member in $array[$dynamic1]: Dynamic key in $array[$dynamic1]',
+                    'Array member in $array[$dynamic2]: Dynamic key in $array[$dynamic2]',
+                    'Direct access of numeric prefixed variable: Numeric prefixed variable',
+                    'Aliased access of numeric prefixed variable: Numeric prefixed variable',
+                    'Received $array.foobar with value <b>Unescaped string</b>',
+                    'Received $array.printf with formatted string Formatted string, value: formatted',
+                    'Received $array.baz with value 42',
+                    'Received $array.xyz.foobar with value Escaped sub-string',
+                    'Received $myVariable with value Nice string'
+                ]
+            ],
+            'example_variableprovider.php' => [
+                'example_variableprovider.php',
+                [
+                    'VariableProvider template from Singles.',
+                    'Random: random',
+                ]
+            ],
+            'example_dynamiclayout.php' => [
+                'example_dynamiclayout.php',
+                [
+                    'Rendered via DynamicLayout, section "Main":',
+                ]
+            ],
+            'example_cachestatic.php' => [
+                'example_cachestatic.php',
+                [
+                    'Cached as static text 1',
+                    'Cached as static text 2',
+                    'Cached as static text 3',
+                ]
+            ]
+        ];
+    }
 }

--- a/tests/Functional/Fixtures/ViewHelpers/AbstractEscapingViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/AbstractEscapingViewHelper.php
@@ -6,19 +6,22 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * Class AbstractEscapingViewHelper
  */
-abstract class AbstractEscapingViewHelper extends AbstractViewHelper {
+abstract class AbstractEscapingViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @return void
-	 */
-    public function initializeArguments() {
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
         $this->registerArgument('content', 'string', 'Content provided as argument');
     }
 
     /**
      * @return string
      */
-    public function render() {
+    public function render()
+    {
         if (!isset($this->arguments['content'])) {
             $content = $this->renderChildren();
         } else {
@@ -26,5 +29,4 @@ abstract class AbstractEscapingViewHelper extends AbstractViewHelper {
         }
         return $content;
     }
-
 }

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper.php
@@ -17,9 +17,9 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 /**
  * Class EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper
  */
-class EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper extends AbstractEscapingViewHelper {
+class EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper extends AbstractEscapingViewHelper
+{
 
-    protected $escapeChildren = FALSE;
-    protected $escapeOutput = FALSE;
-
+    protected $escapeChildren = false;
+    protected $escapeOutput = false;
 }

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper.php
@@ -17,9 +17,9 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 /**
  * Class EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper
  */
-class EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper extends AbstractEscapingViewHelper {
+class EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper extends AbstractEscapingViewHelper
+{
 
-    protected $escapeChildren = FALSE;
-    protected $escapeOutput = TRUE;
-
+    protected $escapeChildren = false;
+    protected $escapeOutput = true;
 }

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper.php
@@ -17,9 +17,9 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 /**
  * Class EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper
  */
-class EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper extends AbstractEscapingViewHelper {
+class EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper extends AbstractEscapingViewHelper
+{
 
-    protected $escapeChildren = TRUE;
-    protected $escapeOutput = FALSE;
-
+    protected $escapeChildren = true;
+    protected $escapeOutput = false;
 }

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper.php
@@ -17,9 +17,9 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 /**
  * Class EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper
  */
-class EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper extends AbstractEscapingViewHelper {
+class EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper extends AbstractEscapingViewHelper
+{
 
-    protected $escapeChildren = TRUE;
-    protected $escapeOutput = TRUE;
-
+    protected $escapeChildren = true;
+    protected $escapeOutput = true;
 }

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -14,100 +14,105 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class FluidCacheWarmupResultTest
  */
-class FluidCacheWarmupResultTest extends UnitTestCase {
+class FluidCacheWarmupResultTest extends UnitTestCase
+{
 
-	/**
-	 * @param array $results
-	 * @param array $expected
-	 * @dataProvider getCacheWarmupResultTestValues
-	 * @test
-	 */
-	public function testMerge(array $results, array $expected) {
-		$result1 = $this->getAccessibleMock(FluidCacheWarmupResult::class, array('dummy'));
-		$result1->_set('results', array_pop($results));
-		$result2 = $this->getAccessibleMock(FluidCacheWarmupResult::class, array('dummy'));
-		$result2->_set('results', array_pop($results));
-		$result1->merge($result2);
-		$this->assertAttributeSame($expected, 'results', $result1);
-	}
+    /**
+     * @param array $results
+     * @param array $expected
+     * @dataProvider getCacheWarmupResultTestValues
+     * @test
+     */
+    public function testMerge(array $results, array $expected)
+    {
+        $result1 = $this->getAccessibleMock(FluidCacheWarmupResult::class, ['dummy']);
+        $result1->_set('results', array_pop($results));
+        $result2 = $this->getAccessibleMock(FluidCacheWarmupResult::class, ['dummy']);
+        $result2->_set('results', array_pop($results));
+        $result1->merge($result2);
+        $this->assertAttributeSame($expected, 'results', $result1);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getCacheWarmupResultTestValues() {
-		return array(
-			array(array(array('foo' => 'bar'), array('baz' => 'oof')), array('baz' => 'oof', 'foo' => 'bar')),
-			array(array(array('foo' => 'bar'), array('baz' => 'oof', 'foo' => 'baz')), array('baz' => 'oof', 'foo' => 'baz')),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getCacheWarmupResultTestValues()
+    {
+        return [
+            [[['foo' => 'bar'], ['baz' => 'oof']], ['baz' => 'oof', 'foo' => 'bar']],
+            [[['foo' => 'bar'], ['baz' => 'oof', 'foo' => 'baz']], ['baz' => 'oof', 'foo' => 'baz']],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetResults() {
-		$subject = $this->getAccessibleMock(FluidCacheWarmupResult::class, array('dummy'));
-		$subject->_set('results', array('foo' => 'bar'));
-		$this->assertAttributeEquals(array('foo' => 'bar'), 'results', $subject);
-	}
+    /**
+     * @test
+     */
+    public function testGetResults()
+    {
+        $subject = $this->getAccessibleMock(FluidCacheWarmupResult::class, ['dummy']);
+        $subject->_set('results', ['foo' => 'bar']);
+        $this->assertAttributeEquals(['foo' => 'bar'], 'results', $subject);
+    }
 
-	/**
-	 * @param ParsedTemplateInterface $subject
-	 * @param array $expected
-	 * @dataProvider getAddTestValues
-	 * @test
-	 */
-	public function testAdd(ParsedTemplateInterface $subject, array $expected) {
-		$result = new FluidCacheWarmupResult();
-		$result->add($subject, 'foobar');
-		$this->assertAttributeEquals(array('foobar' => $expected), 'results', $result);
-	}
+    /**
+     * @param ParsedTemplateInterface $subject
+     * @param array $expected
+     * @dataProvider getAddTestValues
+     * @test
+     */
+    public function testAdd(ParsedTemplateInterface $subject, array $expected)
+    {
+        $result = new FluidCacheWarmupResult();
+        $result->add($subject, 'foobar');
+        $this->assertAttributeEquals(['foobar' => $expected], 'results', $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAddTestValues() {
-		$subject1 = $this->getMockBuilder(
-			ParsedTemplateInterface::class
-		)->setMethods(
-			array('isCompiled', 'isCompilable', 'hasLayout', 'getIdentifier')
-		)->getMockForAbstractClass();
-		$subject1->expects($this->exactly(2))->method('isCompiled')->willReturn(FALSE);
-		$subject1->expects($this->once())->method('isCompilable')->willReturn(TRUE);
-		$subject1->expects($this->once())->method('hasLayout')->willReturn(FALSE);
-		$subject1->expects($this->once())->method('getIdentifier')->willReturn('subject1-identifier');
-		$subject2 = $this->getMockBuilder(
-			FailedCompilingState::class
-		)->setMethods(
-			array('isCompiled', 'isCompilable', 'hasLayout', 'getIdentifier', 'getFailureReason', 'getMitigations')
-		)->getMockForAbstractClass();
-		$subject2->expects($this->exactly(2))->method('isCompiled')->willReturn(TRUE);
-		$subject2->expects($this->once())->method('isCompilable')->willReturn(TRUE);
-		$subject2->expects($this->once())->method('hasLayout')->willReturn(TRUE);
-		$subject2->expects($this->once())->method('getIdentifier')->willReturn('subject2-identifier');
-		$subject2->expects($this->once())->method('getFailureReason')->willReturn('failure-reason');
-		$subject2->expects($this->once())->method('getMitigations')->willReturn(array('m1', 'm2'));
-		return array(
-			array(
-				$subject1,
-				array(
-					FluidCacheWarmupResult::RESULT_COMPILABLE => TRUE,
-					FluidCacheWarmupResult::RESULT_COMPILED => FALSE,
-					FluidCacheWarmupResult::RESULT_HASLAYOUT => FALSE,
-					FluidCacheWarmupResult::RESULT_COMPILEDCLASS => 'subject1-identifier'
-				)
-			),
-			array(
-				$subject2,
-				array(
-					FluidCacheWarmupResult::RESULT_COMPILABLE => TRUE,
-					FluidCacheWarmupResult::RESULT_COMPILED => TRUE,
-					FluidCacheWarmupResult::RESULT_HASLAYOUT => TRUE,
-					FluidCacheWarmupResult::RESULT_COMPILEDCLASS => 'subject2-identifier',
-					FluidCacheWarmupResult::RESULT_FAILURE => 'failure-reason',
-					FluidCacheWarmupResult::RESULT_MITIGATIONS => array('m1', 'm2')
-				)
-			),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getAddTestValues()
+    {
+        $subject1 = $this->getMockBuilder(
+            ParsedTemplateInterface::class
+        )->setMethods(
+            ['isCompiled', 'isCompilable', 'hasLayout', 'getIdentifier']
+        )->getMockForAbstractClass();
+        $subject1->expects($this->exactly(2))->method('isCompiled')->willReturn(false);
+        $subject1->expects($this->once())->method('isCompilable')->willReturn(true);
+        $subject1->expects($this->once())->method('hasLayout')->willReturn(false);
+        $subject1->expects($this->once())->method('getIdentifier')->willReturn('subject1-identifier');
+        $subject2 = $this->getMockBuilder(
+            FailedCompilingState::class
+        )->setMethods(
+            ['isCompiled', 'isCompilable', 'hasLayout', 'getIdentifier', 'getFailureReason', 'getMitigations']
+        )->getMockForAbstractClass();
+        $subject2->expects($this->exactly(2))->method('isCompiled')->willReturn(true);
+        $subject2->expects($this->once())->method('isCompilable')->willReturn(true);
+        $subject2->expects($this->once())->method('hasLayout')->willReturn(true);
+        $subject2->expects($this->once())->method('getIdentifier')->willReturn('subject2-identifier');
+        $subject2->expects($this->once())->method('getFailureReason')->willReturn('failure-reason');
+        $subject2->expects($this->once())->method('getMitigations')->willReturn(['m1', 'm2']);
+        return [
+            [
+                $subject1,
+                [
+                    FluidCacheWarmupResult::RESULT_COMPILABLE => true,
+                    FluidCacheWarmupResult::RESULT_COMPILED => false,
+                    FluidCacheWarmupResult::RESULT_HASLAYOUT => false,
+                    FluidCacheWarmupResult::RESULT_COMPILEDCLASS => 'subject1-identifier'
+                ]
+            ],
+            [
+                $subject2,
+                [
+                    FluidCacheWarmupResult::RESULT_COMPILABLE => true,
+                    FluidCacheWarmupResult::RESULT_COMPILED => true,
+                    FluidCacheWarmupResult::RESULT_HASLAYOUT => true,
+                    FluidCacheWarmupResult::RESULT_COMPILEDCLASS => 'subject2-identifier',
+                    FluidCacheWarmupResult::RESULT_FAILURE => 'failure-reason',
+                    FluidCacheWarmupResult::RESULT_MITIGATIONS => ['m1', 'm2']
+                ]
+            ],
+        ];
+    }
 }

--- a/tests/Unit/Core/Cache/SimpleFileCacheTest.php
+++ b/tests/Unit/Core/Cache/SimpleFileCacheTest.php
@@ -15,114 +15,124 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class SimpleFileCacheTest
  */
-class SimpleFileCacheTest extends UnitTestCase {
+class SimpleFileCacheTest extends UnitTestCase
+{
 
-	/**
-	 * @var vfsStreamDirectory
-	 */
-	protected $directory;
+    /**
+     * @var vfsStreamDirectory
+     */
+    protected $directory;
 
-	/**
-	 * @return void
-	 */
-	public function setUp() {
-		$this->directory = vfsStream::setup('cache');
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->directory = vfsStream::setup('cache');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetCacheWarmerReturnsStandardCacheWarmer() {
-		$cache = new SimpleFileCache(vfsStream::url('cache/'));
-		$this->assertInstanceOf(StandardCacheWarmer::class, $cache->getCacheWarmer());
-	}
+    /**
+     * @test
+     */
+    public function testGetCacheWarmerReturnsStandardCacheWarmer()
+    {
+        $cache = new SimpleFileCache(vfsStream::url('cache/'));
+        $this->assertInstanceOf(StandardCacheWarmer::class, $cache->getCacheWarmer());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetReturnsFalseWhenNotFound() {
-		$cache = new SimpleFileCache(vfsStream::url('cache/'));
-		$result = $cache->get('test');
-		$this->assertFalse($result);
-	}
+    /**
+     * @test
+     */
+    public function testGetReturnsFalseWhenNotFound()
+    {
+        $cache = new SimpleFileCache(vfsStream::url('cache/'));
+        $result = $cache->get('test');
+        $this->assertFalse($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetReturnsTrueWhenFound() {
-		$cache = new SimpleFileCache(vfsStream::url('cache/'));
-		$result = $cache->get('DateTime');
-		$this->assertTrue($result);
-	}
+    /**
+     * @test
+     */
+    public function testGetReturnsTrueWhenFound()
+    {
+        $cache = new SimpleFileCache(vfsStream::url('cache/'));
+        $result = $cache->get('DateTime');
+        $this->assertTrue($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddToCacheCreatesFile() {
-		$cache = new SimpleFileCache(vfsStream::url('cache/'));
-		$cache->set('test', '<?php' . PHP_EOL . 'class MyCachedClass {}' . PHP_EOL);
-		$this->assertFileExists(vfsStream::url('cache/test.php'));
-	}
+    /**
+     * @test
+     */
+    public function testAddToCacheCreatesFile()
+    {
+        $cache = new SimpleFileCache(vfsStream::url('cache/'));
+        $cache->set('test', '<?php' . PHP_EOL . 'class MyCachedClass {}' . PHP_EOL);
+        $this->assertFileExists(vfsStream::url('cache/test.php'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetLoadsFile() {
-		$cache = new SimpleFileCache(vfsStream::url('cache/'));
-		$cache->set('test', '<?php' . PHP_EOL . 'class MyCachedClass {}' . PHP_EOL);
-		$result = $cache->get('test');
-		$this->assertTrue(class_exists('MyCachedClass', FALSE));
-	}
+    /**
+     * @test
+     */
+    public function testGetLoadsFile()
+    {
+        $cache = new SimpleFileCache(vfsStream::url('cache/'));
+        $cache->set('test', '<?php' . PHP_EOL . 'class MyCachedClass {}' . PHP_EOL);
+        $result = $cache->get('test');
+        $this->assertTrue(class_exists('MyCachedClass', false));
+    }
 
-	/**
-	 * @test
-	 */
-	public function testFlushAll() {
-		$cache = $this->getMock(
-			SimpleFileCache::class,
-			array('getCachedFilenames', 'flushByFilename', 'flushByname'),
-			array(vfsStream::url('cache/'))
-		);
-		$cache->expects($this->never())->method('flushByName');
-		$cache->expects($this->once())->method('getCachedFilenames')->willReturn(array('foo'));
-		$cache->expects($this->once())->method('flushByFilename')->with('foo');
-		$cache->flush();
-	}
+    /**
+     * @test
+     */
+    public function testFlushAll()
+    {
+        $cache = $this->getMock(
+            SimpleFileCache::class,
+            ['getCachedFilenames', 'flushByFilename', 'flushByname'],
+            [vfsStream::url('cache/')]
+        );
+        $cache->expects($this->never())->method('flushByName');
+        $cache->expects($this->once())->method('getCachedFilenames')->willReturn(['foo']);
+        $cache->expects($this->once())->method('flushByFilename')->with('foo');
+        $cache->flush();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testFlushByName() {
-		$cache = $this->getMock(
-			SimpleFileCache::class,
-			array('getCachedFilenames', 'flushByFilename', 'flushByname'),
-			array(vfsStream::url('cache/'))
-		);
-		$cache->expects($this->once())->method('flushByName')->with('foo');
-		$cache->expects($this->never())->method('getCachedFilenames');
-		$cache->expects($this->never())->method('flushByFilename');
-		$cache->flush('foo');
-	}
+    /**
+     * @test
+     */
+    public function testFlushByName()
+    {
+        $cache = $this->getMock(
+            SimpleFileCache::class,
+            ['getCachedFilenames', 'flushByFilename', 'flushByname'],
+            [vfsStream::url('cache/')]
+        );
+        $cache->expects($this->once())->method('flushByName')->with('foo');
+        $cache->expects($this->never())->method('getCachedFilenames');
+        $cache->expects($this->never())->method('flushByFilename');
+        $cache->flush('foo');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testFlushByNameDeletesSingleFile() {
-		$cache = new SimpleFileCache(vfsStream::url('cache/'));
-		$cache->set('test', '<?php' . PHP_EOL . 'class MyCachedClass {}' . PHP_EOL);
-		$cache->set('test2', '<?php' . PHP_EOL . 'class MyOtherCachedClass {}' . PHP_EOL);
-		$cache->flush('test');
-		$this->assertFileExists(vfsStream::url('cache/test2.php'));
-		$this->assertFileNotExists(vfsStream::url('cache/test.php'));
-	}
+    /**
+     * @test
+     */
+    public function testFlushByNameDeletesSingleFile()
+    {
+        $cache = new SimpleFileCache(vfsStream::url('cache/'));
+        $cache->set('test', '<?php' . PHP_EOL . 'class MyCachedClass {}' . PHP_EOL);
+        $cache->set('test2', '<?php' . PHP_EOL . 'class MyOtherCachedClass {}' . PHP_EOL);
+        $cache->flush('test');
+        $this->assertFileExists(vfsStream::url('cache/test2.php'));
+        $this->assertFileNotExists(vfsStream::url('cache/test.php'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetThrowsRuntimeExceptionOnInvalidDirectory() {
-		$cache = new SimpleFileCache('/does/not/exist');
-		$this->setExpectedException('RuntimeException');
-		$cache->set('foo', 'bar');
-	}
-
+    /**
+     * @test
+     */
+    public function testSetThrowsRuntimeExceptionOnInvalidDirectory()
+    {
+        $cache = new SimpleFileCache('/does/not/exist');
+        $this->setExpectedException('RuntimeException');
+        $cache->set('foo', 'bar');
+    }
 }

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -25,102 +25,106 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 /**
  * Class StandardCacheWarmerTest
  */
-class StandardCacheWarmerTest extends UnitTestCase {
+class StandardCacheWarmerTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testWarm() {
-		$failedCompilingState = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
-		$subject = $this->getMockBuilder(StandardCacheWarmer::class)
-			->setMethods(array('warmSingleFile', 'detectControllerNamesInTemplateRootPaths'))
-			->getMock();
-		$subject->expects($this->exactly(7))
-			->method('detectControllerNamesInTemplateRootPaths')
-			->willReturn(array('Default', 'Standard'));
-		$subject->expects($this->exactly(70))
-			->method('warmSingleFile')
-			->willReturn($failedCompilingState);
-		$context = new RenderingContextFixture();
-		$paths = $this->getMockBuilder(TemplatePaths::class)
-			->setMethods(
-				array(
-					'resolveAvailableTemplateFiles',
-					'resolveAvailablePartialFiles',
-					'resolveAvailableLayoutFiles',
-					'resolveFileInPaths'
-				)
-			)
-			->getMock();
-		$paths->expects($this->exactly(21))
-			->method('resolveAvailableTemplateFiles')
-			->willReturn(array('foo', 'bar'));
-		$paths->expects($this->exactly(7))
-			->method('resolveAvailablePartialFiles')
-			->willReturn(array('foo', 'bar'));
-		$paths->expects($this->exactly(7))
-			->method('resolveAvailableLayoutFiles')
-			->willReturn(array('foo', 'bar'));
-		$paths->expects($this->exactly(56))->method('resolveFileInPaths')->willReturn('/dev/null');
-		$compiler = $this->getMockBuilder(TemplateCompiler::class)
-			->setMethods(array('enterWarmupMode'))
-			->getMock();
-		$compiler->expects($this->once())->method('enterWarmupMode');
-		$context->setTemplateCompiler($compiler);
-		$context->setTemplatePaths($paths);
-		$failedCompilingState->_set('variableContainer', new StandardVariableProvider());
-		$result = $subject->warm($context);
-		$this->assertInstanceOf(FluidCacheWarmupResult::class, $result);
-	}
+    /**
+     * @test
+     */
+    public function testWarm()
+    {
+        $failedCompilingState = $this->getAccessibleMock(FailedCompilingState::class, ['dummy']);
+        $subject = $this->getMockBuilder(StandardCacheWarmer::class)
+            ->setMethods(['warmSingleFile', 'detectControllerNamesInTemplateRootPaths'])
+            ->getMock();
+        $subject->expects($this->exactly(7))
+            ->method('detectControllerNamesInTemplateRootPaths')
+            ->willReturn(['Default', 'Standard']);
+        $subject->expects($this->exactly(70))
+            ->method('warmSingleFile')
+            ->willReturn($failedCompilingState);
+        $context = new RenderingContextFixture();
+        $paths = $this->getMockBuilder(TemplatePaths::class)
+            ->setMethods(
+                [
+                    'resolveAvailableTemplateFiles',
+                    'resolveAvailablePartialFiles',
+                    'resolveAvailableLayoutFiles',
+                    'resolveFileInPaths'
+                ]
+            )
+            ->getMock();
+        $paths->expects($this->exactly(21))
+            ->method('resolveAvailableTemplateFiles')
+            ->willReturn(['foo', 'bar']);
+        $paths->expects($this->exactly(7))
+            ->method('resolveAvailablePartialFiles')
+            ->willReturn(['foo', 'bar']);
+        $paths->expects($this->exactly(7))
+            ->method('resolveAvailableLayoutFiles')
+            ->willReturn(['foo', 'bar']);
+        $paths->expects($this->exactly(56))->method('resolveFileInPaths')->willReturn('/dev/null');
+        $compiler = $this->getMockBuilder(TemplateCompiler::class)
+            ->setMethods(['enterWarmupMode'])
+            ->getMock();
+        $compiler->expects($this->once())->method('enterWarmupMode');
+        $context->setTemplateCompiler($compiler);
+        $context->setTemplatePaths($paths);
+        $failedCompilingState->_set('variableContainer', new StandardVariableProvider());
+        $result = $subject->warm($context);
+        $this->assertInstanceOf(FluidCacheWarmupResult::class, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testDetectControllerNamesInTemplateRootPaths() {
-		$subject = new StandardCacheWarmer();
-		$method = new \ReflectionMethod($subject, 'detectControllerNamesInTemplateRootPaths');
-		$method->setAccessible(TRUE);
-		$directory = realpath(__DIR__ . '/../../../../examples/Resources/Private/Templates/');
-		$generator = $method->invokeArgs($subject, array(array($directory)));
-		foreach ($generator as $resolvedControllerName) {
-			$this->assertNotEmpty($resolvedControllerName, 'Generator yielded an empty controller name!');
-		}
-	}
+    /**
+     * @test
+     */
+    public function testDetectControllerNamesInTemplateRootPaths()
+    {
+        $subject = new StandardCacheWarmer();
+        $method = new \ReflectionMethod($subject, 'detectControllerNamesInTemplateRootPaths');
+        $method->setAccessible(true);
+        $directory = realpath(__DIR__ . '/../../../../examples/Resources/Private/Templates/');
+        $generator = $method->invokeArgs($subject, [[$directory]]);
+        foreach ($generator as $resolvedControllerName) {
+            $this->assertNotEmpty($resolvedControllerName, 'Generator yielded an empty controller name!');
+        }
+    }
 
-	/**
-	 * @param \RuntimeException $error
-	 * @dataProvider getWarmSingleFileExceptionTestValues
-	 * @test
-	 */
-	public function testWarmuSingleFileHandlesException(\RuntimeException $error) {
-		$subject = new StandardCacheWarmer();
-		$context = new RenderingContextFixture();
-		$parser = $this->getMock(TemplateParser::class, array('getOrParseAndStoreTemplate'));
-		$parser->expects($this->once())->method('getOrParseAndStoreTemplate')->willThrowException($error);
-		$variableProvider = new StandardVariableProvider(array('foo' => 'bar'));
-		$context->setVariableProvider($variableProvider);
-		$context->setTemplateParser($parser);
-		$method = new \ReflectionMethod($subject, 'warmSingleFile');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($subject, array('/some/file', 'some_file', $context));
-		$this->assertInstanceOf(ParsedTemplateInterface::class, $result);
-		$this->assertAttributeNotEmpty('failureReason', $result);
-		$this->assertAttributeNotEmpty('mitigations', $result);
-	}
+    /**
+     * @param \RuntimeException $error
+     * @dataProvider getWarmSingleFileExceptionTestValues
+     * @test
+     */
+    public function testWarmuSingleFileHandlesException(\RuntimeException $error)
+    {
+        $subject = new StandardCacheWarmer();
+        $context = new RenderingContextFixture();
+        $parser = $this->getMock(TemplateParser::class, ['getOrParseAndStoreTemplate']);
+        $parser->expects($this->once())->method('getOrParseAndStoreTemplate')->willThrowException($error);
+        $variableProvider = new StandardVariableProvider(['foo' => 'bar']);
+        $context->setVariableProvider($variableProvider);
+        $context->setTemplateParser($parser);
+        $method = new \ReflectionMethod($subject, 'warmSingleFile');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($subject, ['/some/file', 'some_file', $context]);
+        $this->assertInstanceOf(ParsedTemplateInterface::class, $result);
+        $this->assertAttributeNotEmpty('failureReason', $result);
+        $this->assertAttributeNotEmpty('mitigations', $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getWarmSingleFileExceptionTestValues() {
-		return array(
-			array(new StopCompilingException('StopCompiling exception')),
-			array(new ExpressionException('Expression exception')),
-			array(new Exception('Parser exception')),
-			array(new \TYPO3Fluid\Fluid\Core\ViewHelper\Exception('ViewHelper exception')),
-			array(new \TYPO3Fluid\Fluid\Core\Exception('Fluid core exception')),
-			array(new \TYPO3Fluid\Fluid\View\Exception('Fluid view exception')),
-			array(new \RuntimeException('General runtime exception'))
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getWarmSingleFileExceptionTestValues()
+    {
+        return [
+            [new StopCompilingException('StopCompiling exception')],
+            [new ExpressionException('Expression exception')],
+            [new Exception('Parser exception')],
+            [new \TYPO3Fluid\Fluid\Core\ViewHelper\Exception('ViewHelper exception')],
+            [new \TYPO3Fluid\Fluid\Core\Exception('Fluid core exception')],
+            [new \TYPO3Fluid\Fluid\View\Exception('Fluid view exception')],
+            [new \RuntimeException('General runtime exception')]
+        ];
+    }
 }

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -14,90 +14,99 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class AbstractCompiledTemplateTest
  */
-class AbstractCompiledTemplateTest extends UnitTestCase {
+class AbstractCompiledTemplateTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testSetIdentifierDoesNotChangeObject() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$before = clone $instance;
-		$instance->setIdentifier('test');
-		$this->assertEquals($before, $instance);
-	}
+    /**
+     * @test
+     */
+    public function testSetIdentifierDoesNotChangeObject()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $before = clone $instance;
+        $instance->setIdentifier('test');
+        $this->assertEquals($before, $instance);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetIdentifierReturnsClassName() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$this->assertEquals($instance->getIdentifier(), get_class($instance));
-	}
+    /**
+     * @test
+     */
+    public function testGetIdentifierReturnsClassName()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $this->assertEquals($instance->getIdentifier(), get_class($instance));
+    }
 
-	/**
-	 * @test
-	 */
-	public function testParentGetVariableContainerMethodReturnsStandardVariableProvider() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->getVariableContainer();
-		$this->assertInstanceOf(StandardVariableProvider::class, $result);
-	}
+    /**
+     * @test
+     */
+    public function testParentGetVariableContainerMethodReturnsStandardVariableProvider()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $result = $instance->getVariableContainer();
+        $this->assertInstanceOf(StandardVariableProvider::class, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testParentRenderMethodReturnsEmptyString() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->render(new RenderingContextFixture());
-		$this->assertEquals('', $result);
-	}
+    /**
+     * @test
+     */
+    public function testParentRenderMethodReturnsEmptyString()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $result = $instance->render(new RenderingContextFixture());
+        $this->assertEquals('', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testParentGetLayoutNameMethodReturnsEmptyString() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->getLayoutName(new RenderingContextFixture());
-		$this->assertEquals('', $result);
-	}
+    /**
+     * @test
+     */
+    public function testParentGetLayoutNameMethodReturnsEmptyString()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $result = $instance->getLayoutName(new RenderingContextFixture());
+        $this->assertEquals('', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testParentHasLayoutMethodReturnsFalse() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->hasLayout();
-		$this->assertEquals(FALSE, $result);
-	}
+    /**
+     * @test
+     */
+    public function testParentHasLayoutMethodReturnsFalse()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $result = $instance->hasLayout();
+        $this->assertEquals(false, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testIsCompilableReturnsFalse() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->isCompilable();
-		$this->assertFalse($result);
-	}
+    /**
+     * @test
+     */
+    public function testIsCompilableReturnsFalse()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $result = $instance->isCompilable();
+        $this->assertFalse($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testIsCompiledReturnsTrue() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$result = $instance->isCompiled();
-		$this->assertTrue($result);
-	}
+    /**
+     * @test
+     */
+    public function testIsCompiledReturnsTrue()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $result = $instance->isCompiled();
+        $this->assertTrue($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddCompiledNamespacesDoesNothing() {
-		$instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-		$context = new RenderingContextFixture();
-		$before = $context->getViewHelperResolver()->getNamespaces();
-		$instance->addCompiledNamespaces($context);
-		$after = $context->getViewHelperResolver()->getNamespaces();
-		$this->assertEquals($before, $after);
-	}
-
+    /**
+     * @test
+     */
+    public function testAddCompiledNamespacesDoesNothing()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $context = new RenderingContextFixture();
+        $before = $context->getViewHelperResolver()->getNamespaces();
+        $instance->addCompiledNamespaces($context);
+        $after = $context->getViewHelperResolver()->getNamespaces();
+        $this->assertEquals($before, $after);
+    }
 }

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -12,7 +12,8 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class FailedCompilingStateTest
  */
-class FailedCompilingStateTest extends UnitTestCase {
+class FailedCompilingStateTest extends UnitTestCase
+{
 
     /**
      * @param string $property
@@ -20,8 +21,9 @@ class FailedCompilingStateTest extends UnitTestCase {
      * @dataProvider getPropertyTestValues
      * @test
      */
-    public function testGetter($property, $value) {
-        $subject = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
+    public function testGetter($property, $value)
+    {
+        $subject = $this->getAccessibleMock(FailedCompilingState::class, ['dummy']);
         $subject->_set($property, $value);
         $method = 'get' . ucfirst($property);
         $this->assertEquals($value, $subject->$method());
@@ -33,8 +35,9 @@ class FailedCompilingStateTest extends UnitTestCase {
      * @dataProvider getPropertyTestValues
      * @test
      */
-    public function testSetter($property, $value) {
-        $subject = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
+    public function testSetter($property, $value)
+    {
+        $subject = $this->getAccessibleMock(FailedCompilingState::class, ['dummy']);
         $subject->_set($property, $value);
         $method = 'set' . ucfirst($property);
         $subject->$method($value);
@@ -44,21 +47,22 @@ class FailedCompilingStateTest extends UnitTestCase {
     /**
      * @test
      */
-    public function testAddMitigation() {
-        $subject = $this->getAccessibleMock(FailedCompilingState::class, array('dummy'));
-        $subject->_set('mitigations', array('m1'));
+    public function testAddMitigation()
+    {
+        $subject = $this->getAccessibleMock(FailedCompilingState::class, ['dummy']);
+        $subject->_set('mitigations', ['m1']);
         $subject->addMitigation('m2');
-        $this->assertAttributeEquals(array('m1', 'm2'), 'mitigations', $subject);
+        $this->assertAttributeEquals(['m1', 'm2'], 'mitigations', $subject);
     }
 
     /**
      * @return array
      */
-    public function getPropertyTestValues() {
-        return array(
-            array('failureReason', 'test reason'),
-            array('mitigations', array('m1', 'm2'))
-        );
+    public function getPropertyTestValues()
+    {
+        return [
+            ['failureReason', 'test reason'],
+            ['mitigations', ['m1', 'm2']]
+        ];
     }
-
 }

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -26,139 +26,144 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class NodeConverterTest
  */
-class NodeConverterTest extends UnitTestCase {
+class NodeConverterTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testSetVariableCounter() {
-		$instance = new NodeConverter(new TemplateCompiler());
-		$instance->setVariableCounter(10);
-		$this->assertAttributeEquals(10, 'variableCounter', $instance);
-	}
+    /**
+     * @test
+     */
+    public function testSetVariableCounter()
+    {
+        $instance = new NodeConverter(new TemplateCompiler());
+        $instance->setVariableCounter(10);
+        $this->assertAttributeEquals(10, 'variableCounter', $instance);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getConvertMethodCallTestValues
-	 * @param NodeInterface $node
-	 * @param string $expected
-	 */
-	public function testConvertCallsExpectedMethod(NodeInterface $node, $expected) {
-		$instance = $this->getMock(NodeConverter::class, array($expected), array(), '', FALSE);
-		$instance->expects($this->once())->method($expected);
-		$instance->convert($node);
-	}
+    /**
+     * @test
+     * @dataProvider getConvertMethodCallTestValues
+     * @param NodeInterface $node
+     * @param string $expected
+     */
+    public function testConvertCallsExpectedMethod(NodeInterface $node, $expected)
+    {
+        $instance = $this->getMock(NodeConverter::class, [$expected], [], '', false);
+        $instance->expects($this->once())->method($expected);
+        $instance->convert($node);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getConvertMethodCallTestValues() {
-		return array(
-			array($this->getMock(TextNode::class, array(), array(), '', FALSE), 'convertTextNode'),
-			array($this->getMock(ExpressionNodeInterface::class), 'convertExpressionNode'),
-			array($this->getMock(NumericNode::class, array(), array(), '', FALSE), 'convertNumericNode'),
-			array($this->getMock(ViewHelperNode::class, array(), array(), '', FALSE), 'convertViewHelperNode'),
-			array($this->getMock(ObjectAccessorNode::class, array(), array(), '', FALSE), 'convertObjectAccessorNode'),
-			array($this->getMock(ArrayNode::class, array(), array(), '', FALSE), 'convertArrayNode'),
-			array($this->getMock(RootNode::class, array(), array(), '', FALSE), 'convertListOfSubNodes'),
-			array($this->getMock(BooleanNode::class, array(), array(), '', FALSE), 'convertBooleanNode'),
-			array($this->getMock(EscapingNode::class, array(), array(), '', FALSE), 'convertEscapingNode'),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getConvertMethodCallTestValues()
+    {
+        return [
+            [$this->getMock(TextNode::class, [], [], '', false), 'convertTextNode'],
+            [$this->getMock(ExpressionNodeInterface::class), 'convertExpressionNode'],
+            [$this->getMock(NumericNode::class, [], [], '', false), 'convertNumericNode'],
+            [$this->getMock(ViewHelperNode::class, [], [], '', false), 'convertViewHelperNode'],
+            [$this->getMock(ObjectAccessorNode::class, [], [], '', false), 'convertObjectAccessorNode'],
+            [$this->getMock(ArrayNode::class, [], [], '', false), 'convertArrayNode'],
+            [$this->getMock(RootNode::class, [], [], '', false), 'convertListOfSubNodes'],
+            [$this->getMock(BooleanNode::class, [], [], '', false), 'convertBooleanNode'],
+            [$this->getMock(EscapingNode::class, [], [], '', false), 'convertEscapingNode'],
+        ];
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getConvertTestValues
-	 * @param NodeInterface $node
-	 * @param string $expected
-	 */
-	public function testConvert(NodeInterface $node, $expected) {
-		$instance = new NodeConverter(new TemplateCompiler());
-		$result = $instance->convert($node);
-		$this->assertEquals($expected, $result['execution']);
-	}
+    /**
+     * @test
+     * @dataProvider getConvertTestValues
+     * @param NodeInterface $node
+     * @param string $expected
+     */
+    public function testConvert(NodeInterface $node, $expected)
+    {
+        $instance = new NodeConverter(new TemplateCompiler());
+        $result = $instance->convert($node);
+        $this->assertEquals($expected, $result['execution']);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getConvertTestValues() {
-		$treeBooleanRoot = new RootNode();
-		$treeBooleanRoot->addChildNode(new TextNode('1'));
-		$treeBooleanRoot->addChildNode(new TextNode('!='));
-		$treeBooleanRoot->addChildNode(new TextNode('2'));
-		$treeBoolean = new BooleanNode($treeBooleanRoot);
-		$simpleRoot = new RootNode();
-		$simpleRoot->addChildNode(new TextNode('foobar'));
-		$multiRoot = new RootNode();
-		$multiRoot->addChildNode(new TextNode('foo'));
-		$multiRoot->addChildNode(new TextNode('bar'));
-		$multiRoot->addChildNode(new TextNode('baz'));
-		return array(
-			array(
-				new ObjectAccessorNode('_all'),
-				'$renderingContext->getVariableProvider()->getAll()'
-			),
-			array(
-				new ObjectAccessorNode('foo.bar'),
-				'$renderingContext->getVariableProvider()->getByPath(\'foo.bar\', $array0)'
-			),
-			array(
-				new ObjectAccessorNode('foo.bar', array('array', 'array')),
-				'isset($renderingContext->getVariableProvider()[\'foo\'][\'bar\']) ? $renderingContext->getVariableProvider()[\'foo\'][\'bar\'] : NULL'
-			),
-			array(
-				new BooleanNode(new TextNode('TRUE')),
-				'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::convertToBoolean(
+    /**
+     * @return array
+     */
+    public function getConvertTestValues()
+    {
+        $treeBooleanRoot = new RootNode();
+        $treeBooleanRoot->addChildNode(new TextNode('1'));
+        $treeBooleanRoot->addChildNode(new TextNode('!='));
+        $treeBooleanRoot->addChildNode(new TextNode('2'));
+        $treeBoolean = new BooleanNode($treeBooleanRoot);
+        $simpleRoot = new RootNode();
+        $simpleRoot->addChildNode(new TextNode('foobar'));
+        $multiRoot = new RootNode();
+        $multiRoot->addChildNode(new TextNode('foo'));
+        $multiRoot->addChildNode(new TextNode('bar'));
+        $multiRoot->addChildNode(new TextNode('baz'));
+        return [
+            [
+                new ObjectAccessorNode('_all'),
+                '$renderingContext->getVariableProvider()->getAll()'
+            ],
+            [
+                new ObjectAccessorNode('foo.bar'),
+                '$renderingContext->getVariableProvider()->getByPath(\'foo.bar\', $array0)'
+            ],
+            [
+                new ObjectAccessorNode('foo.bar', ['array', 'array']),
+                'isset($renderingContext->getVariableProvider()[\'foo\'][\'bar\']) ? $renderingContext->getVariableProvider()[\'foo\'][\'bar\'] : NULL'
+            ],
+            [
+                new BooleanNode(new TextNode('TRUE')),
+                'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::convertToBoolean(
 					$expression1(
 						TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::gatherContext($renderingContext, $array0)
 					),
 					$renderingContext
 				)'
-			),
-			array(
-				new BooleanNode(new TextNode('1 = 1')),
-				'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::convertToBoolean(
+            ],
+            [
+                new BooleanNode(new TextNode('1 = 1')),
+                'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::convertToBoolean(
 					$expression1(
 						TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::gatherContext($renderingContext, $array0)
 					),
 					$renderingContext
 				)'
-			),
-			array(
-				$treeBoolean,
-				'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::convertToBoolean(
+            ],
+            [
+                $treeBoolean,
+                'TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::convertToBoolean(
 					$expression1(
 						TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::gatherContext($renderingContext, $array0)
 					),
 					$renderingContext
 				)'
-			),
-			array(
-				new TernaryExpressionNode('1 ? 2 : 3', array(1, 2, 3)),
-				'$ternaryExpression1(TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode::gatherContext($renderingContext, $array0[1]), $renderingContext)'
-			),
-			array(
-				new EscapingNode(new TextNode('foo')),
-				'htmlspecialchars(\'foo\', ENT_QUOTES)'
-			),
-			array(
-				new ViewHelperNode(
-					new RenderingContextFixture(),
-					'f',
-					'render',
-					array('section' => new TextNode('test'), 'partial' => 'test'),
-					new ParsingState()
-				),
-				'TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper::renderStatic($arguments0, $renderChildrenClosure1, $renderingContext)'
-			),
-			array($simpleRoot, '\'foobar\''),
-			array($multiRoot, '$output0'),
-			array(new TextNode('test'), '\'test\''),
-			array(new NumericNode('3'), '3'),
-			array(new NumericNode('4.5'), '4.5'),
-			array(new ArrayNode(array('foo', 'bar')), '$array0'),
-			array(new ArrayNode(array(0, new TextNode('test'), new ArrayNode(array('foo', 'bar')))), '$array0')
-		);
-	}
-
+            ],
+            [
+                new TernaryExpressionNode('1 ? 2 : 3', [1, 2, 3]),
+                '$ternaryExpression1(TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode::gatherContext($renderingContext, $array0[1]), $renderingContext)'
+            ],
+            [
+                new EscapingNode(new TextNode('foo')),
+                'htmlspecialchars(\'foo\', ENT_QUOTES)'
+            ],
+            [
+                new ViewHelperNode(
+                    new RenderingContextFixture(),
+                    'f',
+                    'render',
+                    ['section' => new TextNode('test'), 'partial' => 'test'],
+                    new ParsingState()
+                ),
+                'TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper::renderStatic($arguments0, $renderChildrenClosure1, $renderingContext)'
+            ],
+            [$simpleRoot, '\'foobar\''],
+            [$multiRoot, '$output0'],
+            [new TextNode('test'), '\'test\''],
+            [new NumericNode('3'), '3'],
+            [new NumericNode('4.5'), '4.5'],
+            [new ArrayNode(['foo', 'bar']), '$array0'],
+            [new ArrayNode([0, new TextNode('test'), new ArrayNode(['foo', 'bar'])]), '$array0']
+        ];
+    }
 }

--- a/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
+++ b/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
@@ -12,42 +12,45 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class StopCompilingChildrenExceptionTest
  */
-class StopCompilingChildrenExceptionTest extends UnitTestCase {
+class StopCompilingChildrenExceptionTest extends UnitTestCase
+{
 
-	/**
-	 * @param string $property
-	 * @param mixed $value
-	 * @dataProvider getPropertyTestValues
-	 * @test
-	 */
-	public function testGetter($property, $value) {
-		$subject = $this->getAccessibleMock(StopCompilingChildrenException::class, array('dummy'));
-		$subject->_set($property, $value);
-		$method = 'get' . ucfirst($property);
-		$this->assertEquals($value, $subject->$method());
-	}
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @dataProvider getPropertyTestValues
+     * @test
+     */
+    public function testGetter($property, $value)
+    {
+        $subject = $this->getAccessibleMock(StopCompilingChildrenException::class, ['dummy']);
+        $subject->_set($property, $value);
+        $method = 'get' . ucfirst($property);
+        $this->assertEquals($value, $subject->$method());
+    }
 
-	/**
-	 * @param string $property
-	 * @param mixed $value
-	 * @dataProvider getPropertyTestValues
-	 * @test
-	 */
-	public function testSetter($property, $value) {
-		$subject = $this->getAccessibleMock(StopCompilingChildrenException::class, array('dummy'));
-		$subject->_set($property, $value);
-		$method = 'set' . ucfirst($property);
-		$subject->$method($value);
-		$this->assertAttributeEquals($value, $property, $subject);
-	}
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @dataProvider getPropertyTestValues
+     * @test
+     */
+    public function testSetter($property, $value)
+    {
+        $subject = $this->getAccessibleMock(StopCompilingChildrenException::class, ['dummy']);
+        $subject->_set($property, $value);
+        $method = 'set' . ucfirst($property);
+        $subject->$method($value);
+        $this->assertAttributeEquals($value, $property, $subject);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getPropertyTestValues() {
-		return array(
-			array('replacementString', 'test replacement string'),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getPropertyTestValues()
+    {
+        return [
+            ['replacementString', 'test replacement string'],
+        ];
+    }
 }

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -20,156 +20,170 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class TemplateCompilerTest
  */
-class TemplateCompilerTest extends UnitTestCase {
+class TemplateCompilerTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testConstructorCreatesNodeConverter() {
-		$instance = new TemplateCompiler();
-		$this->assertAttributeInstanceOf(NodeConverter::class, 'nodeConverter', $instance);
-	}
+    /**
+     * @test
+     */
+    public function testConstructorCreatesNodeConverter()
+    {
+        $instance = new TemplateCompiler();
+        $this->assertAttributeInstanceOf(NodeConverter::class, 'nodeConverter', $instance);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetRenderingContext() {
-		$instance = new TemplateCompiler();
-		$renderingContext = new RenderingContextFixture();
-		$instance->setRenderingContext($renderingContext);
-		$this->assertAttributeSame($renderingContext, 'renderingContext', $instance);
-	}
+    /**
+     * @test
+     */
+    public function testSetRenderingContext()
+    {
+        $instance = new TemplateCompiler();
+        $renderingContext = new RenderingContextFixture();
+        $instance->setRenderingContext($renderingContext);
+        $this->assertAttributeSame($renderingContext, 'renderingContext', $instance);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testHasReturnsFalseWithoutCache() {
-		$instance = $this->getMock(TemplateCompiler::class, array('sanitizeIdentifier'));
-		$renderingContext = new RenderingContextFixture();
-		$renderingContext->cacheDisabled = TRUE;
-		$instance->setRenderingContext($renderingContext);
-		$instance->expects($this->never())->method('sanitizeIdentifier');
-		$result = $instance->has('test');
-		$this->assertFalse($result);
-	}
+    /**
+     * @test
+     */
+    public function testHasReturnsFalseWithoutCache()
+    {
+        $instance = $this->getMock(TemplateCompiler::class, ['sanitizeIdentifier']);
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->cacheDisabled = true;
+        $instance->setRenderingContext($renderingContext);
+        $instance->expects($this->never())->method('sanitizeIdentifier');
+        $result = $instance->has('test');
+        $this->assertFalse($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testHasAsksCache() {
-		$cache = $this->getMock(SimpleFileCache::class, array('get'));
-		$cache->expects($this->once())->method('get')->with('test')->willReturn(TRUE);
-		$renderingContext = new RenderingContextFixture();
-		$renderingContext->setCache($cache);
-		$instance = $this->getMock(TemplateCompiler::class, array('sanitizeIdentifier'));
-		$instance->expects($this->once())->method('sanitizeIdentifier')->willReturnArgument(0);
-		$instance->setRenderingContext($renderingContext);
-		$result = $instance->has('test');
-		$this->assertTrue($result);
-	}
+    /**
+     * @test
+     */
+    public function testHasAsksCache()
+    {
+        $cache = $this->getMock(SimpleFileCache::class, ['get']);
+        $cache->expects($this->once())->method('get')->with('test')->willReturn(true);
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->setCache($cache);
+        $instance = $this->getMock(TemplateCompiler::class, ['sanitizeIdentifier']);
+        $instance->expects($this->once())->method('sanitizeIdentifier')->willReturnArgument(0);
+        $instance->setRenderingContext($renderingContext);
+        $result = $instance->has('test');
+        $this->assertTrue($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testWrapViewHelperNodeArgumentEvaluationInClosure() {
-		$instance = new TemplateCompiler();
-		$arguments = array('value' => new TextNode('sometext'));
-		$renderingContext = new RenderingContextFixture();
-		$viewHelperNode = new ViewHelperNode($renderingContext, 'f', 'format.raw', $arguments, new ParsingState());
-		$result = $instance->wrapViewHelperNodeArgumentEvaluationInClosure($viewHelperNode, 'value');
-		$serialized = serialize($arguments['value']);
-		$expected = 'function() use ($renderingContext, $self) {' . chr(10);
-		$expected .= sprintf('$argument = unserialize(\'%s\'); return $argument->evaluate($renderingContext);', $serialized);
-		$expected .= chr(10) . '}';
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @test
+     */
+    public function testWrapViewHelperNodeArgumentEvaluationInClosure()
+    {
+        $instance = new TemplateCompiler();
+        $arguments = ['value' => new TextNode('sometext')];
+        $renderingContext = new RenderingContextFixture();
+        $viewHelperNode = new ViewHelperNode($renderingContext, 'f', 'format.raw', $arguments, new ParsingState());
+        $result = $instance->wrapViewHelperNodeArgumentEvaluationInClosure($viewHelperNode, 'value');
+        $serialized = serialize($arguments['value']);
+        $expected = 'function() use ($renderingContext, $self) {' . chr(10);
+        $expected .= sprintf('$argument = unserialize(\'%s\'); return $argument->evaluate($renderingContext);', $serialized);
+        $expected .= chr(10) . '}';
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGenerateSectionCodeFromParsingState() {
-		$foo = new TextNode('foo');
-		$bar = new TextNode('bar');
-		$parsingState = new ParsingState();
-		$container = new StandardVariableProvider(array('1457379500_sections' => array($foo, $bar)));
-		$parsingState->setVariableProvider($container);
-		$nodeConverter = $this->getMock(
-			NodeConverter::class,
-			array('convertListOfSubNodes'),
-			array(), '', FALSE
-		);
-		$nodeConverter->expects($this->at(0))->method('convertListOfSubNodes')->with($foo)->willReturn(array());
-		$nodeConverter->expects($this->at(1))->method('convertListOfSubNodes')->with($bar)->willReturn(array());
-		$instance = $this->getMock(TemplateCompiler::class, array('generateCodeForSection'));
-		$instance->expects($this->at(0))->method('generateCodeForSection')->with($this->anything())->willReturn('FOO');
-		$instance->expects($this->at(1))->method('generateCodeForSection')->with($this->anything())->willReturn('BAR');
-		$instance->setNodeConverter($nodeConverter);
-		$method = new \ReflectionMethod($instance, 'generateSectionCodeFromParsingState');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($instance, array($parsingState));
-		$this->assertEquals('FOOBAR', $result);
-	}
+    /**
+     * @test
+     */
+    public function testGenerateSectionCodeFromParsingState()
+    {
+        $foo = new TextNode('foo');
+        $bar = new TextNode('bar');
+        $parsingState = new ParsingState();
+        $container = new StandardVariableProvider(['1457379500_sections' => [$foo, $bar]]);
+        $parsingState->setVariableProvider($container);
+        $nodeConverter = $this->getMock(
+            NodeConverter::class,
+            ['convertListOfSubNodes'],
+            [],
+            '',
+            false
+        );
+        $nodeConverter->expects($this->at(0))->method('convertListOfSubNodes')->with($foo)->willReturn([]);
+        $nodeConverter->expects($this->at(1))->method('convertListOfSubNodes')->with($bar)->willReturn([]);
+        $instance = $this->getMock(TemplateCompiler::class, ['generateCodeForSection']);
+        $instance->expects($this->at(0))->method('generateCodeForSection')->with($this->anything())->willReturn('FOO');
+        $instance->expects($this->at(1))->method('generateCodeForSection')->with($this->anything())->willReturn('BAR');
+        $instance->setNodeConverter($nodeConverter);
+        $method = new \ReflectionMethod($instance, 'generateSectionCodeFromParsingState');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($instance, [$parsingState]);
+        $this->assertEquals('FOOBAR', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testStoreReturnsEarlyIfDisabled() {
-		$renderingContext = new RenderingContextFixture();
-		$renderingContext->cacheDisabled = TRUE;
-		$instance = $this->getMock(TemplateCompiler::class, array('sanitizeIdentifier'));
-		$instance->setRenderingContext($renderingContext);
-		$instance->expects($this->never())->method('sanitizeIdentifier');
-		$instance->store('foobar', new ParsingState());
-	}
+    /**
+     * @test
+     */
+    public function testStoreReturnsEarlyIfDisabled()
+    {
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->cacheDisabled = true;
+        $instance = $this->getMock(TemplateCompiler::class, ['sanitizeIdentifier']);
+        $instance->setRenderingContext($renderingContext);
+        $instance->expects($this->never())->method('sanitizeIdentifier');
+        $instance->store('foobar', new ParsingState());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSupportsDisablingCompiler() {
-		$instance = new TemplateCompiler();
-		$this->setExpectedException(StopCompilingException::class);
-		$instance->disable();
-	}
+    /**
+     * @test
+     */
+    public function testSupportsDisablingCompiler()
+    {
+        $instance = new TemplateCompiler();
+        $this->setExpectedException(StopCompilingException::class);
+        $instance->disable();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetNodeConverterReturnsNodeConverterInstance() {
-		$instance = new TemplateCompiler();
-		$this->assertInstanceOf(NodeConverter::class, $instance->getNodeConverter());
-	}
+    /**
+     * @test
+     */
+    public function testGetNodeConverterReturnsNodeConverterInstance()
+    {
+        $instance = new TemplateCompiler();
+        $this->assertInstanceOf(NodeConverter::class, $instance->getNodeConverter());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testStoreWhenDisabledFlushesCache() {
-		$renderingContext = new RenderingContextFixture();
-		$state = new ParsingState();
-		$instance = $this->getAccessibleMock(TemplateCompiler::class);
-		$instance->_set('renderingContext', $renderingContext);
-		$instance->_set('disabled', TRUE);
-		$instance->store('fakeidentifier', $state);
-	}
+    /**
+     * @test
+     */
+    public function testStoreWhenDisabledFlushesCache()
+    {
+        $renderingContext = new RenderingContextFixture();
+        $state = new ParsingState();
+        $instance = $this->getAccessibleMock(TemplateCompiler::class);
+        $instance->_set('renderingContext', $renderingContext);
+        $instance->_set('disabled', true);
+        $instance->store('fakeidentifier', $state);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testVariableNameDelegatesToNodeConverter() {
-		$instance = new TemplateCompiler();
-		$nodeConverter = $this->getMock(NodeConverter::class, array('variableName'), array($instance));
-		$nodeConverter->expects($this->once())->method('variableName')->willReturnArgument(0);
-		$instance->setNodeConverter($nodeConverter);
-		$this->assertEquals('foobar', $instance->variableName('foobar'));
-	}
+    /**
+     * @test
+     */
+    public function testVariableNameDelegatesToNodeConverter()
+    {
+        $instance = new TemplateCompiler();
+        $nodeConverter = $this->getMock(NodeConverter::class, ['variableName'], [$instance]);
+        $nodeConverter->expects($this->once())->method('variableName')->willReturnArgument(0);
+        $instance->setNodeConverter($nodeConverter);
+        $this->assertEquals('foobar', $instance->variableName('foobar'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetRenderingContextGetsRenderingContext() {
-		$context = new RenderingContextFixture();
-		$instance = new TemplateCompiler();
-		$instance->setRenderingContext($context);
-		$this->assertSame($context, $instance->getRenderingContext());
-	}
-
+    /**
+     * @test
+     */
+    public function testGetRenderingContextGetsRenderingContext()
+    {
+        $context = new RenderingContextFixture();
+        $instance = new TemplateCompiler();
+        $instance->setRenderingContext($context);
+        $this->assertSame($context, $instance->getRenderingContext());
+    }
 }

--- a/tests/Unit/Core/Fixtures/TestViewHelper.php
+++ b/tests/Unit/Core/Fixtures/TestViewHelper.php
@@ -11,39 +11,42 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * Class TestViewHelper
  */
-class TestViewHelper extends AbstractViewHelper {
+class TestViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('param1', 'integer', 'P1 Stuff', TRUE);
-		$this->registerArgument('param2', 'array', 'P2 Stuff', TRUE);
-		$this->registerArgument('param3', 'string', 'P3 Stuff', FALSE, 'default');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('param1', 'integer', 'P1 Stuff', true);
+        $this->registerArgument('param2', 'array', 'P2 Stuff', true);
+        $this->registerArgument('param3', 'string', 'P3 Stuff', false, 'default');
+    }
 
-	/**
-	 * My comments.
-	 *
-	 * @return string
-	 */
-	public function render() {
-		return $this->arguments['param1'];
-	}
+    /**
+     * My comments.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        return $this->arguments['param1'];
+    }
 
-	/**
-	 * Handle any additional comments by ignoring them
-	 *
-	 * @param array $arguments
-	 */
-	public function handleAdditionalArguments(array $arguments) {
-		$filtered = array();
-		foreach ($arguments as $name => $value) {
-			if (isset($this->argumentDefinitions[$name])) {
-				$filtered[$name] = $value;
-			}
-		}
-		parent::handleAdditionalArguments($filtered);
-	}
-
+    /**
+     * Handle any additional comments by ignoring them
+     *
+     * @param array $arguments
+     */
+    public function handleAdditionalArguments(array $arguments)
+    {
+        $filtered = [];
+        foreach ($arguments as $name => $value) {
+            if (isset($this->argumentDefinitions[$name])) {
+                $filtered[$name] = $value;
+            }
+        }
+        parent::handleAdditionalArguments($filtered);
+    }
 }

--- a/tests/Unit/Core/Fixtures/TestViewHelper2.php
+++ b/tests/Unit/Core/Fixtures/TestViewHelper2.php
@@ -11,23 +11,25 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * Class TestViewHelper2
  */
-class TestViewHelper2 extends AbstractViewHelper {
+class TestViewHelper2 extends AbstractViewHelper
+{
 
-	/**
-	 * @return void
-	 */
-	public function initializeArguments() {
-		$this->registerArgument('param1', 'integer', 'P1 Stuff', TRUE);
-		$this->registerArgument('param2', 'array', 'P2 Stuff', TRUE);
-		$this->registerArgument('param2', 'string', 'P3 Stuff', FALSE, 'default');
-	}
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('param1', 'integer', 'P1 Stuff', true);
+        $this->registerArgument('param2', 'array', 'P2 Stuff', true);
+        $this->registerArgument('param2', 'string', 'P3 Stuff', false, 'default');
+    }
 
-	/**
-	 * My comments.
-	 *
-	 * @return void
-	 */
-	public function render() {
-	}
-
+    /**
+     * My comments.
+     *
+     * @return void
+     */
+    public function render()
+    {
+    }
 }

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -14,106 +14,109 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for BooleanNode
  */
-class BooleanParserTest extends UnitTestCase {
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
+class BooleanParserTest extends UnitTestCase
+{
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
 
-	/**
-	 * Setup fixture
-	 */
-	public function setUp() {
-		$this->renderingContext = new RenderingContextFixture();
-	}
+    /**
+     * Setup fixture
+     */
+    public function setUp()
+    {
+        $this->renderingContext = new RenderingContextFixture();
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getSomeEvaluationTestValues
-	 * @param string $comparison
-	 * @param boolean $expected
-	 */
-	public function testSomeEvaluations($comparison, $expected, $variables = array()) {
-		$parser = new BooleanParser();
-		$this->assertEquals($expected, BooleanNode::convertToBoolean($parser->evaluate($comparison, $variables), $this->renderingContext), 'Expression: ' . $comparison);
+    /**
+     * @test
+     * @dataProvider getSomeEvaluationTestValues
+     * @param string $comparison
+     * @param boolean $expected
+     */
+    public function testSomeEvaluations($comparison, $expected, $variables = [])
+    {
+        $parser = new BooleanParser();
+        $this->assertEquals($expected, BooleanNode::convertToBoolean($parser->evaluate($comparison, $variables), $this->renderingContext), 'Expression: ' . $comparison);
 
-		$compiledEvaluation = $parser->compile($comparison);
-		$functionName = 'expression_' . md5($comparison . rand(0, 100000));
-		eval('function ' . $functionName . '($context) {return ' . $compiledEvaluation . ';}');
-		$this->assertEquals($expected, BooleanNode::convertToBoolean($functionName($variables), $this->renderingContext), 'compiled Expression: ' . $compiledEvaluation);
-	}
+        $compiledEvaluation = $parser->compile($comparison);
+        $functionName = 'expression_' . md5($comparison . rand(0, 100000));
+        eval('function ' . $functionName . '($context) {return ' . $compiledEvaluation . ';}');
+        $this->assertEquals($expected, BooleanNode::convertToBoolean($functionName($variables), $this->renderingContext), 'compiled Expression: ' . $compiledEvaluation);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getSomeEvaluationTestValues() {
-		return array(
-			array('(1 && false) || false || \'foobar\' == \'foobar\'', TRUE),
+    /**
+     * @return array
+     */
+    public function getSomeEvaluationTestValues()
+    {
+        return [
+            ['(1 && false) || false || \'foobar\' == \'foobar\'', true],
 
-			array('0', FALSE),
-			array('!(1)', FALSE),
-			array('!1', FALSE),
-			array('', FALSE),
-			array('false', FALSE),
-			array('FALSE', FALSE),
-			array('fAlSe', FALSE),
-			array('   false   ', FALSE),
-			array('   FALSE   ', FALSE),
-			array('     ', FALSE),
-			array('\'foo\' == \'bar\'', FALSE),
-			array('\'foo\' != \'foo\'', FALSE),
+            ['0', false],
+            ['!(1)', false],
+            ['!1', false],
+            ['', false],
+            ['false', false],
+            ['FALSE', false],
+            ['fAlSe', false],
+            ['   false   ', false],
+            ['   FALSE   ', false],
+            ['     ', false],
+            ['\'foo\' == \'bar\'', false],
+            ['\'foo\' != \'foo\'', false],
 
-			array('1', TRUE),
-			array('true', true),
-			array('TRUE', true),
-			array('tRuE', true),
-			array('   true   ', true),
-			array('   TRUE   ', true),
-			array('\' FALSE \'', true),
-			array('\' \\\'FALSE \'', true),
-			array('\' \\"FALSE \'', true),
-			array('foo', true),
-			array('\'foo\' == \'foo\'', TRUE),
-			array('\'foo\' != \'bar\'', TRUE),
-			array('(1 && false) || false || \'foobar\' == \'foobar\'', TRUE),
+            ['1', true],
+            ['true', true],
+            ['TRUE', true],
+            ['tRuE', true],
+            ['   true   ', true],
+            ['   TRUE   ', true],
+            ['\' FALSE \'', true],
+            ['\' \\\'FALSE \'', true],
+            ['\' \\"FALSE \'', true],
+            ['foo', true],
+            ['\'foo\' == \'foo\'', true],
+            ['\'foo\' != \'bar\'', true],
+            ['(1 && false) || false || \'foobar\' == \'foobar\'', true],
 
-			array('0 == \'0\'', TRUE, array()),
-			array('0 == "0"', TRUE, array()),
-			array('0 === \'0\'', FALSE, array()),
+            ['0 == \'0\'', true, []],
+            ['0 == "0"', true, []],
+            ['0 === \'0\'', false, []],
 
-			array('1 == 1', TRUE),
-			array('1 == 0', FALSE),
-			array('1 >= 1', TRUE),
-			array('1 <= 1', TRUE),
-			array('1 >= 2', FALSE),
-			array('2 <= 1', FALSE),
-			array('-1 != -1', FALSE),
-			array('-1 == -1', TRUE),
-			array('-1 < 0', TRUE),
-			array('-1 > -2', TRUE),
+            ['1 == 1', true],
+            ['1 == 0', false],
+            ['1 >= 1', true],
+            ['1 <= 1', true],
+            ['1 >= 2', false],
+            ['2 <= 1', false],
+            ['-1 != -1', false],
+            ['-1 == -1', true],
+            ['-1 < 0', true],
+            ['-1 > -2', true],
 
-			array('1 > FALSE',  TRUE),
-			array('FALSE > 0',  FALSE),
+            ['1 > FALSE',  true],
+            ['FALSE > 0',  false],
 
-			array('2 % 2', FALSE),
-			array('1 % 2', TRUE),
+            ['2 % 2', false],
+            ['1 % 2', true],
 
-			array('0 && 1', FALSE),
-			array('1 && 1', TRUE),
-			array('0 || 0', FALSE),
-			array('0 || 1', TRUE),
-			array('(0 && 1) || 1', TRUE),
-			array('(0 && 0) || 0', TRUE),
-			array('(1 && 1) || 0', TRUE),
+            ['0 && 1', false],
+            ['1 && 1', true],
+            ['0 || 0', false],
+            ['0 || 1', true],
+            ['(0 && 1) || 1', true],
+            ['(0 && 0) || 0', true],
+            ['(1 && 1) || 0', true],
 
-			// edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
-			array('\'foo\' == 0', TRUE),
-			array('1.1 >= foo', TRUE),
-			array('\'foo\' > 0', FALSE),
+            // edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
+            ['\'foo\' == 0', true],
+            ['1.1 >= foo', true],
+            ['\'foo\' > 0', false],
 
-			array('{foo}', TRUE, array('foo' => TRUE)),
-			array('{foo} == FALSE', TRUE, array('foo' => FALSE))
-		);
-	}
-
+            ['{foo}', true, ['foo' => true]],
+            ['{foo} == FALSE', true, ['foo' => false]]
+        ];
+    }
 }

--- a/tests/Unit/Core/Parser/ConfigurationTest.php
+++ b/tests/Unit/Core/Parser/ConfigurationTest.php
@@ -14,28 +14,30 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class ConfigurationTest
  */
-class ConfigurationTest extends UnitTestCase {
+class ConfigurationTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testAddInterceptor() {
-		$interceptor = new Escape();
-		$configuration = new Configuration();
-		$configuration->addInterceptor($interceptor);
-		$interceptors = $configuration->getInterceptors(InterceptorInterface::INTERCEPT_OBJECTACCESSOR);
-		$this->assertContains($interceptor, $interceptors);
-	}
+    /**
+     * @test
+     */
+    public function testAddInterceptor()
+    {
+        $interceptor = new Escape();
+        $configuration = new Configuration();
+        $configuration->addInterceptor($interceptor);
+        $interceptors = $configuration->getInterceptors(InterceptorInterface::INTERCEPT_OBJECTACCESSOR);
+        $this->assertContains($interceptor, $interceptors);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddEscapingInterceptor() {
-		$interceptor = new Escape();
-		$configuration = new Configuration();
-		$configuration->addEscapingInterceptor($interceptor);
-		$interceptors = $configuration->getEscapingInterceptors(InterceptorInterface::INTERCEPT_OBJECTACCESSOR);
-		$this->assertContains($interceptor, $interceptors);
-	}
-
+    /**
+     * @test
+     */
+    public function testAddEscapingInterceptor()
+    {
+        $interceptor = new Escape();
+        $configuration = new Configuration();
+        $configuration->addEscapingInterceptor($interceptor);
+        $interceptors = $configuration->getEscapingInterceptors(InterceptorInterface::INTERCEPT_OBJECTACCESSOR);
+        $this->assertContains($interceptor, $interceptors);
+    }
 }

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture01-shorthand-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture01-shorthand-split.php
@@ -1,4 +1,4 @@
 <?php
 
-return array('
-a{f:base()}b');
+return ['
+a{f:base()}b'];

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture06-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture06-split.php
@@ -1,11 +1,11 @@
 <?php
 
-return array(
-	'{namespace foo=TYPO3Fluid\Fluid\ViewHelpers}',
-	'<foo:format.nl2br>',
-	'<foo:format.number decimals="1">',
-	'{number}',
-	'</foo:format.number>',
-	'</foo:format.nl2br>',
-	"\n"
-);
+return [
+    '{namespace foo=TYPO3Fluid\Fluid\ViewHelpers}',
+    '<foo:format.nl2br>',
+    '<foo:format.number decimals="1">',
+    '{number}',
+    '</foo:format.number>',
+    '</foo:format.nl2br>',
+    "\n"
+];

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture14-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture14-split.php
@@ -1,7 +1,7 @@
 <?php
 
-return array(
-	'<f:format.printf arguments="{number : 362525200}">',
-	'%.3e',
-	'</f:format.printf>'
-);
+return [
+    '<f:format.printf arguments="{number : 362525200}">',
+    '%.3e',
+    '</f:format.printf>'
+];

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -18,84 +18,90 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for Interceptor\Escape
  */
-class EscapeTest extends UnitTestCase {
+class EscapeTest extends UnitTestCase
+{
 
-	/**
-	 * @var Escape|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $escapeInterceptor;
+    /**
+     * @var Escape|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $escapeInterceptor;
 
-	/**
-	 * @var AbstractViewHelper|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $mockViewHelper;
+    /**
+     * @var AbstractViewHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockViewHelper;
 
-	/**
-	 * @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $mockNode;
+    /**
+     * @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockNode;
 
-	/**
-	 * @var ParsingState|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $mockParsingState;
+    /**
+     * @var ParsingState|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockParsingState;
 
-	public function setUp() {
-		$this->escapeInterceptor = $this->getAccessibleMock(Escape::class, array('dummy'));
-		$this->mockViewHelper = $this->getMockBuilder(AbstractViewHelper::class)->disableOriginalConstructor()->getMock();
-		$this->mockNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
-		$this->mockParsingState = $this->getMockBuilder(ParsingState::class)
-			->setMethods(array('dummy'))->disableOriginalConstructor()->getMock();
-	}
+    public function setUp()
+    {
+        $this->escapeInterceptor = $this->getAccessibleMock(Escape::class, ['dummy']);
+        $this->mockViewHelper = $this->getMockBuilder(AbstractViewHelper::class)->disableOriginalConstructor()->getMock();
+        $this->mockNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
+        $this->mockParsingState = $this->getMockBuilder(ParsingState::class)
+            ->setMethods(['dummy'])->disableOriginalConstructor()->getMock();
+    }
 
-	/**
-	 * @test
-	 */
-	public function processDoesNotDisableEscapingInterceptorByDefault() {
-		$interceptorPosition = InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER;
-		$this->mockViewHelper->expects($this->once())->method('isChildrenEscapingEnabled')->will($this->returnValue(TRUE));
-		$this->mockNode->expects($this->once())->method('getUninitializedViewHelper')->will($this->returnValue($this->mockViewHelper));
+    /**
+     * @test
+     */
+    public function processDoesNotDisableEscapingInterceptorByDefault()
+    {
+        $interceptorPosition = InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER;
+        $this->mockViewHelper->expects($this->once())->method('isChildrenEscapingEnabled')->will($this->returnValue(true));
+        $this->mockNode->expects($this->once())->method('getUninitializedViewHelper')->will($this->returnValue($this->mockViewHelper));
 
-		$this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
-		$this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
-		$this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
-	}
+        $this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
+        $this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
+        $this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function processDisablesEscapingInterceptorIfViewHelperDisablesIt() {
-		$interceptorPosition = InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER;
-		$this->mockViewHelper->expects($this->once())->method('isChildrenEscapingEnabled')->will($this->returnValue(FALSE));
-		$this->mockNode->expects($this->once())->method('getUninitializedViewHelper')->will($this->returnValue($this->mockViewHelper));
+    /**
+     * @test
+     */
+    public function processDisablesEscapingInterceptorIfViewHelperDisablesIt()
+    {
+        $interceptorPosition = InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER;
+        $this->mockViewHelper->expects($this->once())->method('isChildrenEscapingEnabled')->will($this->returnValue(false));
+        $this->mockNode->expects($this->once())->method('getUninitializedViewHelper')->will($this->returnValue($this->mockViewHelper));
 
-		$this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
-		$this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
-		$this->assertFalse($this->escapeInterceptor->_get('childrenEscapingEnabled'));
-	}
+        $this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
+        $this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
+        $this->assertFalse($this->escapeInterceptor->_get('childrenEscapingEnabled'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function processReenablesEscapingInterceptorOnClosingViewHelperTagIfItWasDisabledBefore() {
-		$interceptorPosition = InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER;
-		$this->mockViewHelper->expects($this->any())->method('isOutputEscapingEnabled')->will($this->returnValue(FALSE));
-		$this->mockNode->expects($this->any())->method('getUninitializedViewHelper')->will($this->returnValue($this->mockViewHelper));
+    /**
+     * @test
+     */
+    public function processReenablesEscapingInterceptorOnClosingViewHelperTagIfItWasDisabledBefore()
+    {
+        $interceptorPosition = InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER;
+        $this->mockViewHelper->expects($this->any())->method('isOutputEscapingEnabled')->will($this->returnValue(false));
+        $this->mockNode->expects($this->any())->method('getUninitializedViewHelper')->will($this->returnValue($this->mockViewHelper));
 
-		$this->escapeInterceptor->_set('childrenEscapingEnabled', FALSE);
-		$this->escapeInterceptor->_set('viewHelperNodesWhichDisableTheInterceptor', array($this->mockNode));
+        $this->escapeInterceptor->_set('childrenEscapingEnabled', false);
+        $this->escapeInterceptor->_set('viewHelperNodesWhichDisableTheInterceptor', [$this->mockNode]);
 
-		$this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
-		$this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
-	}
+        $this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
+        $this->assertTrue($this->escapeInterceptor->_get('childrenEscapingEnabled'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function processWrapsCurrentViewHelperInEscapeNode() {
-		$interceptorPosition = InterceptorInterface::INTERCEPT_OBJECTACCESSOR;
-		$mockNode = $this->getMock(ObjectAccessorNode::class, array(), array(), '', FALSE);
-		$actualResult = $this->escapeInterceptor->process($mockNode, $interceptorPosition, $this->mockParsingState);
-		$this->assertInstanceOf(EscapingNode::class, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function processWrapsCurrentViewHelperInEscapeNode()
+    {
+        $interceptorPosition = InterceptorInterface::INTERCEPT_OBJECTACCESSOR;
+        $mockNode = $this->getMock(ObjectAccessorNode::class, [], [], '', false);
+        $actualResult = $this->escapeInterceptor->process($mockNode, $interceptorPosition, $this->mockParsingState);
+        $this->assertInstanceOf(EscapingNode::class, $actualResult);
+    }
 }

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -15,87 +15,96 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for ParsingState
  */
-class ParsingStateTest extends UnitTestCase {
+class ParsingStateTest extends UnitTestCase
+{
 
-	/**
-	 * Parsing state
-	 *
-	 * @var ParsingState
-	 */
-	protected $parsingState;
+    /**
+     * Parsing state
+     *
+     * @var ParsingState
+     */
+    protected $parsingState;
 
-	public function setUp() {
-		$this->parsingState = new ParsingState();
-	}
+    public function setUp()
+    {
+        $this->parsingState = new ParsingState();
+    }
 
-	public function tearDown() {
-		unset($this->parsingState);
-	}
+    public function tearDown()
+    {
+        unset($this->parsingState);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetIdentifierSetsProperty() {
-		$instance = $this->getMockForAbstractClass(ParsingState::class, array(), '', FALSE, array('dummy'));
-		$instance->setIdentifier('test');
-		$this->assertAttributeEquals('test', 'identifier', $instance);
-	}
+    /**
+     * @test
+     */
+    public function testSetIdentifierSetsProperty()
+    {
+        $instance = $this->getMockForAbstractClass(ParsingState::class, [], '', false, ['dummy']);
+        $instance->setIdentifier('test');
+        $this->assertAttributeEquals('test', 'identifier', $instance);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetIdentifierReturnsProperty() {
-		$instance = $this->getAccessibleMockForAbstractClass(ParsingState::class, array(), '', FALSE, array('dummy'));
-		$instance->_set('identifier', 'test');
-		$this->assertEquals('test', $instance->getIdentifier());
-	}
+    /**
+     * @test
+     */
+    public function testGetIdentifierReturnsProperty()
+    {
+        $instance = $this->getAccessibleMockForAbstractClass(ParsingState::class, [], '', false, ['dummy']);
+        $instance->_set('identifier', 'test');
+        $this->assertEquals('test', $instance->getIdentifier());
+    }
 
-	/**
-	 * @test
-	 */
-	public function setRootNodeCanBeReadOutAgain() {
-		$rootNode = new RootNode();
-		$this->parsingState->setRootNode($rootNode);
-		$this->assertSame($this->parsingState->getRootNode(), $rootNode, 'Root node could not be read out again.');
-	}
+    /**
+     * @test
+     */
+    public function setRootNodeCanBeReadOutAgain()
+    {
+        $rootNode = new RootNode();
+        $this->parsingState->setRootNode($rootNode);
+        $this->assertSame($this->parsingState->getRootNode(), $rootNode, 'Root node could not be read out again.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function pushAndGetFromStackWorks() {
-		$rootNode = new RootNode();
-		$this->parsingState->pushNodeToStack($rootNode);
-		$this->assertSame($rootNode, $this->parsingState->getNodeFromStack($rootNode), 'Node returned from stack was not the right one.');
-		$this->assertSame($rootNode, $this->parsingState->popNodeFromStack($rootNode), 'Node popped from stack was not the right one.');
-	}
+    /**
+     * @test
+     */
+    public function pushAndGetFromStackWorks()
+    {
+        $rootNode = new RootNode();
+        $this->parsingState->pushNodeToStack($rootNode);
+        $this->assertSame($rootNode, $this->parsingState->getNodeFromStack($rootNode), 'Node returned from stack was not the right one.');
+        $this->assertSame($rootNode, $this->parsingState->popNodeFromStack($rootNode), 'Node popped from stack was not the right one.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderCallsTheRightMethodsOnTheRootNode() {
-		$renderingContext = new RenderingContextFixture();
-		$rootNode = $this->getMock(RootNode::class);
-		$rootNode->expects($this->once())->method('evaluate')->with($renderingContext)->will($this->returnValue('T3DD09 Rock!'));
-		$this->parsingState->setRootNode($rootNode);
-		$renderedValue = $this->parsingState->render($renderingContext);
-		$this->assertEquals($renderedValue, 'T3DD09 Rock!', 'The rendered value of the Root Node is not returned by the ParsingState.');
-	}
+    /**
+     * @test
+     */
+    public function renderCallsTheRightMethodsOnTheRootNode()
+    {
+        $renderingContext = new RenderingContextFixture();
+        $rootNode = $this->getMock(RootNode::class);
+        $rootNode->expects($this->once())->method('evaluate')->with($renderingContext)->will($this->returnValue('T3DD09 Rock!'));
+        $this->parsingState->setRootNode($rootNode);
+        $renderedValue = $this->parsingState->render($renderingContext);
+        $this->assertEquals($renderedValue, 'T3DD09 Rock!', 'The rendered value of the Root Node is not returned by the ParsingState.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetLayoutName() {
-		$this->parsingState->setVariableProvider(new StandardVariableProvider(array('layoutName' => 'test')));
-		$result = $this->parsingState->getLayoutName(new RenderingContextFixture());
-		$this->assertEquals('test', $result);
-	}
+    /**
+     * @test
+     */
+    public function testGetLayoutName()
+    {
+        $this->parsingState->setVariableProvider(new StandardVariableProvider(['layoutName' => 'test']));
+        $result = $this->parsingState->getLayoutName(new RenderingContextFixture());
+        $this->assertEquals('test', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetCompilableSetsProperty() {
-		$this->parsingState->setCompilable(FALSE);
-		$this->assertAttributeEquals(FALSE, 'compilable', $this->parsingState);
-	}
-
+    /**
+     * @test
+     */
+    public function testSetCompilableSetsProperty()
+    {
+        $this->parsingState->setCompilable(false);
+        $this->assertAttributeEquals(false, 'compilable', $this->parsingState);
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -15,80 +15,88 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * An AbstractNode Test
  */
-class AbstractNodeTest extends UnitTestCase {
+class AbstractNodeTest extends UnitTestCase
+{
 
-	protected $renderingContext;
+    protected $renderingContext;
 
-	protected $abstractNode;
+    protected $abstractNode;
 
-	protected $childNode;
+    protected $childNode;
 
-	public function setUp() {
-		$this->renderingContext = $this->getMock(RenderingContext::class, array(), array(), '', FALSE);
+    public function setUp()
+    {
+        $this->renderingContext = $this->getMock(RenderingContext::class, [], [], '', false);
 
-		$this->abstractNode = $this->getMock(AbstractNode::class, array('evaluate'));
+        $this->abstractNode = $this->getMock(AbstractNode::class, ['evaluate']);
 
-		$this->childNode = $this->getMock(AbstractNode::class);
-		$this->abstractNode->addChildNode($this->childNode);
-	}
+        $this->childNode = $this->getMock(AbstractNode::class);
+        $this->abstractNode->addChildNode($this->childNode);
+    }
 
-	/**
-	 * @test
-	 */
-	public function evaluateChildNodesPassesRenderingContextToChildNodes() {
-		$this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext);
-		$this->abstractNode->evaluateChildNodes($this->renderingContext);
-	}
+    /**
+     * @test
+     */
+    public function evaluateChildNodesPassesRenderingContextToChildNodes()
+    {
+        $this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext);
+        $this->abstractNode->evaluateChildNodes($this->renderingContext);
+    }
 
-	/**
-	 * @test
-	 */
-	public function evaluateChildNodesReturnsNullIfNoChildNodesExist() {
-		$abstractNode = $this->getMock(AbstractNode::class, array('evaluate'));
-		$this->assertNull($abstractNode->evaluateChildNodes($this->renderingContext));
-	}
+    /**
+     * @test
+     */
+    public function evaluateChildNodesReturnsNullIfNoChildNodesExist()
+    {
+        $abstractNode = $this->getMock(AbstractNode::class, ['evaluate']);
+        $this->assertNull($abstractNode->evaluateChildNodes($this->renderingContext));
+    }
 
-	/**
-	 * @test
-	 */
-	public function evaluateChildNodeThrowsExceptionIfChildNodeCannotBeCastToString() {
-		$this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn(new \DateTime('now'));
-		$method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');
-		$method->setAccessible(TRUE);
-		$this->setExpectedException(Exception::class);
-		$method->invokeArgs($this->abstractNode, array($this->childNode, $this->renderingContext, TRUE));
-	}
+    /**
+     * @test
+     */
+    public function evaluateChildNodeThrowsExceptionIfChildNodeCannotBeCastToString()
+    {
+        $this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn(new \DateTime('now'));
+        $method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');
+        $method->setAccessible(true);
+        $this->setExpectedException(Exception::class);
+        $method->invokeArgs($this->abstractNode, [$this->childNode, $this->renderingContext, true]);
+    }
 
-	/**
-	 * @test
-	 */
-	public function evaluateChildNodeCanCastToString() {
-		$withToString = new UserWithToString('foobar');
-		$this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn($withToString);
-		$method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($this->abstractNode, array($this->childNode, $this->renderingContext, TRUE));
-		$this->assertEquals('foobar', $result);
-	}
+    /**
+     * @test
+     */
+    public function evaluateChildNodeCanCastToString()
+    {
+        $withToString = new UserWithToString('foobar');
+        $this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn($withToString);
+        $method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($this->abstractNode, [$this->childNode, $this->renderingContext, true]);
+        $this->assertEquals('foobar', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function evaluateChildNodesConcatenatesOutputs() {
-		$child2 = clone $this->childNode;
-		$child2->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn('bar');
-		$this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn('foo');
-		$this->abstractNode->addChildNode($child2);
-		$method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNodes');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($this->abstractNode, array($this->renderingContext, TRUE));
-		$this->assertEquals('foobar', $result);
-	}
+    /**
+     * @test
+     */
+    public function evaluateChildNodesConcatenatesOutputs()
+    {
+        $child2 = clone $this->childNode;
+        $child2->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn('bar');
+        $this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn('foo');
+        $this->abstractNode->addChildNode($child2);
+        $method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNodes');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($this->abstractNode, [$this->renderingContext, true]);
+        $this->assertEquals('foobar', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function childNodeCanBeReadOutAgain() {
-		$this->assertSame($this->abstractNode->getChildNodes(), array($this->childNode));
-	}
+    /**
+     * @test
+     */
+    public function childNodeCanBeReadOutAgain()
+    {
+        $this->assertSame($this->abstractNode->getChildNodes(), [$this->childNode]);
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -24,609 +24,658 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for BooleanNode
  */
-class BooleanNodeTest extends UnitTestCase {
-
-	/**
-	 * @var ViewHelperNode
-	 */
-	protected $viewHelperNode;
-
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
-
-	/**
-	 * Setup fixture
-	 */
-	public function setUp() {
-		$this->renderingContext = new RenderingContextFixture();
-	}
-
-	/**
-	 * @test
-	 */
-	public function convertToBooleanProperlyConvertsValuesOfTypeBoolean() {
-		$this->assertFalse(BooleanNode::convertToBoolean(FALSE, $this->renderingContext));
-		$this->assertTrue(BooleanNode::convertToBoolean(TRUE, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function convertToBooleanProperlyConvertsValuesOfTypeString() {
-		$this->assertFalse(BooleanNode::convertToBoolean('', $this->renderingContext));
-		$this->assertFalse(BooleanNode::convertToBoolean('false', $this->renderingContext));
-		$this->assertFalse(BooleanNode::convertToBoolean('FALSE', $this->renderingContext));
-
-		$this->assertTrue(BooleanNode::convertToBoolean('true', $this->renderingContext));
-		$this->assertTrue(BooleanNode::convertToBoolean('TRUE', $this->renderingContext));
-	}
-
-	/**
-	 * @param float $number
-	 * @param boolean $expected
-	 * @test
-	 * @dataProvider getNumericBooleanTestValues
-	 */
-	public function convertToBooleanProperlyConvertsNumericValues($number, $expected) {
-		$this->assertEquals($expected, BooleanNode::convertToBoolean($number, $this->renderingContext));
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getNumericBooleanTestValues() {
-		return array(
-			array(0, FALSE),
-			array(-1, FALSE),
-			array('-1', FALSE),
-			array(-.5, FALSE),
-			array(1, TRUE),
-			array(.5, TRUE),
-		);
-	}
-
-	/**
-	 * @test
-	 */
-	public function convertToBooleanProperlyConvertsValuesOfTypeArray() {
-		$this->assertFalse(BooleanNode::convertToBoolean(array(), $this->renderingContext));
-
-		$this->assertTrue(BooleanNode::convertToBoolean(array('foo'), $this->renderingContext));
-		$this->assertTrue(BooleanNode::convertToBoolean(array('foo' => 'bar'), $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function convertToBooleanProperlyConvertsObjects() {
-		$this->assertFalse(BooleanNode::convertToBoolean(NULL, $this->renderingContext));
-
-		$this->assertTrue(BooleanNode::convertToBoolean(new \stdClass(), $this->renderingContext));
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getEvaluateComparatorTestValues() {
-		$user1 = new UserWithToString('foobar');
-		$user2 = new UserWithToString('foobar');
-		return array(
-			array('===', $user1, $user1, TRUE),
-			array('===', $user1, $user2, FALSE),
-			array('===', $user1, 'foobar', FALSE),
-
-			array('==', $user1, $user1, TRUE),
-			array('==', $user1, $user2, FALSE),
-			array('==', $user1, 'foobar', FALSE),
-			array('==', 'foobar', $user1, FALSE),
-			array('==', 1, 0, FALSE),
-			array('==', 1, 1, TRUE),
-			array('==', array('foobar'), array('foobar'), TRUE),
-			array('==', array('foobar'), array('baz'), FALSE),
-
-			array('>', 1, 0, TRUE),
-			array('>', 1, FALSE, TRUE),
-			array('>', FALSE, 0, FALSE),
-
-			array('<', 1, 0, FALSE),
-
-			// edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
-			array('==', 'foo', 0, TRUE),
-			array('>=', 1.1, 'foo', TRUE),
-			array('>', 'foo', 0, FALSE),
-
-		);
-	}
-
-	/**
-	 * @dataProvider getCreateFromNodeAndEvaluateTestValues
-	 * @param NodeInterface $node
-	 * @param boolean $expected
-	 */
-	public function testCreateFromNodeAndEvaluate(NodeInterface $node, $expected) {
-		$result = BooleanNode::createFromNodeAndEvaluate($node, $this->renderingContext);
-		$this->assertEquals($expected, $result);
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getCreateFromNodeAndEvaluateTestValues() {
-		return array(
-			'1 && 1' => array(new TextNode('1 && 1'), TRUE),
-			'1 && 0' => array(new TextNode('1 && 0'), FALSE),
-			'(1 && 1) && 1' => array(new TextNode('(1 && 1) && 1'), TRUE),
-			'(1 && 0) || 1' => array(new TextNode('(1 && 0) || 1'), TRUE),
-			'(\'text\' == \'text\') || 1 >= 0' => array(new TextNode('(\'text\' == \'text\') || 1 >= 0'), TRUE),
-			'1 <= 0' => array(new TextNode('1 <= 0'), FALSE),
-			'1 > 4' => array(new TextNode('1 > 4'), FALSE),
-			'1 < 4' => array(new TextNode('1 < 4'), TRUE),
-			'4 % 4' => array(new TextNode('4 % 4'), FALSE),
-			'2 % 4' => array(new TextNode('2 % 4'), TRUE),
-			'0 && 1' => array(new TextNode('0 && 1'), FALSE),
-		);
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingNestedComparisonsWorks() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('('));
-		$rootNode->addChildNode(new ArrayNode(array('foo' => 'bar')));
-		$rootNode->addChildNode(new TextNode('=='));
-		$rootNode->addChildNode(new ArrayNode(array('foo' => 'bar')));
-		$rootNode->addChildNode(new TextNode(')'));
-		$rootNode->addChildNode(new TextNode('&&'));
-		$rootNode->addChildNode(new TextNode('1'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingEqualNumbersReturnsTrue() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('5'));
-		$rootNode->addChildNode(new TextNode('=='));
-		$rootNode->addChildNode(new TextNode('5'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingUnequalNumbersReturnsFalse() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('5'));
-		$rootNode->addChildNode(new TextNode('=='));
-		$rootNode->addChildNode(new TextNode('3'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingEqualIdentityReturnsTrue() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('5'));
-		$rootNode->addChildNode(new TextNode('==='));
-		$rootNode->addChildNode(new TextNode('5'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingUnequalIdentityReturnsFalse() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new NumericNode('0'));
-		$rootNode->addChildNode(new TextNode('==='));
-		$rootNode->addChildNode(new BooleanNode(FALSE));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function notEqualReturnsFalseIfNumbersAreEqual() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('5'));
-		$rootNode->addChildNode(new TextNode('!='));
-		$rootNode->addChildNode(new TextNode('5'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function notEqualReturnsTrueIfNumbersAreNotEqual() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('5'));
-		$rootNode->addChildNode(new TextNode('!='));
-		$rootNode->addChildNode(new TextNode('3'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function oddNumberModulo2ReturnsTrue() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('43'));
-		$rootNode->addChildNode(new TextNode('%'));
-		$rootNode->addChildNode(new TextNode('2'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function evenNumberModulo2ReturnsFalse() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('42'));
-		$rootNode->addChildNode(new TextNode('%'));
-		$rootNode->addChildNode(new TextNode('2'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function greaterThanReturnsTrueIfNumberIsReallyGreater() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('>'));
-		$rootNode->addChildNode(new TextNode('9'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function greaterThanReturnsFalseIfNumberIsEqual() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('>'));
-		$rootNode->addChildNode(new TextNode('10'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function greaterOrEqualsReturnsTrueIfNumberIsReallyGreater() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('>='));
-		$rootNode->addChildNode(new TextNode('9'));
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function greaterOrEqualsReturnsTrueIfNumberIsEqual() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('>='));
-		$rootNode->addChildNode(new TextNode('10'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function greaterOrEqualsReturnFalseIfNumberIsSmaller() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('>='));
-		$rootNode->addChildNode(new TextNode('11'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function lessThanReturnsTrueIfNumberIsReallyless() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('9'));
-		$rootNode->addChildNode(new TextNode('<'));
-		$rootNode->addChildNode(new TextNode('10'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function lessThanReturnsFalseIfNumberIsEqual() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('<'));
-		$rootNode->addChildNode(new TextNode('10'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function lessOrEqualsReturnsTrueIfNumberIsReallyLess() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('9'));
-		$rootNode->addChildNode(new TextNode('<='));
-		$rootNode->addChildNode(new TextNode('10'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function lessOrEqualsReturnsTrueIfNumberIsEqual() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('10'));
-		$rootNode->addChildNode(new TextNode('<='));
-		$rootNode->addChildNode(new TextNode('10'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function lessOrEqualsReturnFalseIfNumberIsBigger() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('11'));
-		$rootNode->addChildNode(new TextNode('<='));
-		$rootNode->addChildNode(new TextNode('10'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function lessOrEqualsReturnFalseIfComparingWithANegativeNumber() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('11 <= -2.1'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @param array $variables
-	 * @return RenderingContext
-	 */
-	protected function getDummyRenderingContextWithVariables(array $variables) {
-		$context = $this->renderingContext;
-		$context->setVariableProvider(new StandardVariableProvider($variables));
-		$context->getVariableProvider()->setSource($variables);
-		return $context;
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingVariableWithMatchedQuotedString() {
-		$renderingContext = $this->getDummyRenderingContextWithVariables(array('test' => 'somevalue'));
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new ObjectAccessorNode('test'));
-		$rootNode->addChildNode(new TextNode(' == '));
-		$rootNode->addChildNode(new TextNode('\'somevalue\''));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingVariableWithUnmatchedQuotedString() {
-		$renderingContext = $this->getDummyRenderingContextWithVariables(array('test' => 'somevalue'));
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new ObjectAccessorNode('test'));
-		$rootNode->addChildNode(new TextNode(' != '));
-		$rootNode->addChildNode(new TextNode('\'othervalue\''));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingNotEqualsVariableWithMatchedQuotedString() {
-		$renderingContext = $this->getDummyRenderingContextWithVariables(array('test' => 'somevalue'));
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new ObjectAccessorNode('test'));
-		$rootNode->addChildNode(new TextNode(' != '));
-		$rootNode->addChildNode(new TextNode('\'somevalue\''));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingNotEqualsVariableWithUnmatchedQuotedString() {
-		$renderingContext = $this->getDummyRenderingContextWithVariables(array('test' => 'somevalue'));
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new ObjectAccessorNode('test'));
-		$rootNode->addChildNode(new TextNode(' != '));
-		$rootNode->addChildNode(new TextNode('\'somevalue\''));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function comparingEqualsVariableWithMatchedQuotedStringInSingleTextNode() {
-		$renderingContext = $this->getDummyRenderingContextWithVariables(array('test' => 'somevalue'));
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new ObjectAccessorNode('test'));
-		$rootNode->addChildNode(new TextNode(' != \'somevalue\''));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function notEqualReturnsFalseIfComparingMatchingStrings() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'stringA\' != "stringA"'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function notEqualReturnsTrueIfComparingNonMatchingStrings() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'stringA\' != \'stringB\''));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function equalsReturnsFalseIfComparingNonMatchingStrings() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'stringA\' == \'stringB\''));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function equalsReturnsTrueIfComparingMatchingStrings() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'stringA\' == "stringA"'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function equalsReturnsTrueIfComparingMatchingStringsWithEscapedQuotes() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'\\\'stringA\\\'\' == \'\\\'stringA\\\'\''));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function equalsReturnsFalseIfComparingStringWithNonZero() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'stringA\' == 42'));
-		$this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function equalsReturnsTrueIfComparingStringWithZero() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'stringA\' == 0'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function equalsReturnsFalseIfComparingStringZeroWithZero() {
-		$rootNode = new RootNode();
-		$rootNode->addChildNode(new TextNode('\'0\' == 0'));
-		$this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function objectsAreComparedStrictly() {
-		$object1 = new \stdClass();
-		$object2 = new \stdClass();
-
-		$rootNode = new RootNode();
-
-		$object1Node = $this->getMock(ObjectAccessorNode::class, array('evaluate'), array('foo'));
-		$object1Node->expects($this->any())->method('evaluate')->will($this->returnValue($object1));
-
-		$object2Node = $this->getMock(ObjectAccessorNode::class, array('evaluate'), array('foo'));
-		$object2Node->expects($this->any())->method('evaluate')->will($this->returnValue($object2));
-
-		$rootNode->addChildNode($object1Node);
-		$rootNode->addChildNode(new TextNode('=='));
-		$rootNode->addChildNode($object2Node);
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertFalse($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @test
-	 */
-	public function objectsAreComparedStrictlyInUnequalComparison() {
-		$object1 = new \stdClass();
-		$object2 = new \stdClass();
-
-		$rootNode = new RootNode();
-
-		$object1Node = $this->getMock(ObjectAccessorNode::class, array('evaluate'), array('foo'));
-		$object1Node->expects($this->any())->method('evaluate')->will($this->returnValue($object1));
-
-		$object2Node = $this->getMock(ObjectAccessorNode::class, array('evaluate'), array('foo'));
-		$object2Node->expects($this->any())->method('evaluate')->will($this->returnValue($object2));
-
-		$rootNode->addChildNode($object1Node);
-		$rootNode->addChildNode(new TextNode('!='));
-		$rootNode->addChildNode($object2Node);
-
-		$booleanNode = new BooleanNode($rootNode);
-		$this->assertTrue($booleanNode->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @param mixed $input
-	 * @param boolean $expected
-	 * @test
-	 * @dataProvider getStandardInputTypes
-	 */
-	public function acceptsStandardTypesAsInput($input, $expected) {
-		$node = new BooleanNode($input);
-		$this->assertEquals($expected, $node->evaluate($this->renderingContext));
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getStandardInputTypes() {
-		return array(
-			array(0, FALSE),
-			array(1, TRUE),
-			array(FALSE, FALSE),
-			array(TRUE, TRUE),
-			array(NULL, FALSE),
-			array('', FALSE),
-			array('0', FALSE),
-			array('1', TRUE),
-			array(array(1), TRUE),
-			array(array(0), FALSE),
-		);
-	}
+class BooleanNodeTest extends UnitTestCase
+{
+
+    /**
+     * @var ViewHelperNode
+     */
+    protected $viewHelperNode;
+
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
+
+    /**
+     * Setup fixture
+     */
+    public function setUp()
+    {
+        $this->renderingContext = new RenderingContextFixture();
+    }
+
+    /**
+     * @test
+     */
+    public function convertToBooleanProperlyConvertsValuesOfTypeBoolean()
+    {
+        $this->assertFalse(BooleanNode::convertToBoolean(false, $this->renderingContext));
+        $this->assertTrue(BooleanNode::convertToBoolean(true, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function convertToBooleanProperlyConvertsValuesOfTypeString()
+    {
+        $this->assertFalse(BooleanNode::convertToBoolean('', $this->renderingContext));
+        $this->assertFalse(BooleanNode::convertToBoolean('false', $this->renderingContext));
+        $this->assertFalse(BooleanNode::convertToBoolean('FALSE', $this->renderingContext));
+
+        $this->assertTrue(BooleanNode::convertToBoolean('true', $this->renderingContext));
+        $this->assertTrue(BooleanNode::convertToBoolean('TRUE', $this->renderingContext));
+    }
+
+    /**
+     * @param float $number
+     * @param boolean $expected
+     * @test
+     * @dataProvider getNumericBooleanTestValues
+     */
+    public function convertToBooleanProperlyConvertsNumericValues($number, $expected)
+    {
+        $this->assertEquals($expected, BooleanNode::convertToBoolean($number, $this->renderingContext));
+    }
+
+    /**
+     * @return array
+     */
+    public function getNumericBooleanTestValues()
+    {
+        return [
+            [0, false],
+            [-1, false],
+            ['-1', false],
+            [-.5, false],
+            [1, true],
+            [.5, true],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function convertToBooleanProperlyConvertsValuesOfTypeArray()
+    {
+        $this->assertFalse(BooleanNode::convertToBoolean([], $this->renderingContext));
+
+        $this->assertTrue(BooleanNode::convertToBoolean(['foo'], $this->renderingContext));
+        $this->assertTrue(BooleanNode::convertToBoolean(['foo' => 'bar'], $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function convertToBooleanProperlyConvertsObjects()
+    {
+        $this->assertFalse(BooleanNode::convertToBoolean(null, $this->renderingContext));
+
+        $this->assertTrue(BooleanNode::convertToBoolean(new \stdClass(), $this->renderingContext));
+    }
+
+    /**
+     * @return array
+     */
+    public function getEvaluateComparatorTestValues()
+    {
+        $user1 = new UserWithToString('foobar');
+        $user2 = new UserWithToString('foobar');
+        return [
+            ['===', $user1, $user1, true],
+            ['===', $user1, $user2, false],
+            ['===', $user1, 'foobar', false],
+
+            ['==', $user1, $user1, true],
+            ['==', $user1, $user2, false],
+            ['==', $user1, 'foobar', false],
+            ['==', 'foobar', $user1, false],
+            ['==', 1, 0, false],
+            ['==', 1, 1, true],
+            ['==', ['foobar'], ['foobar'], true],
+            ['==', ['foobar'], ['baz'], false],
+
+            ['>', 1, 0, true],
+            ['>', 1, false, true],
+            ['>', false, 0, false],
+
+            ['<', 1, 0, false],
+
+            // edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
+            ['==', 'foo', 0, true],
+            ['>=', 1.1, 'foo', true],
+            ['>', 'foo', 0, false],
+
+        ];
+    }
+
+    /**
+     * @dataProvider getCreateFromNodeAndEvaluateTestValues
+     * @param NodeInterface $node
+     * @param boolean $expected
+     */
+    public function testCreateFromNodeAndEvaluate(NodeInterface $node, $expected)
+    {
+        $result = BooleanNode::createFromNodeAndEvaluate($node, $this->renderingContext);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCreateFromNodeAndEvaluateTestValues()
+    {
+        return [
+            '1 && 1' => [new TextNode('1 && 1'), true],
+            '1 && 0' => [new TextNode('1 && 0'), false],
+            '(1 && 1) && 1' => [new TextNode('(1 && 1) && 1'), true],
+            '(1 && 0) || 1' => [new TextNode('(1 && 0) || 1'), true],
+            '(\'text\' == \'text\') || 1 >= 0' => [new TextNode('(\'text\' == \'text\') || 1 >= 0'), true],
+            '1 <= 0' => [new TextNode('1 <= 0'), false],
+            '1 > 4' => [new TextNode('1 > 4'), false],
+            '1 < 4' => [new TextNode('1 < 4'), true],
+            '4 % 4' => [new TextNode('4 % 4'), false],
+            '2 % 4' => [new TextNode('2 % 4'), true],
+            '0 && 1' => [new TextNode('0 && 1'), false],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function comparingNestedComparisonsWorks()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('('));
+        $rootNode->addChildNode(new ArrayNode(['foo' => 'bar']));
+        $rootNode->addChildNode(new TextNode('=='));
+        $rootNode->addChildNode(new ArrayNode(['foo' => 'bar']));
+        $rootNode->addChildNode(new TextNode(')'));
+        $rootNode->addChildNode(new TextNode('&&'));
+        $rootNode->addChildNode(new TextNode('1'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingEqualNumbersReturnsTrue()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('5'));
+        $rootNode->addChildNode(new TextNode('=='));
+        $rootNode->addChildNode(new TextNode('5'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingUnequalNumbersReturnsFalse()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('5'));
+        $rootNode->addChildNode(new TextNode('=='));
+        $rootNode->addChildNode(new TextNode('3'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertFalse($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingEqualIdentityReturnsTrue()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('5'));
+        $rootNode->addChildNode(new TextNode('==='));
+        $rootNode->addChildNode(new TextNode('5'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingUnequalIdentityReturnsFalse()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new NumericNode('0'));
+        $rootNode->addChildNode(new TextNode('==='));
+        $rootNode->addChildNode(new BooleanNode(false));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertFalse($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function notEqualReturnsFalseIfNumbersAreEqual()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('5'));
+        $rootNode->addChildNode(new TextNode('!='));
+        $rootNode->addChildNode(new TextNode('5'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertFalse($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function notEqualReturnsTrueIfNumbersAreNotEqual()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('5'));
+        $rootNode->addChildNode(new TextNode('!='));
+        $rootNode->addChildNode(new TextNode('3'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function oddNumberModulo2ReturnsTrue()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('43'));
+        $rootNode->addChildNode(new TextNode('%'));
+        $rootNode->addChildNode(new TextNode('2'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function evenNumberModulo2ReturnsFalse()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('42'));
+        $rootNode->addChildNode(new TextNode('%'));
+        $rootNode->addChildNode(new TextNode('2'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertFalse($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function greaterThanReturnsTrueIfNumberIsReallyGreater()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('>'));
+        $rootNode->addChildNode(new TextNode('9'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function greaterThanReturnsFalseIfNumberIsEqual()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('>'));
+        $rootNode->addChildNode(new TextNode('10'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertFalse($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function greaterOrEqualsReturnsTrueIfNumberIsReallyGreater()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('>='));
+        $rootNode->addChildNode(new TextNode('9'));
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function greaterOrEqualsReturnsTrueIfNumberIsEqual()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('>='));
+        $rootNode->addChildNode(new TextNode('10'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function greaterOrEqualsReturnFalseIfNumberIsSmaller()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('>='));
+        $rootNode->addChildNode(new TextNode('11'));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function lessThanReturnsTrueIfNumberIsReallyless()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('9'));
+        $rootNode->addChildNode(new TextNode('<'));
+        $rootNode->addChildNode(new TextNode('10'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function lessThanReturnsFalseIfNumberIsEqual()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('<'));
+        $rootNode->addChildNode(new TextNode('10'));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function lessOrEqualsReturnsTrueIfNumberIsReallyLess()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('9'));
+        $rootNode->addChildNode(new TextNode('<='));
+        $rootNode->addChildNode(new TextNode('10'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function lessOrEqualsReturnsTrueIfNumberIsEqual()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('10'));
+        $rootNode->addChildNode(new TextNode('<='));
+        $rootNode->addChildNode(new TextNode('10'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function lessOrEqualsReturnFalseIfNumberIsBigger()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('11'));
+        $rootNode->addChildNode(new TextNode('<='));
+        $rootNode->addChildNode(new TextNode('10'));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function lessOrEqualsReturnFalseIfComparingWithANegativeNumber()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('11 <= -2.1'));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @param array $variables
+     * @return RenderingContext
+     */
+    protected function getDummyRenderingContextWithVariables(array $variables)
+    {
+        $context = $this->renderingContext;
+        $context->setVariableProvider(new StandardVariableProvider($variables));
+        $context->getVariableProvider()->setSource($variables);
+        return $context;
+    }
+
+    /**
+     * @test
+     */
+    public function comparingVariableWithMatchedQuotedString()
+    {
+        $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new ObjectAccessorNode('test'));
+        $rootNode->addChildNode(new TextNode(' == '));
+        $rootNode->addChildNode(new TextNode('\'somevalue\''));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingVariableWithUnmatchedQuotedString()
+    {
+        $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new ObjectAccessorNode('test'));
+        $rootNode->addChildNode(new TextNode(' != '));
+        $rootNode->addChildNode(new TextNode('\'othervalue\''));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingNotEqualsVariableWithMatchedQuotedString()
+    {
+        $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new ObjectAccessorNode('test'));
+        $rootNode->addChildNode(new TextNode(' != '));
+        $rootNode->addChildNode(new TextNode('\'somevalue\''));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingNotEqualsVariableWithUnmatchedQuotedString()
+    {
+        $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new ObjectAccessorNode('test'));
+        $rootNode->addChildNode(new TextNode(' != '));
+        $rootNode->addChildNode(new TextNode('\'somevalue\''));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function comparingEqualsVariableWithMatchedQuotedStringInSingleTextNode()
+    {
+        $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new ObjectAccessorNode('test'));
+        $rootNode->addChildNode(new TextNode(' != \'somevalue\''));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function notEqualReturnsFalseIfComparingMatchingStrings()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'stringA\' != "stringA"'));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function notEqualReturnsTrueIfComparingNonMatchingStrings()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'stringA\' != \'stringB\''));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function equalsReturnsFalseIfComparingNonMatchingStrings()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'stringA\' == \'stringB\''));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function equalsReturnsTrueIfComparingMatchingStrings()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'stringA\' == "stringA"'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function equalsReturnsTrueIfComparingMatchingStringsWithEscapedQuotes()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'\\\'stringA\\\'\' == \'\\\'stringA\\\'\''));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function equalsReturnsFalseIfComparingStringWithNonZero()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'stringA\' == 42'));
+        $this->assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function equalsReturnsTrueIfComparingStringWithZero()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'stringA\' == 0'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function equalsReturnsFalseIfComparingStringZeroWithZero()
+    {
+        $rootNode = new RootNode();
+        $rootNode->addChildNode(new TextNode('\'0\' == 0'));
+        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function objectsAreComparedStrictly()
+    {
+        $object1 = new \stdClass();
+        $object2 = new \stdClass();
+
+        $rootNode = new RootNode();
+
+        $object1Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object1Node->expects($this->any())->method('evaluate')->will($this->returnValue($object1));
+
+        $object2Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object2Node->expects($this->any())->method('evaluate')->will($this->returnValue($object2));
+
+        $rootNode->addChildNode($object1Node);
+        $rootNode->addChildNode(new TextNode('=='));
+        $rootNode->addChildNode($object2Node);
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertFalse($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @test
+     */
+    public function objectsAreComparedStrictlyInUnequalComparison()
+    {
+        $object1 = new \stdClass();
+        $object2 = new \stdClass();
+
+        $rootNode = new RootNode();
+
+        $object1Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object1Node->expects($this->any())->method('evaluate')->will($this->returnValue($object1));
+
+        $object2Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object2Node->expects($this->any())->method('evaluate')->will($this->returnValue($object2));
+
+        $rootNode->addChildNode($object1Node);
+        $rootNode->addChildNode(new TextNode('!='));
+        $rootNode->addChildNode($object2Node);
+
+        $booleanNode = new BooleanNode($rootNode);
+        $this->assertTrue($booleanNode->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @param mixed $input
+     * @param boolean $expected
+     * @test
+     * @dataProvider getStandardInputTypes
+     */
+    public function acceptsStandardTypesAsInput($input, $expected)
+    {
+        $node = new BooleanNode($input);
+        $this->assertEquals($expected, $node->evaluate($this->renderingContext));
+    }
+
+    /**
+     * @return array
+     */
+    public function getStandardInputTypes()
+    {
+        return [
+            [0, false],
+            [1, true],
+            [false, false],
+            [true, true],
+            [null, false],
+            ['', false],
+            ['0', false],
+            ['1', true],
+            [[1], true],
+            [[0], false],
+        ];
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -14,29 +14,31 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for EscapingNode
  */
-class EscapingNodeTest extends UnitTestCase {
+class EscapingNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testEscapesNodeInConstructor() {
-		$string = '<strong>escape me</strong>';
-		$childNode = new TextNode($string);
-		$node = new EscapingNode($childNode);
-		$renderingContext = new RenderingContextFixture();
-		$this->assertEquals($node->evaluate($renderingContext), htmlspecialchars($string, ENT_QUOTES));
-	}
+    /**
+     * @test
+     */
+    public function testEscapesNodeInConstructor()
+    {
+        $string = '<strong>escape me</strong>';
+        $childNode = new TextNode($string);
+        $node = new EscapingNode($childNode);
+        $renderingContext = new RenderingContextFixture();
+        $this->assertEquals($node->evaluate($renderingContext), htmlspecialchars($string, ENT_QUOTES));
+    }
 
-	/**
-	 * @test
-	 */
-	public function testEscapesNodeOverriddenWithAddChildNode() {
-		$string1 = '<strong>escape me</strong>';
-		$string2 = '<strong>no, escape me!</strong>';
-		$node = new EscapingNode(new TextNode($string1));
-		$node->addChildNode(new TextNode($string2));
-		$renderingContext = new RenderingContextFixture();
-		$this->assertEquals($node->evaluate($renderingContext), htmlspecialchars($string2, ENT_QUOTES));
-	}
-
+    /**
+     * @test
+     */
+    public function testEscapesNodeOverriddenWithAddChildNode()
+    {
+        $string1 = '<strong>escape me</strong>';
+        $string2 = '<strong>no, escape me!</strong>';
+        $node = new EscapingNode(new TextNode($string1));
+        $node->addChildNode(new TextNode($string2));
+        $renderingContext = new RenderingContextFixture();
+        $this->assertEquals($node->evaluate($renderingContext), htmlspecialchars($string2, ENT_QUOTES));
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -17,75 +17,79 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 /**
  * Class CastingExpressionNodeTest
  */
-class CastingExpressionNodeTest extends UnitTestCase {
+class CastingExpressionNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testEvaluateDelegatesToEvaluteExpression() {
-		$subject = $this->getMock(
-			CastingExpressionNode::class,
-			array('dummy'),
-			array('{test as string}', array('test as string'))
-		);
-		$view = new TemplateView();
-		$context = new RenderingContext($view);
-		$context->setVariableProvider(new StandardVariableProvider(array('test' => 10)));
-		$result = $subject->evaluate($context);
-		$this->assertSame('10', $result);
-	}
+    /**
+     * @test
+     */
+    public function testEvaluateDelegatesToEvaluteExpression()
+    {
+        $subject = $this->getMock(
+            CastingExpressionNode::class,
+            ['dummy'],
+            ['{test as string}', ['test as string']]
+        );
+        $view = new TemplateView();
+        $context = new RenderingContext($view);
+        $context->setVariableProvider(new StandardVariableProvider(['test' => 10]));
+        $result = $subject->evaluate($context);
+        $this->assertSame('10', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testEvaluateInvalidExpressionThrowsException() {
-		$view = new TemplateView();
-		$renderingContext = new RenderingContext($view);
-		$renderingContext->setVariableProvider(new StandardVariableProvider());
-		$this->setExpectedException(ExpressionException::class);
-		$result = CastingExpressionNode::evaluateExpression($renderingContext, 'suchaninvalidexpression as 1', array());
-	}
+    /**
+     * @test
+     */
+    public function testEvaluateInvalidExpressionThrowsException()
+    {
+        $view = new TemplateView();
+        $renderingContext = new RenderingContext($view);
+        $renderingContext->setVariableProvider(new StandardVariableProvider());
+        $this->setExpectedException(ExpressionException::class);
+        $result = CastingExpressionNode::evaluateExpression($renderingContext, 'suchaninvalidexpression as 1', []);
+    }
 
-	/**
-	 * @dataProvider getEvaluateExpressionTestValues
-	 * @param string $expression
-	 * @param array $variables
-	 * @param mixed $expected
-	 */
-	public function testEvaluateExpression($expression, array $variables, $expected) {
-		$view = new TemplateView();
-		$renderingContext = new RenderingContext($view);
-		$renderingContext->setVariableProvider(new StandardVariableProvider($variables));
-		$result = CastingExpressionNode::evaluateExpression($renderingContext, $expression, array());
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @dataProvider getEvaluateExpressionTestValues
+     * @param string $expression
+     * @param array $variables
+     * @param mixed $expected
+     */
+    public function testEvaluateExpression($expression, array $variables, $expected)
+    {
+        $view = new TemplateView();
+        $renderingContext = new RenderingContext($view);
+        $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
+        $result = CastingExpressionNode::evaluateExpression($renderingContext, $expression, []);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getEvaluateExpressionTestValues() {
-		$arrayIterator = new \ArrayIterator(array('foo', 'bar'));
-		$toArrayObject = new UserWithToArray('foobar');
-		return array(
-			array('123 as string', array(), '123'),
-			array('1 as boolean', array(), TRUE),
-			array('0 as boolean', array(), FALSE),
-			array('0 as array', array(), array(0)),
-			array('1 as array', array(), array(1)),
-			array('mystring as float', array('mystring' => '1.23'), 1.23),
-			array('myvariable as integer', array('myvariable' => 321), 321),
-			array('myinteger as string', array('myinteger' => 111), '111'),
-			array('mydate as DateTime', array('mydate' => 90000), \DateTime::createFromFormat('U', 90000)),
-			array('mydate as DateTime', array('mydate' => 'January'), new \DateTime('January')),
-			array('1 as namestoredinvariables', array('namestoredinvariables' => 'boolean'), TRUE),
-			array('mystring as array', array('mystring' => 'foo,bar'), array('foo', 'bar')),
-			array('mystring as array', array('mystring' => 'foo , bar'), array('foo', 'bar')),
-			array('myiterator as array', array('myiterator' => $arrayIterator), array('foo', 'bar')),
-			array('myarray as array', array('myarray' => array('foo', 'bar')), array('foo', 'bar')),
-			array('myboolean as array', array('myboolean' => TRUE), array()),
-			array('myboolean as array', array('myboolean' => FALSE), array()),
-			array('myobject as array', array('myobject' => $toArrayObject), array('name' => 'foobar')),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getEvaluateExpressionTestValues()
+    {
+        $arrayIterator = new \ArrayIterator(['foo', 'bar']);
+        $toArrayObject = new UserWithToArray('foobar');
+        return [
+            ['123 as string', [], '123'],
+            ['1 as boolean', [], true],
+            ['0 as boolean', [], false],
+            ['0 as array', [], [0]],
+            ['1 as array', [], [1]],
+            ['mystring as float', ['mystring' => '1.23'], 1.23],
+            ['myvariable as integer', ['myvariable' => 321], 321],
+            ['myinteger as string', ['myinteger' => 111], '111'],
+            ['mydate as DateTime', ['mydate' => 90000], \DateTime::createFromFormat('U', 90000)],
+            ['mydate as DateTime', ['mydate' => 'January'], new \DateTime('January')],
+            ['1 as namestoredinvariables', ['namestoredinvariables' => 'boolean'], true],
+            ['mystring as array', ['mystring' => 'foo,bar'], ['foo', 'bar']],
+            ['mystring as array', ['mystring' => 'foo , bar'], ['foo', 'bar']],
+            ['myiterator as array', ['myiterator' => $arrayIterator], ['foo', 'bar']],
+            ['myarray as array', ['myarray' => ['foo', 'bar']], ['foo', 'bar']],
+            ['myboolean as array', ['myboolean' => true], []],
+            ['myboolean as array', ['myboolean' => false], []],
+            ['myobject as array', ['myobject' => $toArrayObject], ['name' => 'foobar']],
+        ];
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -15,38 +15,40 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 /**
  * Class MathExpressionNodeTest
  */
-class MathExpressionNodeTest extends UnitTestCase {
+class MathExpressionNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @dataProvider getEvaluateExpressionTestValues
-	 * @param string $expression
-	 * @param array $variables
-	 * @param mixed $expected
-	 */
-	public function testEvaluateExpression($expression, array $variables, $expected) {
-		$view = new TemplateView();
-		$renderingContext = new RenderingContext($view);
-		$renderingContext->setVariableProvider(new StandardVariableProvider($variables));
-		$result = MathExpressionNode::evaluateExpression($renderingContext, $expression, array());
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @dataProvider getEvaluateExpressionTestValues
+     * @param string $expression
+     * @param array $variables
+     * @param mixed $expected
+     */
+    public function testEvaluateExpression($expression, array $variables, $expected)
+    {
+        $view = new TemplateView();
+        $renderingContext = new RenderingContext($view);
+        $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
+        $result = MathExpressionNode::evaluateExpression($renderingContext, $expression, []);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getEvaluateExpressionTestValues() {
-		return array(
-			array('1 gabbagabbahey 1', array(), 0),
-			array('1 + 1', array(), 2),
-			array('2 - 1', array(), 1),
-			array('2 % 4', array(), 2),
-			array('2 * 4', array(), 8),
-			array('4 / 2', array(), 2),
-			array('4 ^ 2', array(), 16),
-			array('a + 1', array('a' => 1), 2),
-			array('1 + b', array('b' => 1), 2),
-			array('a + b', array('a' => 1, 'b' => 1), 2),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getEvaluateExpressionTestValues()
+    {
+        return [
+            ['1 gabbagabbahey 1', [], 0],
+            ['1 + 1', [], 2],
+            ['2 - 1', [], 1],
+            ['2 % 4', [], 2],
+            ['2 * 4', [], 8],
+            ['4 / 2', [], 2],
+            ['4 ^ 2', [], 16],
+            ['a + 1', ['a' => 1], 2],
+            ['1 + b', ['b' => 1], 2],
+            ['a + b', ['a' => 1, 'b' => 1], 2],
+        ];
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
@@ -15,64 +15,68 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 /**
  * Class TernaryExpressionNodeTest
  */
-class TernaryExpressionNodeTest extends UnitTestCase {
+class TernaryExpressionNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @dataProvider getTernaryExpressionDetection
-	 * @param string $expression
-	 * @param mixed $expected
-	 */
-	public function testTernaryExpressionDetection($expression, $expected) {
-		$result = preg_match_all(TernaryExpressionNode::$detectionExpression, $expression, $matches, PREG_SET_ORDER);
-		$this->assertEquals($expected, count($matches) > 0);
-	}
+    /**
+     * @dataProvider getTernaryExpressionDetection
+     * @param string $expression
+     * @param mixed $expected
+     */
+    public function testTernaryExpressionDetection($expression, $expected)
+    {
+        $result = preg_match_all(TernaryExpressionNode::$detectionExpression, $expression, $matches, PREG_SET_ORDER);
+        $this->assertEquals($expected, count($matches) > 0);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getTernaryExpressionDetection() {
-		return array(
-			array('{true ? foo : bar}', TRUE),
-			array('{true ? 1 : 0}', TRUE),
-			array('{true ? foo : \'no\'}', TRUE),
-			array('{(true) ? \'yes\' : \'no\'}', TRUE),
-			array('{!(true) ? \'yes\' : \'no\'}', TRUE),
-			array('{(true || false) ? \'yes\' : \'no\'}', TRUE),
-			array('{(true && 1) ? \'yes\' : \'no\'}', TRUE),
-			array('{(\'foo\' == \'foo\') ? \'yes\' : \'no\'}', TRUE),
-			array('{(1 > 0) ? \'yes\' : \'no\'}', TRUE),
-			array('{(1 < 0) ? \'yes\' : \'no\'}', TRUE),
-			array('{(1 >= 0) ? \'yes\' : \'no\'}', TRUE),
-			array('{(1 <= 0) ? \'yes\' : \'no\'}', TRUE),
-			array('{(1 % 0) ? \'yes\' : \'no\'}', TRUE),
-			array('{(true || (\'foo\' == \'bar\')) ? \'yes\' : \'no\'}', TRUE),
-			array('{(foo || 1 && 1 && !(false) || (1 % 2) || (1 > 0) || (\'foo\' == \'bar\')) ? \'yes\' : \'no\'}', TRUE),
-			array('{{f:if(condition: 1, then: 1, else: 0)} ? \'yes\' : \'no\'}', TRUE),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getTernaryExpressionDetection()
+    {
+        return [
+            ['{true ? foo : bar}', true],
+            ['{true ? 1 : 0}', true],
+            ['{true ? foo : \'no\'}', true],
+            ['{(true) ? \'yes\' : \'no\'}', true],
+            ['{!(true) ? \'yes\' : \'no\'}', true],
+            ['{(true || false) ? \'yes\' : \'no\'}', true],
+            ['{(true && 1) ? \'yes\' : \'no\'}', true],
+            ['{(\'foo\' == \'foo\') ? \'yes\' : \'no\'}', true],
+            ['{(1 > 0) ? \'yes\' : \'no\'}', true],
+            ['{(1 < 0) ? \'yes\' : \'no\'}', true],
+            ['{(1 >= 0) ? \'yes\' : \'no\'}', true],
+            ['{(1 <= 0) ? \'yes\' : \'no\'}', true],
+            ['{(1 % 0) ? \'yes\' : \'no\'}', true],
+            ['{(true || (\'foo\' == \'bar\')) ? \'yes\' : \'no\'}', true],
+            ['{(foo || 1 && 1 && !(false) || (1 % 2) || (1 > 0) || (\'foo\' == \'bar\')) ? \'yes\' : \'no\'}', true],
+            ['{{f:if(condition: 1, then: 1, else: 0)} ? \'yes\' : \'no\'}', true],
+        ];
+    }
 
-	/**
-	 * @dataProvider getEvaluateExpressionTestValues
-	 * @param string $expression
-	 * @param array $variables
-	 * @param mixed $expected
-	 */
-	public function testEvaluateExpression($expression, array $variables, $expected) {
-		$view = new TemplateView();
-		$renderingContext = new RenderingContext($view);
-		$renderingContext->setVariableProvider(new StandardVariableProvider($variables));
-		$result = TernaryExpressionNode::evaluateExpression($renderingContext, $expression, array());
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @dataProvider getEvaluateExpressionTestValues
+     * @param string $expression
+     * @param array $variables
+     * @param mixed $expected
+     */
+    public function testEvaluateExpression($expression, array $variables, $expected)
+    {
+        $view = new TemplateView();
+        $renderingContext = new RenderingContext($view);
+        $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
+        $result = TernaryExpressionNode::evaluateExpression($renderingContext, $expression, []);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getEvaluateExpressionTestValues() {
-		return array(
-			array('1 ? 2 : 3', array(), 2),
-			array('0 ? 2 : 3', array(), 3),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getEvaluateExpressionTestValues()
+    {
+        return [
+            ['1 ? 2 : 3', [], 2],
+            ['0 ? 2 : 3', [], 3],
+        ];
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -15,49 +15,55 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
  * Testcase for NumericNode
  *
  */
-class NumericNodeTest extends UnitTestCase {
+class NumericNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @var RenderingContext
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
 
-	public function setUp() {
-		$this->renderingContext = new RenderingContextFixture();
-	}
+    public function setUp()
+    {
+        $this->renderingContext = new RenderingContextFixture();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsProperIntegerGivenInConstructor() {
-		$string = '1';
-		$node = new NumericNode($string);
-		$this->assertEquals($node->evaluate($this->renderingContext), 1, 'The rendered value of a numeric node does not match the string given in the constructor.');
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsProperIntegerGivenInConstructor()
+    {
+        $string = '1';
+        $node = new NumericNode($string);
+        $this->assertEquals($node->evaluate($this->renderingContext), 1, 'The rendered value of a numeric node does not match the string given in the constructor.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsProperFloatGivenInConstructor() {
-		$string = '1.1';
-		$node = new NumericNode($string);
-		$this->assertEquals($node->evaluate($this->renderingContext), 1.1, 'The rendered value of a numeric node does not match the string given in the constructor.');
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsProperFloatGivenInConstructor()
+    {
+        $string = '1.1';
+        $node = new NumericNode($string);
+        $this->assertEquals($node->evaluate($this->renderingContext), 1.1, 'The rendered value of a numeric node does not match the string given in the constructor.');
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
-	 */
-	public function constructorThrowsExceptionIfNoNumericGiven() {
-		new NumericNode('foo');
-	}
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
+     */
+    public function constructorThrowsExceptionIfNoNumericGiven()
+    {
+        new NumericNode('foo');
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
-	 */
-	public function addChildNodeThrowsException() {
-		$node = new NumericNode('1');
-		$node->addChildNode(clone $node);
-	}
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
+     */
+    public function addChildNodeThrowsException()
+    {
+        $node = new NumericNode('1');
+        $node->addChildNode(clone $node);
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -14,50 +14,53 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for ObjectAccessorNode
  */
-class ObjectAccessorNodeTest extends UnitTestCase {
+class ObjectAccessorNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 * @dataProvider getEvaluateTestValues
-	 * @param array $variables
-	 * @param string $path
-	 * @param mixed $expected
-	 */
-	public function testEvaluateGetsExpectedValue(array $variables, $path, $expected) {
-		$node = new ObjectAccessorNode($path);
-		$renderingContext = $this->getMock(RenderingContextInterface::class);
-		$variableContainer = new StandardVariableProvider($variables);
-		$renderingContext->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
-		$value = $node->evaluate($renderingContext);
-		$this->assertEquals($expected, $value);
-	}
+    /**
+     * @test
+     * @dataProvider getEvaluateTestValues
+     * @param array $variables
+     * @param string $path
+     * @param mixed $expected
+     */
+    public function testEvaluateGetsExpectedValue(array $variables, $path, $expected)
+    {
+        $node = new ObjectAccessorNode($path);
+        $renderingContext = $this->getMock(RenderingContextInterface::class);
+        $variableContainer = new StandardVariableProvider($variables);
+        $renderingContext->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $value = $node->evaluate($renderingContext);
+        $this->assertEquals($expected, $value);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getEvaluateTestValues() {
-		return array(
-			array(array('foo' => 'bar'), 'foo.notaproperty', NULL),
-			array(array('foo' => 'bar'), '_all', array('foo' => 'bar')),
-			array(array('foo' => 'bar'), 'foo', 'bar'),
-			array(array('foo' => array('bar' => 'test')), 'foo.bar', 'test'),
-			array(array('foo' => array('bar' => 'test'), 'dynamic' => 'bar'), 'foo.{dynamic}', 'test'),
-			array(array('foo' => array('bar' => 'test'), 'dynamic' => array('sub' => 'bar')), 'foo.{dynamic.sub}', 'test'),
-			array(array('foo' => array('bar' => 'test'), 'dynamic' => array('sub' => 'bar'), 'baz' => 'sub'), 'foo.{dynamic.{baz}}', 'test'),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getEvaluateTestValues()
+    {
+        return [
+            [['foo' => 'bar'], 'foo.notaproperty', null],
+            [['foo' => 'bar'], '_all', ['foo' => 'bar']],
+            [['foo' => 'bar'], 'foo', 'bar'],
+            [['foo' => ['bar' => 'test']], 'foo.bar', 'test'],
+            [['foo' => ['bar' => 'test'], 'dynamic' => 'bar'], 'foo.{dynamic}', 'test'],
+            [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar']], 'foo.{dynamic.sub}', 'test'],
+            [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar'], 'baz' => 'sub'], 'foo.{dynamic.{baz}}', 'test'],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testEvaluatedUsesVariableProviderGetByPath() {
-		$node = new ObjectAccessorNode('foo.bar');
-		$renderingContext = $this->getMock(RenderingContextInterface::class);
-		$variableContainer = $this->getMock(StandardVariableProvider::class, array());
-		$variableContainer->expects($this->once())->method('getByPath')->with('foo.bar', array())->will($this->returnValue('foo'));
-		$renderingContext->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
-		$value = $node->evaluate($renderingContext);
-		$this->assertEquals('foo', $value);
-	}
-
+    /**
+     * @test
+     */
+    public function testEvaluatedUsesVariableProviderGetByPath()
+    {
+        $node = new ObjectAccessorNode('foo.bar');
+        $renderingContext = $this->getMock(RenderingContextInterface::class);
+        $variableContainer = $this->getMock(StandardVariableProvider::class, []);
+        $variableContainer->expects($this->once())->method('getByPath')->with('foo.bar', [])->will($this->returnValue('foo'));
+        $renderingContext->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $value = $node->evaluate($renderingContext);
+        $this->assertEquals('foo', $value);
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -15,16 +15,17 @@ use TYPO3Fluid\Fluid\View\TemplateView;
  * Testcase for RootNode
  *
  */
-class RootNodeTest extends UnitTestCase {
+class RootNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testEvaluateCallsEvaluateChildNodes() {
-		$view = new TemplateView();
-		$subject = $this->getMock(RootNode::class, array('evaluateChildNodes'));
-		$subject->expects($this->once())->method('evaluateChildNodes');
-		$subject->evaluate(new RenderingContext($view));
-	}
-
+    /**
+     * @test
+     */
+    public function testEvaluateCallsEvaluateChildNodes()
+    {
+        $view = new TemplateView();
+        $subject = $this->getMock(RootNode::class, ['evaluateChildNodes']);
+        $subject->expects($this->once())->method('evaluateChildNodes');
+        $subject->evaluate(new RenderingContext($view));
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -13,23 +13,26 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for TextNode
  */
-class TextNodeTest extends UnitTestCase {
+class TextNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsSameStringAsGivenInConstructor() {
-		$string = 'I can work quite effectively in a train!';
-		$node = new TextNode($string);
-		$renderingContext = new RenderingContextFixture();
-		$this->assertEquals($node->evaluate($renderingContext), $string, 'The rendered string of a text node is not the same as the string given in the constructor.');
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsSameStringAsGivenInConstructor()
+    {
+        $string = 'I can work quite effectively in a train!';
+        $node = new TextNode($string);
+        $renderingContext = new RenderingContextFixture();
+        $this->assertEquals($node->evaluate($renderingContext), $string, 'The rendered string of a text node is not the same as the string given in the constructor.');
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
-	 */
-	public function constructorThrowsExceptionIfNoStringGiven() {
-		new TextNode(123);
-	}
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
+     */
+    public function constructorThrowsExceptionIfNoStringGiven()
+    {
+        new TextNode(123);
+    }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -21,100 +21,106 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for \TYPO3Fluid\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode
  */
-class ViewHelperNodeTest extends UnitTestCase {
+class ViewHelperNodeTest extends UnitTestCase
+{
 
-	/**
-	 * @var RenderingContext
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
 
-	/**
-	 * @var TemplateVariableContainer|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $templateVariableContainer;
+    /**
+     * @var TemplateVariableContainer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templateVariableContainer;
 
-	/**
-	 * @var ViewHelperResolver|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $mockViewHelperResolver;
+    /**
+     * @var ViewHelperResolver|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockViewHelperResolver;
 
-	/**
-	 * Setup fixture
-	 */
-	public function setUp() {
-		$this->renderingContext = new RenderingContextFixture();
-		$this->mockViewHelperResolver = $this->getMock(ViewHelperResolver::class, array('resolveViewHelperClassName', 'createViewHelperInstanceFromClassName', 'getArgumentDefinitionsForViewHelper'));
-		$this->mockViewHelperResolver->expects($this->any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
-		$this->mockViewHelperResolver->expects($this->any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
-		$this->mockViewHelperResolver->expects($this->any())->method('getArgumentDefinitionsForViewHelper')->willReturn(array(
-			'foo' => new ArgumentDefinition('foo', 'string', 'Dummy required argument', TRUE)
-		));
-		$this->renderingContext->setViewHelperResolver($this->mockViewHelperResolver);
-	}
+    /**
+     * Setup fixture
+     */
+    public function setUp()
+    {
+        $this->renderingContext = new RenderingContextFixture();
+        $this->mockViewHelperResolver = $this->getMock(ViewHelperResolver::class, ['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName', 'getArgumentDefinitionsForViewHelper']);
+        $this->mockViewHelperResolver->expects($this->any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
+        $this->mockViewHelperResolver->expects($this->any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
+        $this->mockViewHelperResolver->expects($this->any())->method('getArgumentDefinitionsForViewHelper')->willReturn([
+            'foo' => new ArgumentDefinition('foo', 'string', 'Dummy required argument', true)
+        ]);
+        $this->renderingContext->setViewHelperResolver($this->mockViewHelperResolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function constructorSetsViewHelperAndArguments() {
-		$arguments = array('foo' => 'bar');
-		/** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $viewHelperNode */
-		$viewHelperNode = new ViewHelperNode($this->renderingContext, 'f', 'vh', $arguments, new ParsingState());
+    /**
+     * @test
+     */
+    public function constructorSetsViewHelperAndArguments()
+    {
+        $arguments = ['foo' => 'bar'];
+        /** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $viewHelperNode */
+        $viewHelperNode = new ViewHelperNode($this->renderingContext, 'f', 'vh', $arguments, new ParsingState());
 
-		$this->assertAttributeEquals($arguments, 'arguments', $viewHelperNode);
-	}
+        $this->assertAttributeEquals($arguments, 'arguments', $viewHelperNode);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testEvaluateCallsInvoker() {
-		$invoker = $this->getMock(ViewHelperInvoker::class, array('invoke'));
-		$invoker->expects($this->once())->method('invoke')->willReturn('test');
-		$this->renderingContext->setViewHelperInvoker($invoker);
-		$node = new ViewHelperNode($this->renderingContext, 'f', 'vh', array('foo' => 'bar'), new ParsingState());
-		$result = $node->evaluate($this->renderingContext);
-		$this->assertEquals('test', $result);
-	}
+    /**
+     * @test
+     */
+    public function testEvaluateCallsInvoker()
+    {
+        $invoker = $this->getMock(ViewHelperInvoker::class, ['invoke']);
+        $invoker->expects($this->once())->method('invoke')->willReturn('test');
+        $this->renderingContext->setViewHelperInvoker($invoker);
+        $node = new ViewHelperNode($this->renderingContext, 'f', 'vh', ['foo' => 'bar'], new ParsingState());
+        $result = $node->evaluate($this->renderingContext);
+        $this->assertEquals('test', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testThrowsExceptionOnMissingRequiredArgument() {
-		$this->setExpectedException(ParserException::class);
-		new ViewHelperNode($this->renderingContext, 'f', 'vh', array('notfoo' => FALSE), new ParsingState());
-	}
+    /**
+     * @test
+     */
+    public function testThrowsExceptionOnMissingRequiredArgument()
+    {
+        $this->setExpectedException(ParserException::class);
+        new ViewHelperNode($this->renderingContext, 'f', 'vh', ['notfoo' => false], new ParsingState());
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
-	 */
-	public function abortIfRequiredArgumentsAreMissingThrowsException() {
-		$expected = array(
-			new ArgumentDefinition('firstArgument', 'string', '', FALSE),
-			new ArgumentDefinition('secondArgument', 'string', '', TRUE)
-		);
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
+     */
+    public function abortIfRequiredArgumentsAreMissingThrowsException()
+    {
+        $expected = [
+            new ArgumentDefinition('firstArgument', 'string', '', false),
+            new ArgumentDefinition('secondArgument', 'string', '', true)
+        ];
 
-		$templateParser = $this->getAccessibleMock(ViewHelperNode::class, array('dummy'), array(), '', FALSE);
+        $templateParser = $this->getAccessibleMock(ViewHelperNode::class, ['dummy'], [], '', false);
 
-		$templateParser->_call('abortIfRequiredArgumentsAreMissing', $expected, array());
-	}
+        $templateParser->_call('abortIfRequiredArgumentsAreMissing', $expected, []);
+    }
 
-	/**
-	 * @test
-	 */
-	public function abortIfRequiredArgumentsAreMissingDoesNotThrowExceptionIfRequiredArgumentExists() {
-		$expectedArguments = array(
-			new ArgumentDefinition('name1', 'string', 'desc', FALSE),
-			new ArgumentDefinition('name2', 'string', 'desc', TRUE)
-		);
-		$actualArguments = array(
-			'name2' => 'bla'
-		);
+    /**
+     * @test
+     */
+    public function abortIfRequiredArgumentsAreMissingDoesNotThrowExceptionIfRequiredArgumentExists()
+    {
+        $expectedArguments = [
+            new ArgumentDefinition('name1', 'string', 'desc', false),
+            new ArgumentDefinition('name2', 'string', 'desc', true)
+        ];
+        $actualArguments = [
+            'name2' => 'bla'
+        ];
 
-		$mockTemplateParser = $this->getAccessibleMock(ViewHelperNode::class, array('dummy'), array(), '', FALSE);
+        $mockTemplateParser = $this->getAccessibleMock(ViewHelperNode::class, ['dummy'], [], '', false);
 
-		$mockTemplateParser->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
-		// dummy assertion to avoid "did not perform any assertions" error
-		$this->assertTrue(TRUE);
-	}
-
+        $mockTemplateParser->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
+        // dummy assertion to avoid "did not perform any assertions" error
+        $this->assertTrue(true);
+    }
 }

--- a/tests/Unit/Core/Parser/TemplateParserPatternTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserPatternTest.php
@@ -13,478 +13,497 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for Regular expressions in parser
  */
-class PatternsTest extends UnitTestCase {
+class PatternsTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testSCAN_PATTERN_NAMESPACEDECLARATION() {
-		$this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '{namespace acme=Acme.MyPackage\Bla\blubb}'), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (1).');
-		$this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '{namespace acme=Acme.MyPackage\Bla\Blubb }'), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (2).');
-		$this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '    {namespace foo = Foo\Bla3\Blubb }    '), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (3).');
-		$this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '    {namespace foo.bar  = Foo\Bla3\Blubb }    '), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (4).');
-		$this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, ' \{namespace fblubb = TYPO3.Fluid\Bla3\Blubb }'), 0, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did match a namespace declaration even if it was escaped. (1)');
-		$this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '\{namespace typo3 = TYPO3.TYPO3\Bla3\Blubb }'), 0, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did match a namespace declaration even if it was escaped. (2)');
-	}
+    /**
+     * @test
+     */
+    public function testSCAN_PATTERN_NAMESPACEDECLARATION()
+    {
+        $this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '{namespace acme=Acme.MyPackage\Bla\blubb}'), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (1).');
+        $this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '{namespace acme=Acme.MyPackage\Bla\Blubb }'), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (2).');
+        $this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '    {namespace foo = Foo\Bla3\Blubb }    '), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (3).');
+        $this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '    {namespace foo.bar  = Foo\Bla3\Blubb }    '), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (4).');
+        $this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, ' \{namespace fblubb = TYPO3.Fluid\Bla3\Blubb }'), 0, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did match a namespace declaration even if it was escaped. (1)');
+        $this->assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '\{namespace typo3 = TYPO3.TYPO3\Bla3\Blubb }'), 0, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did match a namespace declaration even if it was escaped. (2)');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSPLIT_PATTERN_DYNAMICTAGS() {
-		$pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, array('typo3', 't3', 'f'));
+    /**
+     * @test
+     */
+    public function testSPLIT_PATTERN_DYNAMICTAGS()
+    {
+        $pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS, ['typo3', 't3', 'f']);
 
-		$source = '<html><head> <f:a.testing /> <f:blablubb> {testing}</f4:blz> </t3:hi.jo>';
-		$expected = array('<html><head> ','<f:a.testing />', ' ', '<f:blablubb>', ' {testing}', '</f4:blz>', ' ', '</t3:hi.jo>');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with simple tags.');
+        $source = '<html><head> <f:a.testing /> <f:blablubb> {testing}</f4:blz> </t3:hi.jo>';
+        $expected = ['<html><head> ','<f:a.testing />', ' ', '<f:blablubb>', ' {testing}', '</f4:blz>', ' ', '</t3:hi.jo>'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with simple tags.');
 
-		$source = 'hi<f:testing attribute="Hallo>{yep}" nested:attribute="jup" />ja';
-		$expected = array('hi', '<f:testing attribute="Hallo>{yep}" nested:attribute="jup" />', 'ja');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with  > inside an attribute.');
+        $source = 'hi<f:testing attribute="Hallo>{yep}" nested:attribute="jup" />ja';
+        $expected = ['hi', '<f:testing attribute="Hallo>{yep}" nested:attribute="jup" />', 'ja'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with  > inside an attribute.');
 
-		$source = 'hi<f:testing attribute="Hallo\"{yep}" nested:attribute="jup" />ja';
-		$expected = array('hi', '<f:testing attribute="Hallo\"{yep}" nested:attribute="jup" />', 'ja');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if a " is inside a double-quoted string.');
+        $source = 'hi<f:testing attribute="Hallo\"{yep}" nested:attribute="jup" />ja';
+        $expected = ['hi', '<f:testing attribute="Hallo\"{yep}" nested:attribute="jup" />', 'ja'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if a " is inside a double-quoted string.');
 
-		$source = 'hi<f:testing attribute=\'Hallo>{yep}\' nested:attribute="jup" />ja';
-		$expected = array('hi', '<f:testing attribute=\'Hallo>{yep}\' nested:attribute="jup" />', 'ja');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with single quotes as attribute delimiters.');
+        $source = 'hi<f:testing attribute=\'Hallo>{yep}\' nested:attribute="jup" />ja';
+        $expected = ['hi', '<f:testing attribute=\'Hallo>{yep}\' nested:attribute="jup" />', 'ja'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with single quotes as attribute delimiters.');
 
-		$source = 'hi<f:testing attribute=\'Hallo\\\'{yep}\' nested:attribute="jup" />ja';
-		$expected = array('hi', '<f:testing attribute=\'Hallo\\\'{yep}\' nested:attribute="jup" />', 'ja');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if \' is inside a single-quoted attribute.');
+        $source = 'hi<f:testing attribute=\'Hallo\\\'{yep}\' nested:attribute="jup" />ja';
+        $expected = ['hi', '<f:testing attribute=\'Hallo\\\'{yep}\' nested:attribute="jup" />', 'ja'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if \' is inside a single-quoted attribute.');
 
-		$source = 'Hallo <f:testing><![CDATA[<f:notparsed>]]></f:testing>';
-		$expected = array('Hallo ', '<f:testing>', '<![CDATA[<f:notparsed>]]>', '</f:testing>');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if there is a CDATA section the parser should ignore.');
+        $source = 'Hallo <f:testing><![CDATA[<f:notparsed>]]></f:testing>';
+        $expected = ['Hallo ', '<f:testing>', '<![CDATA[<f:notparsed>]]>', '</f:testing>'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if there is a CDATA section the parser should ignore.');
 
-		$veryLongViewHelper = '<f:form enctype="multipart/form-data" onsubmit="void(0)" onreset="void(0)" action="someAction" arguments="{arg1: \'val1\', arg2: \'val2\'}" controller="someController" package="YourCompanyName.somePackage" subpackage="YourCompanyName.someSubpackage" section="someSection" format="txt" additionalParams="{param1: \'val1\', param2: \'val2\'}" absolute="true" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: \'foo\'}" />';
-		$source = $veryLongViewHelper . 'Begin' . $veryLongViewHelper . 'End';
-		$expected = array($veryLongViewHelper, 'Begin', $veryLongViewHelper, 'End');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if the VH has lots of arguments.');
+        $veryLongViewHelper = '<f:form enctype="multipart/form-data" onsubmit="void(0)" onreset="void(0)" action="someAction" arguments="{arg1: \'val1\', arg2: \'val2\'}" controller="someController" package="YourCompanyName.somePackage" subpackage="YourCompanyName.someSubpackage" section="someSection" format="txt" additionalParams="{param1: \'val1\', param2: \'val2\'}" absolute="true" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: \'foo\'}" />';
+        $source = $veryLongViewHelper . 'Begin' . $veryLongViewHelper . 'End';
+        $expected = [$veryLongViewHelper, 'Begin', $veryLongViewHelper, 'End'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly if the VH has lots of arguments.');
 
-		$source = '<f:a.testing data-bar="foo"> <f:a.testing>';
-		$expected = array('<f:a.testing data-bar="foo">', ' ', '<f:a.testing>');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with data- attribute.');
+        $source = '<f:a.testing data-bar="foo"> <f:a.testing>';
+        $expected = ['<f:a.testing data-bar="foo">', ' ', '<f:a.testing>'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with data- attribute.');
 
-		$source = '<foo:a.testing someArgument="bar"> <f:a.testing>';
-		$expected = array('<foo:a.testing someArgument="bar">', ' ', '<f:a.testing>');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with custom namespace identifier.');
+        $source = '<foo:a.testing someArgument="bar"> <f:a.testing>';
+        $expected = ['<foo:a.testing someArgument="bar">', ' ', '<f:a.testing>'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with custom namespace identifier.');
 
-		$source = '<foo.bar:a.testing someArgument="baz"> <f:a.testing>';
-		$expected = array('<foo.bar:a.testing someArgument="baz">', ' ', '<f:a.testing>');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with custom multi-part namespace identifier.');
-	}
+        $source = '<foo.bar:a.testing someArgument="baz"> <f:a.testing>';
+        $expected = ['<foo.bar:a.testing someArgument="baz">', ' ', '<f:a.testing>'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with custom multi-part namespace identifier.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSCAN_PATTERN_DYNAMICTAG() {
-		$pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, array('f'));
-		$source = '<f:crop attribute="Hallo">';
-		$expected = array(
-			0 => '<f:crop attribute="Hallo">',
-			'NamespaceIdentifier' => 'f',
-			1 => 'f',
-			'MethodIdentifier' => 'crop',
-			2 => 'crop',
-			'Attributes' => ' attribute="Hallo"',
-			3 => ' attribute="Hallo"',
-			'Selfclosing' => '',
-			4 => ''
-		);
-		preg_match($pattern, $source, $matches);
-		$this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly.');
+    /**
+     * @test
+     */
+    public function testSCAN_PATTERN_DYNAMICTAG()
+    {
+        $pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, ['f']);
+        $source = '<f:crop attribute="Hallo">';
+        $expected = [
+            0 => '<f:crop attribute="Hallo">',
+            'NamespaceIdentifier' => 'f',
+            1 => 'f',
+            'MethodIdentifier' => 'crop',
+            2 => 'crop',
+            'Attributes' => ' attribute="Hallo"',
+            3 => ' attribute="Hallo"',
+            'Selfclosing' => '',
+            4 => ''
+        ];
+        preg_match($pattern, $source, $matches);
+        $this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly.');
 
-		$pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, array('f'));
-		$source = '<f:crop data-attribute="Hallo">';
-		$expected = array(
-			0 => '<f:crop data-attribute="Hallo">',
-			'NamespaceIdentifier' => 'f',
-			1 => 'f',
-			'MethodIdentifier' => 'crop',
-			2 => 'crop',
-			'Attributes' => ' data-attribute="Hallo"',
-			3 => ' data-attribute="Hallo"',
-			'Selfclosing' => '',
-			4 => ''
-		);
-		preg_match($pattern, $source, $matches);
-		$this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with data- attributes.');
+        $pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, ['f']);
+        $source = '<f:crop data-attribute="Hallo">';
+        $expected = [
+            0 => '<f:crop data-attribute="Hallo">',
+            'NamespaceIdentifier' => 'f',
+            1 => 'f',
+            'MethodIdentifier' => 'crop',
+            2 => 'crop',
+            'Attributes' => ' data-attribute="Hallo"',
+            3 => ' data-attribute="Hallo"',
+            'Selfclosing' => '',
+            4 => ''
+        ];
+        preg_match($pattern, $source, $matches);
+        $this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with data- attributes.');
 
-		$source = '<f:base />';
-		$expected = array(
-			0 => '<f:base />',
-			'NamespaceIdentifier' => 'f',
-			1 => 'f',
-			'MethodIdentifier' => 'base',
-			2 => 'base',
-			'Attributes' => '',
-			3 => '',
-			'Selfclosing' => '/',
-			4 => '/'
-		);
-		preg_match($pattern, $source, $matches);
-		$this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly when there is a space before the self-closing tag.');
+        $source = '<f:base />';
+        $expected = [
+            0 => '<f:base />',
+            'NamespaceIdentifier' => 'f',
+            1 => 'f',
+            'MethodIdentifier' => 'base',
+            2 => 'base',
+            'Attributes' => '',
+            3 => '',
+            'Selfclosing' => '/',
+            4 => '/'
+        ];
+        preg_match($pattern, $source, $matches);
+        $this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly when there is a space before the self-closing tag.');
 
-		$source = '<f:crop attribute="Ha\"llo"/>';
-		$expected = array(
-			0 => '<f:crop attribute="Ha\"llo"/>',
-			'NamespaceIdentifier' => 'f',
-			1 => 'f',
-			'MethodIdentifier' => 'crop',
-			2 => 'crop',
-			'Attributes' => ' attribute="Ha\"llo"',
-			3 => ' attribute="Ha\"llo"',
-			'Selfclosing' => '/',
-			4 => '/'
-		);
-		preg_match($pattern, $source, $matches);
-		$this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with self-closing tags.');
+        $source = '<f:crop attribute="Ha\"llo"/>';
+        $expected = [
+            0 => '<f:crop attribute="Ha\"llo"/>',
+            'NamespaceIdentifier' => 'f',
+            1 => 'f',
+            'MethodIdentifier' => 'crop',
+            2 => 'crop',
+            'Attributes' => ' attribute="Ha\"llo"',
+            3 => ' attribute="Ha\"llo"',
+            'Selfclosing' => '/',
+            4 => '/'
+        ];
+        preg_match($pattern, $source, $matches);
+        $this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with self-closing tags.');
 
-		$source = '<f:link.uriTo complex:attribute="Ha>llo" a="b" c=\'d\'/>';
-		$expected = array(
-			0 => '<f:link.uriTo complex:attribute="Ha>llo" a="b" c=\'d\'/>',
-			'NamespaceIdentifier' => 'f',
-			1 => 'f',
-			'MethodIdentifier' => 'link.uriTo',
-			2 => 'link.uriTo',
-			'Attributes' => ' complex:attribute="Ha>llo" a="b" c=\'d\'',
-			3 => ' complex:attribute="Ha>llo" a="b" c=\'d\'',
-			'Selfclosing' => '/',
-			4 => '/'
-		);
-		preg_match($pattern, $source, $matches);
-		$this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with complex attributes and > inside the attributes.');
-	}
+        $source = '<f:link.uriTo complex:attribute="Ha>llo" a="b" c=\'d\'/>';
+        $expected = [
+            0 => '<f:link.uriTo complex:attribute="Ha>llo" a="b" c=\'d\'/>',
+            'NamespaceIdentifier' => 'f',
+            1 => 'f',
+            'MethodIdentifier' => 'link.uriTo',
+            2 => 'link.uriTo',
+            'Attributes' => ' complex:attribute="Ha>llo" a="b" c=\'d\'',
+            3 => ' complex:attribute="Ha>llo" a="b" c=\'d\'',
+            'Selfclosing' => '/',
+            4 => '/'
+        ];
+        preg_match($pattern, $source, $matches);
+        $this->assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with complex attributes and > inside the attributes.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSCAN_PATTERN_CLOSINGDYNAMICTAG() {
-		$pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG, array('f'));
-		$this->assertEquals(preg_match($pattern, '</f:bla>'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a tag it should match.');
-		$this->assertEquals(preg_match($pattern, '</f:bla.a    >'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a tag (with spaces included) it should match.');
-		$this->assertEquals(preg_match($pattern, '</t:bla>'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a unknown namespace tag it should match.');
-	}
+    /**
+     * @test
+     */
+    public function testSCAN_PATTERN_CLOSINGDYNAMICTAG()
+    {
+        $pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG, ['f']);
+        $this->assertEquals(preg_match($pattern, '</f:bla>'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a tag it should match.');
+        $this->assertEquals(preg_match($pattern, '</f:bla.a    >'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a tag (with spaces included) it should match.');
+        $this->assertEquals(preg_match($pattern, '</t:bla>'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a unknown namespace tag it should match.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSPLIT_PATTERN_TAGARGUMENTS() {
-		$pattern = Patterns::$SPLIT_PATTERN_TAGARGUMENTS;
-		$source = ' test="Hallo" argument:post="\'Web" other=\'Single"Quoted\' data-foo="bar"';
-		$this->assertEquals(preg_match_all($pattern, $source, $matches, PREG_SET_ORDER), 4, 'The SPLIT_PATTERN_TAGARGUMENTS does not match correctly.');
-		$this->assertEquals('data-foo', $matches[3]['Argument']);
-	}
+    /**
+     * @test
+     */
+    public function testSPLIT_PATTERN_TAGARGUMENTS()
+    {
+        $pattern = Patterns::$SPLIT_PATTERN_TAGARGUMENTS;
+        $source = ' test="Hallo" argument:post="\'Web" other=\'Single"Quoted\' data-foo="bar"';
+        $this->assertEquals(preg_match_all($pattern, $source, $matches, PREG_SET_ORDER), 4, 'The SPLIT_PATTERN_TAGARGUMENTS does not match correctly.');
+        $this->assertEquals('data-foo', $matches[3]['Argument']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSPLIT_PATTERN_SHORTHANDSYNTAX() {
-		$pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX, array('f'));
+    /**
+     * @test
+     */
+    public function testSPLIT_PATTERN_SHORTHANDSYNTAX()
+    {
+        $pattern = $this->insertNamespaceIntoRegularExpression(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX, ['f']);
 
-		$source = 'some string{Object.bla}here as well';
-		$expected = array('some string', '{Object.bla}', 'here as well');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a simple example.');
+        $source = 'some string{Object.bla}here as well';
+        $expected = ['some string', '{Object.bla}', 'here as well'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a simple example.');
 
-		$source = 'some {}string\{Object.bla}here as well';
-		$expected = array('some {}string\\', '{Object.bla}', 'here as well');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example. (1)');
+        $source = 'some {}string\{Object.bla}here as well';
+        $expected = ['some {}string\\', '{Object.bla}', 'here as well'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example. (1)');
 
-		$source = 'some {f:viewHelper()} as well';
-		$expected = array('some ', '{f:viewHelper()}', ' as well');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example. (2)');
+        $source = 'some {f:viewHelper()} as well';
+        $expected = ['some ', '{f:viewHelper()}', ' as well'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example. (2)');
 
-		$source = 'abc {f:for(arg1: post)} def';
-		$expected = array('abc ', '{f:for(arg1: post)}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(3)');
+        $source = 'abc {f:for(arg1: post)} def';
+        $expected = ['abc ', '{f:for(arg1: post)}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(3)');
 
-		$source = 'abc {bla.blubb->f:for(param:42)} def';
-		$expected = array('abc ', '{bla.blubb->f:for(param:42)}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(4)');
+        $source = 'abc {bla.blubb->f:for(param:42)} def';
+        $expected = ['abc ', '{bla.blubb->f:for(param:42)}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(4)');
 
-		$source = 'abc {f:for(bla:"post{{")} def';
-		$expected = array('abc ', '{f:for(bla:"post{{")}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(5)');
+        $source = 'abc {f:for(bla:"post{{")} def';
+        $expected = ['abc ', '{f:for(bla:"post{{")}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(5)');
 
-		$source = 'abc {f:for(param:"abc\"abc")} def';
-		$expected = array('abc ', '{f:for(param:"abc\"abc")}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(6)');
+        $source = 'abc {f:for(param:"abc\"abc")} def';
+        $expected = ['abc ', '{f:for(param:"abc\"abc")}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with an escaped example.(6)');
 
-		$source = 'abc {foo:for(arg1: post)} def';
-		$expected = array('abc ', '{foo:for(arg1: post)}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom namespace identifier.(7)');
+        $source = 'abc {foo:for(arg1: post)} def';
+        $expected = ['abc ', '{foo:for(arg1: post)}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom namespace identifier.(7)');
 
-		$source = 'abc {bla.blubb->foo:for(param:42)} def';
-		$expected = array('abc ', '{bla.blubb->foo:for(param:42)}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom namespace identifier.(8)');
+        $source = 'abc {bla.blubb->foo:for(param:42)} def';
+        $expected = ['abc ', '{bla.blubb->foo:for(param:42)}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom namespace identifier.(8)');
 
-		$source = 'abc {foo.bar:for(arg1: post)} def';
-		$expected = array('abc ', '{foo.bar:for(arg1: post)}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom multi-part namespace identifier.(9)');
+        $source = 'abc {foo.bar:for(arg1: post)} def';
+        $expected = ['abc ', '{foo.bar:for(arg1: post)}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom multi-part namespace identifier.(9)');
 
-		$source = 'abc {bla.blubb->foo.bar:for(param:42)} def';
-		$expected = array('abc ', '{bla.blubb->foo.bar:for(param:42)}', ' def');
-		$this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom multi-part namespace identifier.(10)');
-	}
+        $source = 'abc {bla.blubb->foo.bar:for(param:42)} def';
+        $expected = ['abc ', '{bla.blubb->foo.bar:for(param:42)}', ' def'];
+        $this->assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom multi-part namespace identifier.(10)');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER() {
-		$pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER;
+    /**
+     * @test
+     */
+    public function testSPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER()
+    {
+        $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER;
 
-		$source = 'f:for(each: bla)';
-		$expected = array(
-			0 => array(
-				0 => 'f:for(each: bla)',
-				1 => 'f',
-				'NamespaceIdentifier' => 'f',
-				2 => 'for',
-				'MethodIdentifier' => 'for',
-				3 => 'each: bla',
-				'ViewHelperArguments' => 'each: bla'
-			)
-		);
-		preg_match_all($pattern, $source, $matches, PREG_SET_ORDER);
-		$this->assertEquals($matches, $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER');
+        $source = 'f:for(each: bla)';
+        $expected = [
+            0 => [
+                0 => 'f:for(each: bla)',
+                1 => 'f',
+                'NamespaceIdentifier' => 'f',
+                2 => 'for',
+                'MethodIdentifier' => 'for',
+                3 => 'each: bla',
+                'ViewHelperArguments' => 'each: bla'
+            ]
+        ];
+        preg_match_all($pattern, $source, $matches, PREG_SET_ORDER);
+        $this->assertEquals($matches, $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER');
 
-		$source = 'f:for(each: bla)->foo.bar:bla(a:"b\"->(f:a()", cd: {a:b})';
-		$expected = array(
-			0 => array(
-				0 => 'f:for(each: bla)',
-				1 => 'f',
-				'NamespaceIdentifier' => 'f',
-				2 => 'for',
-				'MethodIdentifier' => 'for',
-				3 => 'each: bla',
-				'ViewHelperArguments' => 'each: bla'
-			),
-			1 => array(
-				0 => 'foo.bar:bla(a:"b\"->(f:a()", cd: {a:b})',
-				1 => 'foo.bar',
-				'NamespaceIdentifier' => 'foo.bar',
-				2 => 'bla',
-				'MethodIdentifier' => 'bla',
-				3 => 'a:"b\"->(f:a()", cd: {a:b}',
-				'ViewHelperArguments' => 'a:"b\"->(f:a()", cd: {a:b}'
-			)
-		);
-		preg_match_all($pattern, $source, $matches, PREG_SET_ORDER);
-		$this->assertEquals($matches, $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER');
-	}
+        $source = 'f:for(each: bla)->foo.bar:bla(a:"b\"->(f:a()", cd: {a:b})';
+        $expected = [
+            0 => [
+                0 => 'f:for(each: bla)',
+                1 => 'f',
+                'NamespaceIdentifier' => 'f',
+                2 => 'for',
+                'MethodIdentifier' => 'for',
+                3 => 'each: bla',
+                'ViewHelperArguments' => 'each: bla'
+            ],
+            1 => [
+                0 => 'foo.bar:bla(a:"b\"->(f:a()", cd: {a:b})',
+                1 => 'foo.bar',
+                'NamespaceIdentifier' => 'foo.bar',
+                2 => 'bla',
+                'MethodIdentifier' => 'bla',
+                3 => 'a:"b\"->(f:a()", cd: {a:b}',
+                'ViewHelperArguments' => 'a:"b\"->(f:a()", cd: {a:b}'
+            ]
+        ];
+        preg_match_all($pattern, $source, $matches, PREG_SET_ORDER);
+        $this->assertEquals($matches, $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS() {
-		$pattern = Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS;
-		$this->assertEquals(preg_match($pattern, '{object}'), 1, 'Object accessor not identified!');
-		$this->assertEquals(preg_match($pattern, '{oBject1}'), 1, 'Object accessor not identified if there is a number and capitals inside!');
-		$this->assertEquals(preg_match($pattern, '{object.recursive}'), 1, 'Object accessor not identified if there is a dot inside!');
-		$this->assertEquals(preg_match($pattern, '{object-with-dash.recursive_value}'), 1, 'Object accessor not identified if there is a _ or - inside!');
-		$this->assertEquals(preg_match($pattern, '{f:for()}'), 1, 'Object accessor not identified if it contains only of a ViewHelper.');
-		$this->assertEquals(preg_match($pattern, '{f:for()->f:for2()}'), 1, 'Object accessor not identified if it contains only of a ViewHelper (nested).');
-		$this->assertEquals(preg_match($pattern, '{abc->f:for()}'), 1, 'Object accessor not identified if there is a ViewHelper inside!');
-		$this->assertEquals(preg_match($pattern, '{bla-blubb.recursive_value->f:for()->f:for()}'), 1, 'Object accessor not identified if there is a recursive ViewHelper inside!');
-		$this->assertEquals(preg_match($pattern, '{f:for(arg1:arg1value, arg2: "bla\"blubb")}'), 1, 'Object accessor not identified if there is an argument inside!');
-		$this->assertEquals(preg_match($pattern, '{foo.bar:for(arg1:arg1value)}'), 1, 'Object accessor not identified multi-part namespace identifier!');
-		$this->assertEquals(preg_match($pattern, '{dash:value}'), 0, 'Object accessor identified, but was array!');
-		// $this->assertEquals(preg_match($pattern, '{}'), 0, 'Object accessor identified, and it was empty!');
-	}
+    /**
+     * @test
+     */
+    public function testSCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS()
+    {
+        $pattern = Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS;
+        $this->assertEquals(preg_match($pattern, '{object}'), 1, 'Object accessor not identified!');
+        $this->assertEquals(preg_match($pattern, '{oBject1}'), 1, 'Object accessor not identified if there is a number and capitals inside!');
+        $this->assertEquals(preg_match($pattern, '{object.recursive}'), 1, 'Object accessor not identified if there is a dot inside!');
+        $this->assertEquals(preg_match($pattern, '{object-with-dash.recursive_value}'), 1, 'Object accessor not identified if there is a _ or - inside!');
+        $this->assertEquals(preg_match($pattern, '{f:for()}'), 1, 'Object accessor not identified if it contains only of a ViewHelper.');
+        $this->assertEquals(preg_match($pattern, '{f:for()->f:for2()}'), 1, 'Object accessor not identified if it contains only of a ViewHelper (nested).');
+        $this->assertEquals(preg_match($pattern, '{abc->f:for()}'), 1, 'Object accessor not identified if there is a ViewHelper inside!');
+        $this->assertEquals(preg_match($pattern, '{bla-blubb.recursive_value->f:for()->f:for()}'), 1, 'Object accessor not identified if there is a recursive ViewHelper inside!');
+        $this->assertEquals(preg_match($pattern, '{f:for(arg1:arg1value, arg2: "bla\"blubb")}'), 1, 'Object accessor not identified if there is an argument inside!');
+        $this->assertEquals(preg_match($pattern, '{foo.bar:for(arg1:arg1value)}'), 1, 'Object accessor not identified multi-part namespace identifier!');
+        $this->assertEquals(preg_match($pattern, '{dash:value}'), 0, 'Object accessor identified, but was array!');
+        // $this->assertEquals(preg_match($pattern, '{}'), 0, 'Object accessor identified, and it was empty!');
+    }
 
-	/**
-	 * @return array
-	 */
-	public function dataProviderSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS() {
-		return array(
-			array('string' => '{a:b}'),
-			array('string' => '{a:b, c :   d}'),
-			array('string' => '{  a:b, c :   d }'),
+    /**
+     * @return array
+     */
+    public function dataProviderSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS()
+    {
+        return [
+            ['string' => '{a:b}'],
+            ['string' => '{a:b, c :   d}'],
+            ['string' => '{  a:b, c :   d }'],
 
-			// multiple lines
-			array('string' => '{' . chr(10) . ' foo: 1,' . chr(10) . ' bar: 2' . chr(10) . '}'),
+            // multiple lines
+            ['string' => '{' . chr(10) . ' foo: 1,' . chr(10) . ' bar: 2' . chr(10) . '}'],
 
-			// trailing comma
-			array('string' => '{a:b, c :   d,}'),
+            // trailing comma
+            ['string' => '{a:b, c :   d,}'],
 
-			array('string' => '{a : 123}'),
-			array('string' => '{a:"String"}'),
-			array('string' => '{a:\'String\'}'),
+            ['string' => '{a : 123}'],
+            ['string' => '{a:"String"}'],
+            ['string' => '{a:\'String\'}'],
 
-			// empty string value
-			array('string' => '{a:""}'),
-			array('string' => '{a:\'\'}'),
+            // empty string value
+            ['string' => '{a:""}'],
+            ['string' => '{a:\'\'}'],
 
-			// nested arrays
-			array('string' => '{a:{bla:{x:z}, b: a}}'),
-			array('string' => '{a:"{bla{{}"}'),
+            // nested arrays
+            ['string' => '{a:{bla:{x:z}, b: a}}'],
+            ['string' => '{a:"{bla{{}"}'],
 
-			// quoted keys
-			array('string' => '{"foo": "bar"}'),
-			array('string' => '{"foo[bar]": "baz"}'),
-			array('string' => '{"foo.bar": "baz"}'),
-			array('string' => '{\'foo\': "bar"}'),
-			array('string' => '{  \'foo\'  : "bar" }'),
-			array('string' => '{"a":{bla:{x:z}, b: a}}'),
-			array('string' => '{a:{bla:{"x":z}, b: a}}'),
-			array('string' => '{"@a": "bar"}'),
-			array('string' => '{\'_b\': "bar"}')
-		);
-	}
+            // quoted keys
+            ['string' => '{"foo": "bar"}'],
+            ['string' => '{"foo[bar]": "baz"}'],
+            ['string' => '{"foo.bar": "baz"}'],
+            ['string' => '{\'foo\': "bar"}'],
+            ['string' => '{  \'foo\'  : "bar" }'],
+            ['string' => '{"a":{bla:{x:z}, b: a}}'],
+            ['string' => '{a:{bla:{"x":z}, b: a}}'],
+            ['string' => '{"@a": "bar"}'],
+            ['string' => '{\'_b\': "bar"}']
+        ];
+    }
 
-	/**
-	 * @param string $string
-	 * @dataProvider dataProviderSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS()
-	 * @test
-	 */
-	public function testSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS($string) {
-		$success = preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $string, $matches) === 1;
-		$this->assertTrue($success);
-		$this->assertSame($string, $matches[0]);
-	}
+    /**
+     * @param string $string
+     * @dataProvider dataProviderSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS()
+     * @test
+     */
+    public function testSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS($string)
+    {
+        $success = preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $string, $matches) === 1;
+        $this->assertTrue($success);
+        $this->assertSame($string, $matches[0]);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function dataProviderInvalidSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS() {
-		return array(
-			array('string' => '{"foo\': "bar"}'),
-			array('string' => '{"": "bar"}'),
-			array('string' => '{\'\': "bar"}'),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function dataProviderInvalidSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS()
+    {
+        return [
+            ['string' => '{"foo\': "bar"}'],
+            ['string' => '{"": "bar"}'],
+            ['string' => '{\'\': "bar"}'],
+        ];
+    }
 
-	/**
-	 * @param string $string
-	 * @dataProvider dataProviderInvalidSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS()
-	 * @test
-	 */
-	public function SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS_doesNotMatchInvalidSyntax($string) {
-		$success = preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $string, $matches) === 1;
-		$this->assertFalse($success);
-	}
+    /**
+     * @param string $string
+     * @dataProvider dataProviderInvalidSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS()
+     * @test
+     */
+    public function SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS_doesNotMatchInvalidSyntax($string)
+    {
+        $success = preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $string, $matches) === 1;
+        $this->assertFalse($success);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS() {
-		$pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
+    /**
+     * @test
+     */
+    public function testSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS()
+    {
+        $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
 
-		$source = '{a: b, e: {c:d, "e#":f, \'g\': "h"}}';
-		$success = preg_match_all($pattern, $source, $matches, PREG_SET_ORDER) > 0;
+        $source = '{a: b, e: {c:d, "e#":f, \'g\': "h"}}';
+        $success = preg_match_all($pattern, $source, $matches, PREG_SET_ORDER) > 0;
 
-		$expected = array(
-			0 => array(
-				0 => 'a: b',
-				'ArrayPart' => 'a: b',
-				1 => 'a: b',
-				'Key' => 'a',
-				2 => 'a',
-				'QuotedString' => '',
-				3 => '',
-				'VariableIdentifier' => 'b',
-				4 => 'b'
-			),
-			1 => array(
-				0 => 'e: {c:d, "e#":f, \'g\': "h"}',
-				'ArrayPart' => 'e: {c:d, "e#":f, \'g\': "h"}',
-				1 => 'e: {c:d, "e#":f, \'g\': "h"}',
-				'Key' => 'e',
-				2 => 'e',
-				'QuotedString' => '',
-				3 => '',
-				'VariableIdentifier' => '',
-				4 => '',
-				'Number' => '',
-				5 => '',
-				'Subarray' => 'c:d, "e#":f, \'g\': "h"',
-				6 => 'c:d, "e#":f, \'g\': "h"'
-			)
-		);
-		$this->assertTrue($success);
-		$this->assertEquals($expected, $matches, 'The regular expression splitting the array apart does not work!');
-	}
+        $expected = [
+            0 => [
+                0 => 'a: b',
+                'ArrayPart' => 'a: b',
+                1 => 'a: b',
+                'Key' => 'a',
+                2 => 'a',
+                'QuotedString' => '',
+                3 => '',
+                'VariableIdentifier' => 'b',
+                4 => 'b'
+            ],
+            1 => [
+                0 => 'e: {c:d, "e#":f, \'g\': "h"}',
+                'ArrayPart' => 'e: {c:d, "e#":f, \'g\': "h"}',
+                1 => 'e: {c:d, "e#":f, \'g\': "h"}',
+                'Key' => 'e',
+                2 => 'e',
+                'QuotedString' => '',
+                3 => '',
+                'VariableIdentifier' => '',
+                4 => '',
+                'Number' => '',
+                5 => '',
+                'Subarray' => 'c:d, "e#":f, \'g\': "h"',
+                6 => 'c:d, "e#":f, \'g\': "h"'
+            ]
+        ];
+        $this->assertTrue($success);
+        $this->assertEquals($expected, $matches, 'The regular expression splitting the array apart does not work!');
+    }
 
-	/**
-	 * @test
-	 */
-	public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_matchesQuotedKeys() {
-		$pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
+    /**
+     * @test
+     */
+    public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_matchesQuotedKeys()
+    {
+        $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
 
-		$source = '{"a": b, \'c\': d}';
-		$success = preg_match_all($pattern, $source, $matches, PREG_SET_ORDER) > 0;
+        $source = '{"a": b, \'c\': d}';
+        $success = preg_match_all($pattern, $source, $matches, PREG_SET_ORDER) > 0;
 
-		$expected = array(
-			0 => array(
-				0 => '"a": b',
-				'ArrayPart' => '"a": b',
-				1 => '"a": b',
-				'Key' => '"a"',
-				2 => '"a"',
-				'QuotedString' => '',
-				3 => '',
-				'VariableIdentifier' => 'b',
-				4 => 'b'
-			),
-			1 => array(
-				0 => '\'c\': d',
-				'ArrayPart' => '\'c\': d',
-				1 => '\'c\': d',
-				'Key' => '\'c\'',
-				2 => '\'c\'',
-				'QuotedString' => '',
-				3 => '',
-				'VariableIdentifier' => 'd',
-				4 => 'd'
-			)
-		);
-		$this->assertTrue($success);
-		$this->assertEquals($expected, $matches, 'The regular expression splitting the array apart does not work!');
-	}
+        $expected = [
+            0 => [
+                0 => '"a": b',
+                'ArrayPart' => '"a": b',
+                1 => '"a": b',
+                'Key' => '"a"',
+                2 => '"a"',
+                'QuotedString' => '',
+                3 => '',
+                'VariableIdentifier' => 'b',
+                4 => 'b'
+            ],
+            1 => [
+                0 => '\'c\': d',
+                'ArrayPart' => '\'c\': d',
+                1 => '\'c\': d',
+                'Key' => '\'c\'',
+                2 => '\'c\'',
+                'QuotedString' => '',
+                3 => '',
+                'VariableIdentifier' => 'd',
+                4 => 'd'
+            ]
+        ];
+        $this->assertTrue($success);
+        $this->assertEquals($expected, $matches, 'The regular expression splitting the array apart does not work!');
+    }
 
-	/**
-	 * @return array
-	 */
-	public function dataProviderInvalidSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS() {
-		return array(
-			array('string' => '{"a\': b}'),
-			array('string' => '{"": "bar"}'),
-			array('string' => '{\'\': "bar"}'),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function dataProviderInvalidSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS()
+    {
+        return [
+            ['string' => '{"a\': b}'],
+            ['string' => '{"": "bar"}'],
+            ['string' => '{\'\': "bar"}'],
+        ];
+    }
 
-	/**
-	 * @param string $string
-	 * @dataProvider dataProviderInvalidSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS()
-	 * @test
-	 */
-	public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_doesNotMatchInvalidSyntax($string) {
-		$pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
-		$success = preg_match_all($pattern, $string, $matches, PREG_SET_ORDER) > 0;
-		$this->assertFalse($success);
-	}
+    /**
+     * @param string $string
+     * @dataProvider dataProviderInvalidSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS()
+     * @test
+     */
+    public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_doesNotMatchInvalidSyntax($string)
+    {
+        $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
+        $success = preg_match_all($pattern, $string, $matches, PREG_SET_ORDER) > 0;
+        $this->assertFalse($success);
+    }
 
-	/**
-	 * Test the SCAN_PATTERN_CDATA which should detect <![CDATA[...]]> (with no leading or trailing spaces!)
-	 *
-	 * @test
-	 */
-	public function testSCAN_PATTERN_CDATA() {
-		$pattern = Patterns::$SCAN_PATTERN_CDATA;
-		$this->assertEquals(preg_match($pattern, '<!-- Test -->'), 0, 'The SCAN_PATTERN_CDATA matches a comment, but it should not.');
-		$this->assertEquals(preg_match($pattern, '<![CDATA[This is some ]]>'), 1, 'The SCAN_PATTERN_CDATA does not match a simple CDATA string.');
-		$this->assertEquals(preg_match($pattern, '<![CDATA[This is<bla:test> some ]]>'), 1, 'The SCAN_PATTERN_CDATA does not match a CDATA string with tags inside..');
-	}
+    /**
+     * Test the SCAN_PATTERN_CDATA which should detect <![CDATA[...]]> (with no leading or trailing spaces!)
+     *
+     * @test
+     */
+    public function testSCAN_PATTERN_CDATA()
+    {
+        $pattern = Patterns::$SCAN_PATTERN_CDATA;
+        $this->assertEquals(preg_match($pattern, '<!-- Test -->'), 0, 'The SCAN_PATTERN_CDATA matches a comment, but it should not.');
+        $this->assertEquals(preg_match($pattern, '<![CDATA[This is some ]]>'), 1, 'The SCAN_PATTERN_CDATA does not match a simple CDATA string.');
+        $this->assertEquals(preg_match($pattern, '<![CDATA[This is<bla:test> some ]]>'), 1, 'The SCAN_PATTERN_CDATA does not match a CDATA string with tags inside..');
+    }
 
-	/**
-	 * Helper method which replaces NAMESPACE in the regular expression with the real namespace used.
-	 *
-	 * @param string $regularExpression The regular expression in which to replace NAMESPACE
-	 * @param array $namespace List of namespace identifiers.
-	 * @return string working regular expression with NAMESPACE replaced.
-	 */
-	protected function insertNamespaceIntoRegularExpression($regularExpression, $namespace) {
-		return str_replace('NAMESPACE', implode('|', $namespace), $regularExpression);
-	}
+    /**
+     * Helper method which replaces NAMESPACE in the regular expression with the real namespace used.
+     *
+     * @param string $regularExpression The regular expression in which to replace NAMESPACE
+     * @param array $namespace List of namespace identifiers.
+     * @return string working regular expression with NAMESPACE replaced.
+     */
+    protected function insertNamespaceIntoRegularExpression($regularExpression, $namespace)
+    {
+        return str_replace('NAMESPACE', implode('|', $namespace), $regularExpression);
+    }
 }

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -33,654 +33,698 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
  * This is to at least half a system test, as it compares rendered results to
  * expectations, and does not strictly check the parsing...
  */
-class TemplateParserTest extends UnitTestCase {
-
-	/**
-	 * @test
-	 */
-	public function testInitializeViewHelperAndAddItToStackReturnsFalseIfNamespaceNotValid() {
-		$resolver = $this->getMock(ViewHelperResolver::class, array('isNamespaceValid'));
-		$resolver->expects($this->once())->method('isNamespaceValid')->willReturn(FALSE);
-		$context = new RenderingContextFixture();
-		$context->setViewHelperResolver($resolver);
-		$templateParser = new TemplateParser();
-		$templateParser->setRenderingContext($context);
-		$method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($templateParser, array(new ParsingState(), 'f', 'render', array()));
-		$this->assertNull($result);
-	}
-
-	/**
-	 * @test
-	 */
-	public function testClosingViewHelperTagHandlerReturnsFalseIfNamespaceNotValid() {
-		$resolver = $this->getMock(ViewHelperResolver::class, array('isNamespaceValid'));
-		$resolver->expects($this->once())->method('isNamespaceValid')->willReturn(FALSE);
-		$context = new RenderingContextFixture();
-		$context->setViewHelperResolver($resolver);
-		$templateParser = new TemplateParser();
-		$templateParser->setRenderingContext($context);
-		$method = new \ReflectionMethod($templateParser, 'closingViewHelperTagHandler');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($templateParser, array(new ParsingState(), 'f', 'render'));
-		$this->assertFalse($result);
-	}
-
-	/**
-	 * @test
-	 */
-	public function testBuildObjectTreeThrowsExceptionOnUnclosedViewHelperTag() {
-		$renderingContext = new RenderingContextFixture();
-		$renderingContext->setVariableProvider(new StandardVariableProvider());
-		$templateParser = new TemplateParser();
-		$templateParser->setRenderingContext($renderingContext);
-		$this->setExpectedException(Exception::class);
-		$method = new \ReflectionMethod($templateParser, 'buildObjectTree');
-		$method->setAccessible(TRUE);
-		$method->invokeArgs($templateParser, array(array('<f:render>'), TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS));
-	}
-
-	/**
-	 * @test
-	 */
-	public function testParseCallsPreProcessOnTemplateProcessors() {
-		$templateParser = new TemplateParser();
-		$processor1 = $this->getMockForAbstractClass(
-			TemplateProcessorInterface::class,
-			array(), '', FALSE, FALSE, TRUE,
-			array('preProcessSource')
-		);
-		$processor2 = clone $processor1;
-		$processor1->expects($this->once())->method('preProcessSource')->with('source1')->willReturn('source2');
-		$processor2->expects($this->once())->method('preProcesssource')->with('source2')->willReturn('final');
-		$context = new RenderingContextFixture();
-		$context->setTemplateProcessors(array($processor1, $processor2));
-		$context->setVariableProvider(new StandardVariableProvider());
-		$templateParser->setRenderingContext($context);
-		$result = $templateParser->parse('source1')->render($context);
-		$this->assertEquals('final', $result);
-	}
-
-	/**
-	 * @test
-	 */
-	public function getOrParseAndStoreTemplateSetsCompilableStateAndReturnsOnStopComilingException() {
-		$parsedTemplate = $this->getMock(ParsingState::class, array('setCompilable'));
-		$parsedTemplate->expects($this->once())->method('setCompilable')->with(FALSE);
-		$templateParser = $this->getMock(TemplateParser::class, array('parse'));
-		$templateParser->expects($this->once())->method('parse')->willReturn($parsedTemplate);
-		$context = new RenderingContextFixture();
-		$compiler = $this->getMock(TemplateCompiler::class, array('store', 'has'));
-		$compiler->expects($this->once())->method('has')->willReturn(FALSE);
-		$compiler->expects($this->once())->method('store')->willThrowException(new StopCompilingException());
-		$context->setTemplateCompiler($compiler);
-		$context->setVariableProvider(new StandardVariableProvider());
-		$templateParser->setRenderingContext($context);
-		$parsedTemplate = $templateParser->getOrParseAndStoreTemplate('fake-foo-baz', function($a, $b) { return 'test'; });
-	}
-
-	/**
-	 * @test
-	 * @expectedException Exception
-	 */
-	public function parseThrowsExceptionWhenStringArgumentMissing() {
-		$templateParser = new TemplateParser();
-		$templateParser->parse(123);
-	}
-
-	/**
-	 */
-	public function quotedStrings() {
-		return array(
-			array('"no quotes here"', 'no quotes here'),
-			array("'no quotes here'", 'no quotes here'),
-			array("'this \"string\" had \\'quotes\\' in it'", 'this "string" had \'quotes\' in it'),
-			array('"this \\"string\\" had \'quotes\' in it"', 'this "string" had \'quotes\' in it'),
-			array('"a weird \"string\" \'with\' *freaky* \\\\stuff', 'a weird "string" \'with\' *freaky* \\stuff'),
-			array('\'\\\'escaped quoted string in string\\\'\'', '\'escaped quoted string in string\'')
-		);
-	}
-
-	/**
-	 * @dataProvider quotedStrings
-	 * @test
-	 */
-	public function unquoteStringReturnsUnquotedStrings($quoted, $unquoted) {
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$this->assertEquals($unquoted, $templateParser->_call('unquoteString', $quoted));
-	}
-
-	/**
-	 */
-	public function templatesToSplit() {
-		return array(
-			array('TemplateParserTestFixture01-shorthand'),
-			array('TemplateParserTestFixture06'),
-			array('TemplateParserTestFixture14')
-		);
-	}
-
-	/**
-	 * @dataProvider templatesToSplit
-	 * @test
-	 */
-	public function splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate($templateName) {
-		$template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html', FILE_TEXT);
-		$expectedResult = require(__DIR__ . '/Fixtures/' . $templateName . '-split.php');
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$this->assertSame($expectedResult, $templateParser->_call('splitTemplateAtDynamicTags', $template), 'Filed for ' . $templateName);
-	}
-
-	/**
-	 * @test
-	 */
-	public function buildObjectTreeCreatesRootNodeAndSetsUpParsingState() {
-		$context = new RenderingContextFixture();
-		$context->setVariableProvider(new StandardVariableProvider());
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$templateParser->setRenderingContext($context);
-		$result = $templateParser->_call('buildObjectTree', array(), TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
-		$this->assertInstanceOf(ParsingState::class, $result);
-	}
-
-	/**
-	 * @test
-	 */
-	public function buildObjectTreeDelegatesHandlingOfTemplateElements() {
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array(
-				'textHandler',
-				'openingViewHelperTagHandler',
-				'closingViewHelperTagHandler',
-				'textAndShorthandSyntaxHandler'
-			)
-		);
-		$context = new RenderingContextFixture();
-		$context->setVariableProvider(new StandardVariableProvider());
-		$templateParser->setRenderingContext($context);
-		$splitTemplate = $templateParser->_call('splitTemplateAtDynamicTags', 'The first part is simple<![CDATA[<f:for each="{a: {a: 0, b: 2, c: 4}}" as="array"><f:for each="{array}" as="value">{value} </f:for>]]><f:format.printf arguments="{number : 362525200}">%.3e</f:format.printf>and here goes some {text} that could have {shorthand}');
-		$result = $templateParser->_call('buildObjectTree', $splitTemplate, TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
-		$this->assertInstanceOf(ParsingState::class, $result);
-	}
-
-	/**
-	 * @test
-	 */
-	public function openingViewHelperTagHandlerDelegatesViewHelperInitialization() {
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->never())->method('popNodeFromStack');
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array('parseArguments', 'initializeViewHelperAndAddItToStack')
-		);
-		$context = new RenderingContextFixture();
-		$templateParser->setRenderingContext($context);
-		$templateParser->expects($this->once())->method('parseArguments')
-			->with(array('arguments'))->will($this->returnValue(array('parsedArguments')));
-		$templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')
-			->with($mockState, 'namespaceIdentifier', 'methodIdentifier', array('parsedArguments'));
-
-		$templateParser->_call('openingViewHelperTagHandler', $mockState, 'namespaceIdentifier', 'methodIdentifier', array('arguments'), FALSE, '');
-	}
-
-	/**
-	 * @test
-	 */
-	public function openingViewHelperTagHandlerPopsNodeFromStackForSelfClosingTags() {
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($this->getMock(NodeInterface::class)));
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($this->getMock(NodeInterface::class)));
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array('parseArguments', 'initializeViewHelperAndAddItToStack')
-		);
-		$node = $this->getMock(ViewHelperNode::class, array('dummy'), array(), '', FALSE);
-		$templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')->will($this->returnValue($node));
-
-		$templateParser->_call('openingViewHelperTagHandler', $mockState, '', '', array(), TRUE, '');
-	}
-
-	/**
-	 * @__test
-	 * @expectedException Exception
-	 */
-	public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassDoesNotExisit() {
-		$mockState = $this->getMock(ParsingState::class);
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array(
-				'abortIfUnregisteredArgumentsExist',
-				'abortIfRequiredArgumentsAreMissing',
-				'rewriteBooleanNodesInArgumentsObjectTree'
-			)
-		);
-
-		$templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'nonExisting', array('arguments'));
-	}
-
-	/**
-	 * @__test
-	 * @expectedException Exception
-	 */
-	public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassNameIsWronglyCased() {
-		$mockState = $this->getMock(ParsingState::class);
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array(
-				'abortIfUnregisteredArgumentsExist',
-				'abortIfRequiredArgumentsAreMissing',
-				'rewriteBooleanNodesInArgumentsObjectTree'
-			)
-		);
-
-		$templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'wRongLyCased', array('arguments'));
-	}
-
-	/**
-	 * @__test
-	 */
-	public function initializeViewHelperAndAddItToStackCreatesRequestedViewHelperAndViewHelperNode() {
-		$mockViewHelper = $this->getMock(AbstractViewHelper::class);
-		$mockViewHelperNode = $this->getMock(ViewHelperNode::class, array(), array(), '', FALSE);
-
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('pushNodeToStack')->with($this->anything());
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array(
-				'abortIfUnregisteredArgumentsExist',
-				'abortIfRequiredArgumentsAreMissing',
-				'rewriteBooleanNodesInArgumentsObjectTree'
-			)
-		);
-
-		$templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'render', array('arguments'));
-	}
-
-	/**
-	 * @test
-	 * @expectedException Exception
-	 */
-	public function closingViewHelperTagHandlerThrowsExceptionBecauseOfClosingTagWhichWasNeverOpened() {
-		$mockNodeOnStack = $this->getMock(NodeInterface::class, array(), array(), '', FALSE);
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$templateParser->_set('renderingContext', new RenderingContextFixture());
-
-		$templateParser->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
-	}
-
-	/**
-	 * @test
-	 * @expectedException Exception
-	 */
-	public function closingViewHelperTagHandlerThrowsExceptionBecauseOfWrongTagNesting() {
-		$mockNodeOnStack = $this->getMock(ViewHelperNode::class, array(), array(), '', FALSE);
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$templateParser->_set('renderingContext', new RenderingContextFixture());
-		$templateParser->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
-	}
-
-	/**
-	 * @test
-	 */
-	public function objectAccessorHandlerCallsInitializeViewHelperAndAddItToStackIfViewHelperSyntaxIsPresent() {
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->exactly(2))->method('popNodeFromStack')
-			->will($this->returnValue($this->getMock(NodeInterface::class)));
-		$mockState->expects($this->exactly(2))->method('getNodeFromStack')
-			->will($this->returnValue($this->getMock(NodeInterface::class)));
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array('recursiveArrayHandler', 'initializeViewHelperAndAddItToStack')
-		);
-		$templateParser->expects($this->at(0))->method('recursiveArrayHandler')
-			->with('format: "H:i"')->will($this->returnValue(array('format' => 'H:i')));
-		$templateParser->expects($this->at(1))->method('initializeViewHelperAndAddItToStack')
-			->with($mockState, 'f', 'format.date', array('format' => 'H:i'))->will($this->returnValue(TRUE));
-		$templateParser->expects($this->at(2))->method('initializeViewHelperAndAddItToStack')
-			->with($mockState, 'f', 'debug', array())->will($this->returnValue(TRUE));
-
-		$templateParser->_call('objectAccessorHandler', $mockState, '', '', 'f:debug() -> f:format.date(format: "H:i")', '');
-	}
-
-	/**
-	 * @test
-	 */
-	public function objectAccessorHandlerCreatesObjectAccessorNodeWithExpectedValueAndAddsItToStack() {
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-
-		$templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
-	}
-
-	/**
-	 * @test
-	 */
-	public function valuesFromObjectAccessorsAreRunThroughEscapingInterceptorsByDefault() {
-		$objectAccessorNodeInterceptor = $this->getMock(InterceptorInterface::class);
-		$objectAccessorNodeInterceptor->expects($this->once())->method('process')
-			->with($this->anything())->willReturnArgument(0);
-
-		$parserConfiguration = $this->getMock(Configuration::class);
-		$parserConfiguration->expects($this->any())->method('getInterceptors')->willReturn(array());
-		$parserConfiguration->expects($this->once())->method('getEscapingInterceptors')
-			->with(InterceptorInterface::INTERCEPT_OBJECTACCESSOR)
-			->will($this->returnValue(array($objectAccessorNodeInterceptor)));
-
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$templateParser->_set('configuration', $parserConfiguration);
-
-		$templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
-	}
-
-	/**
-	 * @test
-	 */
-	public function valuesFromObjectAccessorsAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled() {
-		$objectAccessorNode = $this->getMock(ObjectAccessorNode::class, array(), array(), '', FALSE);
-
-		$parserConfiguration = $this->getMock(Configuration::class);
-		$parserConfiguration->expects($this->any())->method('getInterceptors')->will($this->returnValue(array()));
-		$parserConfiguration->expects($this->never())->method('getEscapingInterceptors');
-
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$templateParser->_set('configuration', $parserConfiguration);
-		$templateParser->_set('escapingEnabled', FALSE);
-
-		$templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
-	}
-
-
-	/**
-	 * @test
-	 */
-	public function valuesFromObjectAccessorsAreRunThroughInterceptors() {
-		$objectAccessorNode = $this->getMock(ObjectAccessorNode::class, array(), array(), '', FALSE);
-		$objectAccessorNodeInterceptor = $this->getMock(InterceptorInterface::class);
-		$objectAccessorNodeInterceptor->expects($this->once())->method('process')
-			->with($this->anything())->will($this->returnArgument(0));
-
-		$parserConfiguration = $this->getMock(Configuration::class);
-		$parserConfiguration->expects($this->any())->method('getEscapingInterceptors')->willReturn(array());
-		$parserConfiguration->expects($this->once())->method('getInterceptors')
-			->with(InterceptorInterface::INTERCEPT_OBJECTACCESSOR)->willReturn(array($objectAccessorNodeInterceptor));
-
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-		$templateParser->_set('configuration', $parserConfiguration);
-		$templateParser->_set('escapingEnabled', FALSE);
-
-		$templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
-	}
-
-	/**
-	 */
-	public function argumentsStrings() {
-		return array(
-			array('a="2"', array('a' => '2')),
-			array('a="2" b="foobar \' with \\" quotes"', array('a' => '2', 'b' => 'foobar \' with " quotes')),
-			array(' arguments="{number : 362525200}"', array('arguments' => '{number : 362525200}'))
-		);
-	}
-
-	/**
-	 * @test
-	 * @dataProvider argumentsStrings
-	 * @param string $argumentsString
-	 * @param array $expected
-	 */
-	public function parseArgumentsWorksAsExpected($argumentsString, array $expected) {
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('buildArgumentObjectTree'));
-		$templateParser->expects($this->any())->method('buildArgumentObjectTree')->will($this->returnArgument(0));
-
-		$this->assertSame($expected, $templateParser->_call('parseArguments', $argumentsString));
-	}
-
-	/**
-	 * @test
-	 */
-	public function buildArgumentObjectTreeReturnsTextNodeForSimplyString() {
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('dummy'));
-
-		$this->assertInstanceof(
-			TextNode::class,
-			$templateParser->_call('buildArgumentObjectTree', 'a very plain string')
-		);
-	}
-
-	/**
-	 * @test
-	 */
-	public function buildArgumentObjectTreeBuildsObjectTreeForComlexString() {
-		$objectTree = $this->getMock(ParsingState::class);
-		$objectTree->expects($this->once())->method('getRootNode')->will($this->returnValue('theRootNode'));
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array('splitTemplateAtDynamicTags', 'buildObjectTree')
-		);
-		$templateParser->expects($this->at(0))->method('splitTemplateAtDynamicTags')
-			->with('a <very> {complex} string')->will($this->returnValue(array('split string')));
-		$templateParser->expects($this->at(1))->method('buildObjectTree')
-			->with(array('split string'))->will($this->returnValue($objectTree));
-
-		$this->assertEquals('theRootNode', $templateParser->_call('buildArgumentObjectTree', 'a <very> {complex} string'));
-	}
-
-	/**
-	 * @test
-	 */
-	public function textAndShorthandSyntaxHandlerDelegatesAppropriately() {
-		$mockState = $this->getMock(ParsingState::class, array('getNodeFromStack'));
-		$mockState->expects($this->any())->method('getNodeFromStack')->willReturn(new RootNode());
-
-		$templateParser = $this->getMock(
-			TemplateParser::class,
-			array('objectAccessorHandler', 'arrayHandler', 'textHandler')
-		);
-		$context = new RenderingContextFixture();
-		$templateParser->setRenderingContext($context);
-		$templateParser->expects($this->at(0))->method('textHandler')->with($mockState, ' ');
-		$templateParser->expects($this->at(1))->method('objectAccessorHandler')->with($mockState, 'someThing.absolutely', '', '', '');
-		$templateParser->expects($this->at(2))->method('textHandler')->with($mockState, ' "fishy" is \'going\' ');
-		$templateParser->expects($this->at(3))->method('arrayHandler')->with($mockState, $this->anything());
-
-		$text = ' {someThing.absolutely} "fishy" is \'going\' {on: "here"}';
-		$method = new \ReflectionMethod(TemplateParser::class, 'textAndShorthandSyntaxHandler');
-		$method->setAccessible(TRUE);
-		$method->invokeArgs($templateParser, array($mockState, $text, TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS));
-	}
-
-	/**
-	 * @test
-	 */
-	public function arrayHandlerAddsArrayNodeWithProperContentToStack() {
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array('recursiveArrayHandler')
-		);
-		$templateParser->expects($this->any())->method('recursiveArrayHandler')
-			->with(array('arrayText'))->will($this->returnValue('processedArrayText'));
-
-		$templateParser->_call('arrayHandler', $mockState, array('arrayText'));
-	}
-
-	/**
-	 */
-	public function arrayTexts() {
-		return array(
-			array(
-				'key1: "foo", key2: \'bar\', key3: someVar, key4: 123, key5: { key6: "baz" }',
-				array('key1' => 'foo', 'key2' => 'bar', 'key3' => 'someVar', 'key4' => 123.0, 'key5' => array('key6' => 'baz'))
-			),
-			array(
-				'key1: "\'foo\'", key2: \'\\\'bar\\\'\'',
-				array('key1' => '\'foo\'', 'key2' => '\'bar\'')
-			)
-		);
-	}
-
-	/**
-	 * @__test
-	 * @dataProvider arrayTexts
-	 */
-	public function recursiveArrayHandlerReturnsExpectedArray($arrayText, $expectedArray) {
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('buildArgumentObjectTree'));
-		$templateParser->expects($this->any())->method('buildArgumentObjectTree')->willReturnArgument(0);
-		$this->assertSame($expectedArray, $templateParser->_call('recursiveArrayHandler', $arrayText));
-	}
-
-	/**
-	 * @test
-	 */
-	public function textNodesAreRunThroughEscapingInterceptorsByDefault() {
-		$textNode = $this->getMock(TextNode::class, array(), array(), '', FALSE);
-		$textInterceptor = $this->getMock(InterceptorInterface::class);
-		$textInterceptor->expects($this->once())->method('process')->with($this->anything())->willReturnArgument(0);
-
-		$parserConfiguration = $this->getMock(Configuration::class);
-		$parserConfiguration->expects($this->once())->method('getEscapingInterceptors')
-			->with(InterceptorInterface::INTERCEPT_TEXT)->will($this->returnValue(array($textInterceptor)));
-		$parserConfiguration->expects($this->any())->method('getInterceptors')->will($this->returnValue(array()));
-
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(TemplateParser::class, array('splitTemplateAtDynamicTags', 'buildObjectTree'));
-		$templateParser->_set('configuration', $parserConfiguration);
-
-		$templateParser->_call('textHandler', $mockState, 'string');
-	}
-
-	/**
-	 * @test
-	 */
-	public function textNodesAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled() {
-		$parserConfiguration = $this->getMock(Configuration::class);
-		$parserConfiguration->expects($this->never())->method('getEscapingInterceptors');
-		$parserConfiguration->expects($this->any())->method('getInterceptors')->will($this->returnValue(array()));
-
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class, array('splitTemplateAtDynamicTags', 'buildObjectTree')
-		);
-		$templateParser->_set('configuration', $parserConfiguration);
-		$templateParser->_set('escapingEnabled', FALSE);
-
-		$templateParser->_call('textHandler', $mockState, 'string');
-	}
-
-	/**
-	 * @test
-	 */
-	public function textNodesAreRunThroughInterceptors() {
-		$textInterceptor = $this->getMock(InterceptorInterface::class);
-		$textInterceptor->expects($this->once())->method('process')->with($this->anything())->will($this->returnArgument(0));
-
-		$parserConfiguration = $this->getMock(Configuration::class);
-		$parserConfiguration->expects($this->once())->method('getInterceptors')
-			->with(InterceptorInterface::INTERCEPT_TEXT)->will($this->returnValue(array($textInterceptor)));
-		$parserConfiguration->expects($this->any())->method('getEscapingInterceptors')->will($this->returnValue(array()));
-
-		$mockNodeOnStack = $this->getMock(AbstractNode::class, array(), array(), '', FALSE);
-		$mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
-		$mockState = $this->getMock(ParsingState::class);
-		$mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
-
-		$templateParser = $this->getAccessibleMock(
-			TemplateParser::class,
-			array('splitTemplateAtDynamicTags', 'buildObjectTree')
-		);
-		$templateParser->_set('configuration', $parserConfiguration);
-		$templateParser->_set('escapingEnabled', FALSE);
-
-		$templateParser->_call('textHandler', $mockState, 'string');
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getExampleScriptTestValues() {
-		return array(
-			array(
-				'<f:format.raw></f:format.raw>'
-			),
-			array(
-				'{foo -> f:format.raw()}'
-			),
-			array(
-				'{f:format.raw(value: foo)}'
-			),
-
-			array(
-				'<foo:bar></foo:bar>',
-				array(),
-				Exception::class
-			),
-			array(
-				'{foo -> foo:bar()}',
-				array(),
-				Exception::class
-			),
-			array(
-				'{foo:bar(value: foo)}',
-				array(),
-				Exception::class
-			),
-
-			array(
-				'{namespace *} <foo:bar></foo:bar>',
-				array('foo')
-			),
-			array(
-				'{namespace foo} {foo -> foo:bar()}',
-				array('foo')
-			),
-			array(
-				'{namespace fo*} {foo:bar(value: foo)}',
-				array('foo')
-			),
-			array(
-				'
+class TemplateParserTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function testInitializeViewHelperAndAddItToStackReturnsFalseIfNamespaceNotValid()
+    {
+        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceValid']);
+        $resolver->expects($this->once())->method('isNamespaceValid')->willReturn(false);
+        $context = new RenderingContextFixture();
+        $context->setViewHelperResolver($resolver);
+        $templateParser = new TemplateParser();
+        $templateParser->setRenderingContext($context);
+        $method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render', []]);
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testClosingViewHelperTagHandlerReturnsFalseIfNamespaceNotValid()
+    {
+        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceValid']);
+        $resolver->expects($this->once())->method('isNamespaceValid')->willReturn(false);
+        $context = new RenderingContextFixture();
+        $context->setViewHelperResolver($resolver);
+        $templateParser = new TemplateParser();
+        $templateParser->setRenderingContext($context);
+        $method = new \ReflectionMethod($templateParser, 'closingViewHelperTagHandler');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render']);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testBuildObjectTreeThrowsExceptionOnUnclosedViewHelperTag()
+    {
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->setVariableProvider(new StandardVariableProvider());
+        $templateParser = new TemplateParser();
+        $templateParser->setRenderingContext($renderingContext);
+        $this->setExpectedException(Exception::class);
+        $method = new \ReflectionMethod($templateParser, 'buildObjectTree');
+        $method->setAccessible(true);
+        $method->invokeArgs($templateParser, [['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
+    }
+
+    /**
+     * @test
+     */
+    public function testParseCallsPreProcessOnTemplateProcessors()
+    {
+        $templateParser = new TemplateParser();
+        $processor1 = $this->getMockForAbstractClass(
+            TemplateProcessorInterface::class,
+            [],
+            '',
+            false,
+            false,
+            true,
+            ['preProcessSource']
+        );
+        $processor2 = clone $processor1;
+        $processor1->expects($this->once())->method('preProcessSource')->with('source1')->willReturn('source2');
+        $processor2->expects($this->once())->method('preProcesssource')->with('source2')->willReturn('final');
+        $context = new RenderingContextFixture();
+        $context->setTemplateProcessors([$processor1, $processor2]);
+        $context->setVariableProvider(new StandardVariableProvider());
+        $templateParser->setRenderingContext($context);
+        $result = $templateParser->parse('source1')->render($context);
+        $this->assertEquals('final', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getOrParseAndStoreTemplateSetsCompilableStateAndReturnsOnStopComilingException()
+    {
+        $parsedTemplate = $this->getMock(ParsingState::class, ['setCompilable']);
+        $parsedTemplate->expects($this->once())->method('setCompilable')->with(false);
+        $templateParser = $this->getMock(TemplateParser::class, ['parse']);
+        $templateParser->expects($this->once())->method('parse')->willReturn($parsedTemplate);
+        $context = new RenderingContextFixture();
+        $compiler = $this->getMock(TemplateCompiler::class, ['store', 'has']);
+        $compiler->expects($this->once())->method('has')->willReturn(false);
+        $compiler->expects($this->once())->method('store')->willThrowException(new StopCompilingException());
+        $context->setTemplateCompiler($compiler);
+        $context->setVariableProvider(new StandardVariableProvider());
+        $templateParser->setRenderingContext($context);
+        $parsedTemplate = $templateParser->getOrParseAndStoreTemplate('fake-foo-baz', function ($a, $b) {
+            return 'test';
+        });
+    }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function parseThrowsExceptionWhenStringArgumentMissing()
+    {
+        $templateParser = new TemplateParser();
+        $templateParser->parse(123);
+    }
+
+    /**
+     */
+    public function quotedStrings()
+    {
+        return [
+            ['"no quotes here"', 'no quotes here'],
+            ["'no quotes here'", 'no quotes here'],
+            ["'this \"string\" had \\'quotes\\' in it'", 'this "string" had \'quotes\' in it'],
+            ['"this \\"string\\" had \'quotes\' in it"', 'this "string" had \'quotes\' in it'],
+            ['"a weird \"string\" \'with\' *freaky* \\\\stuff', 'a weird "string" \'with\' *freaky* \\stuff'],
+            ['\'\\\'escaped quoted string in string\\\'\'', '\'escaped quoted string in string\'']
+        ];
+    }
+
+    /**
+     * @dataProvider quotedStrings
+     * @test
+     */
+    public function unquoteStringReturnsUnquotedStrings($quoted, $unquoted)
+    {
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $this->assertEquals($unquoted, $templateParser->_call('unquoteString', $quoted));
+    }
+
+    /**
+     */
+    public function templatesToSplit()
+    {
+        return [
+            ['TemplateParserTestFixture01-shorthand'],
+            ['TemplateParserTestFixture06'],
+            ['TemplateParserTestFixture14']
+        ];
+    }
+
+    /**
+     * @dataProvider templatesToSplit
+     * @test
+     */
+    public function splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate($templateName)
+    {
+        $template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html', FILE_TEXT);
+        $expectedResult = require(__DIR__ . '/Fixtures/' . $templateName . '-split.php');
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $this->assertSame($expectedResult, $templateParser->_call('splitTemplateAtDynamicTags', $template), 'Filed for ' . $templateName);
+    }
+
+    /**
+     * @test
+     */
+    public function buildObjectTreeCreatesRootNodeAndSetsUpParsingState()
+    {
+        $context = new RenderingContextFixture();
+        $context->setVariableProvider(new StandardVariableProvider());
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $templateParser->setRenderingContext($context);
+        $result = $templateParser->_call('buildObjectTree', [], TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
+        $this->assertInstanceOf(ParsingState::class, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function buildObjectTreeDelegatesHandlingOfTemplateElements()
+    {
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            [
+                'textHandler',
+                'openingViewHelperTagHandler',
+                'closingViewHelperTagHandler',
+                'textAndShorthandSyntaxHandler'
+            ]
+        );
+        $context = new RenderingContextFixture();
+        $context->setVariableProvider(new StandardVariableProvider());
+        $templateParser->setRenderingContext($context);
+        $splitTemplate = $templateParser->_call('splitTemplateAtDynamicTags', 'The first part is simple<![CDATA[<f:for each="{a: {a: 0, b: 2, c: 4}}" as="array"><f:for each="{array}" as="value">{value} </f:for>]]><f:format.printf arguments="{number : 362525200}">%.3e</f:format.printf>and here goes some {text} that could have {shorthand}');
+        $result = $templateParser->_call('buildObjectTree', $splitTemplate, TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
+        $this->assertInstanceOf(ParsingState::class, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function openingViewHelperTagHandlerDelegatesViewHelperInitialization()
+    {
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->never())->method('popNodeFromStack');
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['parseArguments', 'initializeViewHelperAndAddItToStack']
+        );
+        $context = new RenderingContextFixture();
+        $templateParser->setRenderingContext($context);
+        $templateParser->expects($this->once())->method('parseArguments')
+            ->with(['arguments'])->will($this->returnValue(['parsedArguments']));
+        $templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')
+            ->with($mockState, 'namespaceIdentifier', 'methodIdentifier', ['parsedArguments']);
+
+        $templateParser->_call('openingViewHelperTagHandler', $mockState, 'namespaceIdentifier', 'methodIdentifier', ['arguments'], false, '');
+    }
+
+    /**
+     * @test
+     */
+    public function openingViewHelperTagHandlerPopsNodeFromStackForSelfClosingTags()
+    {
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($this->getMock(NodeInterface::class)));
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($this->getMock(NodeInterface::class)));
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['parseArguments', 'initializeViewHelperAndAddItToStack']
+        );
+        $node = $this->getMock(ViewHelperNode::class, ['dummy'], [], '', false);
+        $templateParser->expects($this->once())->method('initializeViewHelperAndAddItToStack')->will($this->returnValue($node));
+
+        $templateParser->_call('openingViewHelperTagHandler', $mockState, '', '', [], true, '');
+    }
+
+    /**
+     * @__test
+     * @expectedException Exception
+     */
+    public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassDoesNotExisit()
+    {
+        $mockState = $this->getMock(ParsingState::class);
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            [
+                'abortIfUnregisteredArgumentsExist',
+                'abortIfRequiredArgumentsAreMissing',
+                'rewriteBooleanNodesInArgumentsObjectTree'
+            ]
+        );
+
+        $templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'nonExisting', ['arguments']);
+    }
+
+    /**
+     * @__test
+     * @expectedException Exception
+     */
+    public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassNameIsWronglyCased()
+    {
+        $mockState = $this->getMock(ParsingState::class);
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            [
+                'abortIfUnregisteredArgumentsExist',
+                'abortIfRequiredArgumentsAreMissing',
+                'rewriteBooleanNodesInArgumentsObjectTree'
+            ]
+        );
+
+        $templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'wRongLyCased', ['arguments']);
+    }
+
+    /**
+     * @__test
+     */
+    public function initializeViewHelperAndAddItToStackCreatesRequestedViewHelperAndViewHelperNode()
+    {
+        $mockViewHelper = $this->getMock(AbstractViewHelper::class);
+        $mockViewHelperNode = $this->getMock(ViewHelperNode::class, [], [], '', false);
+
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('pushNodeToStack')->with($this->anything());
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            [
+                'abortIfUnregisteredArgumentsExist',
+                'abortIfRequiredArgumentsAreMissing',
+                'rewriteBooleanNodesInArgumentsObjectTree'
+            ]
+        );
+
+        $templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'render', ['arguments']);
+    }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function closingViewHelperTagHandlerThrowsExceptionBecauseOfClosingTagWhichWasNeverOpened()
+    {
+        $mockNodeOnStack = $this->getMock(NodeInterface::class, [], [], '', false);
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $templateParser->_set('renderingContext', new RenderingContextFixture());
+
+        $templateParser->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
+    }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function closingViewHelperTagHandlerThrowsExceptionBecauseOfWrongTagNesting()
+    {
+        $mockNodeOnStack = $this->getMock(ViewHelperNode::class, [], [], '', false);
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $templateParser->_set('renderingContext', new RenderingContextFixture());
+        $templateParser->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
+    }
+
+    /**
+     * @test
+     */
+    public function objectAccessorHandlerCallsInitializeViewHelperAndAddItToStackIfViewHelperSyntaxIsPresent()
+    {
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->exactly(2))->method('popNodeFromStack')
+            ->will($this->returnValue($this->getMock(NodeInterface::class)));
+        $mockState->expects($this->exactly(2))->method('getNodeFromStack')
+            ->will($this->returnValue($this->getMock(NodeInterface::class)));
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['recursiveArrayHandler', 'initializeViewHelperAndAddItToStack']
+        );
+        $templateParser->expects($this->at(0))->method('recursiveArrayHandler')
+            ->with('format: "H:i"')->will($this->returnValue(['format' => 'H:i']));
+        $templateParser->expects($this->at(1))->method('initializeViewHelperAndAddItToStack')
+            ->with($mockState, 'f', 'format.date', ['format' => 'H:i'])->will($this->returnValue(true));
+        $templateParser->expects($this->at(2))->method('initializeViewHelperAndAddItToStack')
+            ->with($mockState, 'f', 'debug', [])->will($this->returnValue(true));
+
+        $templateParser->_call('objectAccessorHandler', $mockState, '', '', 'f:debug() -> f:format.date(format: "H:i")', '');
+    }
+
+    /**
+     * @test
+     */
+    public function objectAccessorHandlerCreatesObjectAccessorNodeWithExpectedValueAndAddsItToStack()
+    {
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+
+        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+    }
+
+    /**
+     * @test
+     */
+    public function valuesFromObjectAccessorsAreRunThroughEscapingInterceptorsByDefault()
+    {
+        $objectAccessorNodeInterceptor = $this->getMock(InterceptorInterface::class);
+        $objectAccessorNodeInterceptor->expects($this->once())->method('process')
+            ->with($this->anything())->willReturnArgument(0);
+
+        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration->expects($this->any())->method('getInterceptors')->willReturn([]);
+        $parserConfiguration->expects($this->once())->method('getEscapingInterceptors')
+            ->with(InterceptorInterface::INTERCEPT_OBJECTACCESSOR)
+            ->will($this->returnValue([$objectAccessorNodeInterceptor]));
+
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $templateParser->_set('configuration', $parserConfiguration);
+
+        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+    }
+
+    /**
+     * @test
+     */
+    public function valuesFromObjectAccessorsAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled()
+    {
+        $objectAccessorNode = $this->getMock(ObjectAccessorNode::class, [], [], '', false);
+
+        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration->expects($this->any())->method('getInterceptors')->will($this->returnValue([]));
+        $parserConfiguration->expects($this->never())->method('getEscapingInterceptors');
+
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $templateParser->_set('configuration', $parserConfiguration);
+        $templateParser->_set('escapingEnabled', false);
+
+        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+    }
+
+
+    /**
+     * @test
+     */
+    public function valuesFromObjectAccessorsAreRunThroughInterceptors()
+    {
+        $objectAccessorNode = $this->getMock(ObjectAccessorNode::class, [], [], '', false);
+        $objectAccessorNodeInterceptor = $this->getMock(InterceptorInterface::class);
+        $objectAccessorNodeInterceptor->expects($this->once())->method('process')
+            ->with($this->anything())->will($this->returnArgument(0));
+
+        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration->expects($this->any())->method('getEscapingInterceptors')->willReturn([]);
+        $parserConfiguration->expects($this->once())->method('getInterceptors')
+            ->with(InterceptorInterface::INTERCEPT_OBJECTACCESSOR)->willReturn([$objectAccessorNodeInterceptor]);
+
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+        $templateParser->_set('configuration', $parserConfiguration);
+        $templateParser->_set('escapingEnabled', false);
+
+        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+    }
+
+    /**
+     */
+    public function argumentsStrings()
+    {
+        return [
+            ['a="2"', ['a' => '2']],
+            ['a="2" b="foobar \' with \\" quotes"', ['a' => '2', 'b' => 'foobar \' with " quotes']],
+            [' arguments="{number : 362525200}"', ['arguments' => '{number : 362525200}']]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider argumentsStrings
+     * @param string $argumentsString
+     * @param array $expected
+     */
+    public function parseArgumentsWorksAsExpected($argumentsString, array $expected)
+    {
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['buildArgumentObjectTree']);
+        $templateParser->expects($this->any())->method('buildArgumentObjectTree')->will($this->returnArgument(0));
+
+        $this->assertSame($expected, $templateParser->_call('parseArguments', $argumentsString));
+    }
+
+    /**
+     * @test
+     */
+    public function buildArgumentObjectTreeReturnsTextNodeForSimplyString()
+    {
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
+
+        $this->assertInstanceof(
+            TextNode::class,
+            $templateParser->_call('buildArgumentObjectTree', 'a very plain string')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function buildArgumentObjectTreeBuildsObjectTreeForComlexString()
+    {
+        $objectTree = $this->getMock(ParsingState::class);
+        $objectTree->expects($this->once())->method('getRootNode')->will($this->returnValue('theRootNode'));
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['splitTemplateAtDynamicTags', 'buildObjectTree']
+        );
+        $templateParser->expects($this->at(0))->method('splitTemplateAtDynamicTags')
+            ->with('a <very> {complex} string')->will($this->returnValue(['split string']));
+        $templateParser->expects($this->at(1))->method('buildObjectTree')
+            ->with(['split string'])->will($this->returnValue($objectTree));
+
+        $this->assertEquals('theRootNode', $templateParser->_call('buildArgumentObjectTree', 'a <very> {complex} string'));
+    }
+
+    /**
+     * @test
+     */
+    public function textAndShorthandSyntaxHandlerDelegatesAppropriately()
+    {
+        $mockState = $this->getMock(ParsingState::class, ['getNodeFromStack']);
+        $mockState->expects($this->any())->method('getNodeFromStack')->willReturn(new RootNode());
+
+        $templateParser = $this->getMock(
+            TemplateParser::class,
+            ['objectAccessorHandler', 'arrayHandler', 'textHandler']
+        );
+        $context = new RenderingContextFixture();
+        $templateParser->setRenderingContext($context);
+        $templateParser->expects($this->at(0))->method('textHandler')->with($mockState, ' ');
+        $templateParser->expects($this->at(1))->method('objectAccessorHandler')->with($mockState, 'someThing.absolutely', '', '', '');
+        $templateParser->expects($this->at(2))->method('textHandler')->with($mockState, ' "fishy" is \'going\' ');
+        $templateParser->expects($this->at(3))->method('arrayHandler')->with($mockState, $this->anything());
+
+        $text = ' {someThing.absolutely} "fishy" is \'going\' {on: "here"}';
+        $method = new \ReflectionMethod(TemplateParser::class, 'textAndShorthandSyntaxHandler');
+        $method->setAccessible(true);
+        $method->invokeArgs($templateParser, [$mockState, $text, TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
+    }
+
+    /**
+     * @test
+     */
+    public function arrayHandlerAddsArrayNodeWithProperContentToStack()
+    {
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['recursiveArrayHandler']
+        );
+        $templateParser->expects($this->any())->method('recursiveArrayHandler')
+            ->with(['arrayText'])->will($this->returnValue('processedArrayText'));
+
+        $templateParser->_call('arrayHandler', $mockState, ['arrayText']);
+    }
+
+    /**
+     */
+    public function arrayTexts()
+    {
+        return [
+            [
+                'key1: "foo", key2: \'bar\', key3: someVar, key4: 123, key5: { key6: "baz" }',
+                ['key1' => 'foo', 'key2' => 'bar', 'key3' => 'someVar', 'key4' => 123.0, 'key5' => ['key6' => 'baz']]
+            ],
+            [
+                'key1: "\'foo\'", key2: \'\\\'bar\\\'\'',
+                ['key1' => '\'foo\'', 'key2' => '\'bar\'']
+            ]
+        ];
+    }
+
+    /**
+     * @__test
+     * @dataProvider arrayTexts
+     */
+    public function recursiveArrayHandlerReturnsExpectedArray($arrayText, $expectedArray)
+    {
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['buildArgumentObjectTree']);
+        $templateParser->expects($this->any())->method('buildArgumentObjectTree')->willReturnArgument(0);
+        $this->assertSame($expectedArray, $templateParser->_call('recursiveArrayHandler', $arrayText));
+    }
+
+    /**
+     * @test
+     */
+    public function textNodesAreRunThroughEscapingInterceptorsByDefault()
+    {
+        $textNode = $this->getMock(TextNode::class, [], [], '', false);
+        $textInterceptor = $this->getMock(InterceptorInterface::class);
+        $textInterceptor->expects($this->once())->method('process')->with($this->anything())->willReturnArgument(0);
+
+        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration->expects($this->once())->method('getEscapingInterceptors')
+            ->with(InterceptorInterface::INTERCEPT_TEXT)->will($this->returnValue([$textInterceptor]));
+        $parserConfiguration->expects($this->any())->method('getInterceptors')->will($this->returnValue([]));
+
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['splitTemplateAtDynamicTags', 'buildObjectTree']);
+        $templateParser->_set('configuration', $parserConfiguration);
+
+        $templateParser->_call('textHandler', $mockState, 'string');
+    }
+
+    /**
+     * @test
+     */
+    public function textNodesAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled()
+    {
+        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration->expects($this->never())->method('getEscapingInterceptors');
+        $parserConfiguration->expects($this->any())->method('getInterceptors')->will($this->returnValue([]));
+
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['splitTemplateAtDynamicTags', 'buildObjectTree']
+        );
+        $templateParser->_set('configuration', $parserConfiguration);
+        $templateParser->_set('escapingEnabled', false);
+
+        $templateParser->_call('textHandler', $mockState, 'string');
+    }
+
+    /**
+     * @test
+     */
+    public function textNodesAreRunThroughInterceptors()
+    {
+        $textInterceptor = $this->getMock(InterceptorInterface::class);
+        $textInterceptor->expects($this->once())->method('process')->with($this->anything())->will($this->returnArgument(0));
+
+        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration->expects($this->once())->method('getInterceptors')
+            ->with(InterceptorInterface::INTERCEPT_TEXT)->will($this->returnValue([$textInterceptor]));
+        $parserConfiguration->expects($this->any())->method('getEscapingInterceptors')->will($this->returnValue([]));
+
+        $mockNodeOnStack = $this->getMock(AbstractNode::class, [], [], '', false);
+        $mockNodeOnStack->expects($this->once())->method('addChildNode')->with($this->anything());
+        $mockState = $this->getMock(ParsingState::class);
+        $mockState->expects($this->once())->method('getNodeFromStack')->will($this->returnValue($mockNodeOnStack));
+
+        $templateParser = $this->getAccessibleMock(
+            TemplateParser::class,
+            ['splitTemplateAtDynamicTags', 'buildObjectTree']
+        );
+        $templateParser->_set('configuration', $parserConfiguration);
+        $templateParser->_set('escapingEnabled', false);
+
+        $templateParser->_call('textHandler', $mockState, 'string');
+    }
+
+    /**
+     * @return array
+     */
+    public function getExampleScriptTestValues()
+    {
+        return [
+            [
+                '<f:format.raw></f:format.raw>'
+            ],
+            [
+                '{foo -> f:format.raw()}'
+            ],
+            [
+                '{f:format.raw(value: foo)}'
+            ],
+
+            [
+                '<foo:bar></foo:bar>',
+                [],
+                Exception::class
+            ],
+            [
+                '{foo -> foo:bar()}',
+                [],
+                Exception::class
+            ],
+            [
+                '{foo:bar(value: foo)}',
+                [],
+                Exception::class
+            ],
+
+            [
+                '{namespace *} <foo:bar></foo:bar>',
+                ['foo']
+            ],
+            [
+                '{namespace foo} {foo -> foo:bar()}',
+                ['foo']
+            ],
+            [
+                '{namespace fo*} {foo:bar(value: foo)}',
+                ['foo']
+            ],
+            [
+                '
 				{namespace a=Foo\A\ViewHelpers}
 				<![CDATA[
 					{namespace b=Foo\B\ViewHelpers}
@@ -691,63 +735,62 @@ class TemplateParserTest extends UnitTestCase {
 				]]>
 				{namespace e=Foo\E\ViewHelpers}
 				',
-				array(),
-				NULL,
-				array(
-					'f' => 'TYPO3Fluid\Fluid\ViewHelpers',
-					'a' => 'Foo\A\ViewHelpers',
-					'e' => 'Foo\E\ViewHelpers'
-				)
-			),
-			array(
-				'<a href="javascript:window.location.reload()">reload</a>'
-			),
+                [],
+                null,
+                [
+                    'f' => 'TYPO3Fluid\Fluid\ViewHelpers',
+                    'a' => 'Foo\A\ViewHelpers',
+                    'e' => 'Foo\E\ViewHelpers'
+                ]
+            ],
+            [
+                '<a href="javascript:window.location.reload()">reload</a>'
+            ],
 
-			array(
-				'\{namespace f4=F7\Rocks} {namespace f4=TYPO3\Rocks\Really}',
-				array(),
-				NULL,
-				array(
-					'f' => 'TYPO3Fluid\Fluid\ViewHelpers',
-					'f4' => 'TYPO3\Rocks\Really'
-				)
-			),
+            [
+                '\{namespace f4=F7\Rocks} {namespace f4=TYPO3\Rocks\Really}',
+                [],
+                null,
+                [
+                    'f' => 'TYPO3Fluid\Fluid\ViewHelpers',
+                    'f4' => 'TYPO3\Rocks\Really'
+                ]
+            ],
 
-			// old test method: extractNamespaceDefinitionsResolveNamespacesWithDefaultPattern
-			array(
-				'<xml xmlns="http://www.w3.org/1999/xhtml" xmlns:xyz="http://typo3.org/ns/Some/Package/ViewHelpers" />',
-				array(),
-				NULL,
-				array(
-					'f' => 'TYPO3Fluid\Fluid\ViewHelpers',
-					'xyz' => 'Some\Package\ViewHelpers'
-				)
-			),
+            // old test method: extractNamespaceDefinitionsResolveNamespacesWithDefaultPattern
+            [
+                '<xml xmlns="http://www.w3.org/1999/xhtml" xmlns:xyz="http://typo3.org/ns/Some/Package/ViewHelpers" />',
+                [],
+                null,
+                [
+                    'f' => 'TYPO3Fluid\Fluid\ViewHelpers',
+                    'xyz' => 'Some\Package\ViewHelpers'
+                ]
+            ],
 
-			// old test method: extractNamespaceDefinitionsSilentlySkipsXmlNamespaceDeclarationForTheDefaultFluidNamespace
-			array(
-				'<foo xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://domain.tld/this/will/be/ignored" />',
-				array(),
-				NULL,
-				array(
-					'f' => 'TYPO3Fluid\Fluid\ViewHelpers'
-				)
-			),
+            // old test method: extractNamespaceDefinitionsSilentlySkipsXmlNamespaceDeclarationForTheDefaultFluidNamespace
+            [
+                '<foo xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://domain.tld/this/will/be/ignored" />',
+                [],
+                null,
+                [
+                    'f' => 'TYPO3Fluid\Fluid\ViewHelpers'
+                ]
+            ],
 
-			// old test method: extractNamespaceDefinitionsThrowsExceptionIfNamespaceIsRedeclared
-			array(
-				'{namespace typo3=TYPO3\Fluid\Blablubb} {namespace typo3= TYPO3\Rocks\Blu}',
-				array(),
-				'\TYPO3Fluid\Fluid\Core\Parser\Exception'
-			),
+            // old test method: extractNamespaceDefinitionsThrowsExceptionIfNamespaceIsRedeclared
+            [
+                '{namespace typo3=TYPO3\Fluid\Blablubb} {namespace typo3= TYPO3\Rocks\Blu}',
+                [],
+                '\TYPO3Fluid\Fluid\Core\Parser\Exception'
+            ],
 
-			// old test method: extractNamespaceDefinitionsThrowsExceptionIfFluidNamespaceIsRedeclaredAsXmlNamespace
-			array(
-				'{namespace typo3=TYPO3\Fluid\Blablubb} <foo xmlns="http://www.w3.org/1999/xhtml" xmlns:typo3="http://typo3.org/ns/Some/Package/ViewHelpers" />',
-				array(),
-				'\TYPO3Fluid\Fluid\Core\Parser\Exception'
-			),
-		);
-	}
-
+            // old test method: extractNamespaceDefinitionsThrowsExceptionIfFluidNamespaceIsRedeclaredAsXmlNamespace
+            [
+                '{namespace typo3=TYPO3\Fluid\Blablubb} <foo xmlns="http://www.w3.org/1999/xhtml" xmlns:typo3="http://typo3.org/ns/Some/Package/ViewHelpers" />',
+                [],
+                '\TYPO3Fluid\Fluid\Core\Parser\Exception'
+            ],
+        ];
+    }
 }

--- a/tests/Unit/Core/Rendering/RenderingContextFixture.php
+++ b/tests/Unit/Core/Rendering/RenderingContextFixture.php
@@ -21,294 +21,321 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 /**
  * Class RenderingContextFixture
  */
-class RenderingContextFixture implements RenderingContextInterface {
+class RenderingContextFixture implements RenderingContextInterface
+{
 
-	/**
-	 * @var VariableProviderInterface
-	 */
-	public $variableProvider;
+    /**
+     * @var VariableProviderInterface
+     */
+    public $variableProvider;
 
-	/**
-	 * @var ViewHelperVariableContainer
-	 */
-	public $viewHelperVariableContainer;
+    /**
+     * @var ViewHelperVariableContainer
+     */
+    public $viewHelperVariableContainer;
 
-	/**
-	 * @var ViewHelperResolver
-	 */
-	public $viewHelperResolver;
+    /**
+     * @var ViewHelperResolver
+     */
+    public $viewHelperResolver;
 
-	/**
-	 * @var ViewHelperInvoker
-	 */
-	public $viewHelperInvoker;
+    /**
+     * @var ViewHelperInvoker
+     */
+    public $viewHelperInvoker;
 
-	/**
-	 * @var TemplateParser
-	 */
-	public $templateParser;
+    /**
+     * @var TemplateParser
+     */
+    public $templateParser;
 
-	/**
-	 * @var TemplateCompiler
-	 */
-	public $templateCompiler;
+    /**
+     * @var TemplateCompiler
+     */
+    public $templateCompiler;
 
-	/**
-	 * @var TemplatePaths
-	 */
-	public $templatePaths;
+    /**
+     * @var TemplatePaths
+     */
+    public $templatePaths;
 
-	/**
-	 * @var FluidCacheInterface
-	 */
-	public $cache;
+    /**
+     * @var FluidCacheInterface
+     */
+    public $cache;
 
-	/**
-	 * @var TemplateProcessorInterface[]
-	 */
-	public $templateProcessors = array();
+    /**
+     * @var TemplateProcessorInterface[]
+     */
+    public $templateProcessors = [];
 
-	/**
-	 * @var array
-	 */
-	public $expressionNodeTypes = array();
+    /**
+     * @var array
+     */
+    public $expressionNodeTypes = [];
 
-	/**
-	 * @var string
-	 */
-	public $controllerName = 'Default';
+    /**
+     * @var string
+     */
+    public $controllerName = 'Default';
 
-	/**
-	 * @var string
-	 */
-	public $controllerAction = 'Default';
+    /**
+     * @var string
+     */
+    public $controllerAction = 'Default';
 
-	/**
-	 * @var boolean
-	 */
-	public $cacheDisabled = FALSE;
+    /**
+     * @var boolean
+     */
+    public $cacheDisabled = false;
 
-	/**
-	 * Constructor
-	 */
-	public function __construct() {
-		$mockBuilder = new \PHPUnit_Framework_MockObject_Generator();
-		$this->variableProvider = $mockBuilder->getMock(VariableProviderInterface::class);
-		$this->viewHelperVariableContainer = $mockBuilder->getMock(ViewHelperVariableContainer::class, array('dummy'));
-		$this->viewHelperResolver = $mockBuilder->getMock(ViewHelperResolver::class, array('dummy'));
-		$this->viewHelperInvoker = $mockBuilder->getMock(ViewHelperInvoker::class, array('dummy'));
-		$this->templateParser = $mockBuilder->getMock(TemplateParser::class, array('dummy'));
-		$this->templateCompiler = $mockBuilder->getMock(TemplateCompiler::class, array('dummy'));
-		$this->templatePaths = $mockBuilder->getMock(TemplatePaths::class, array('dummy'));
-		$this->cache = $mockBuilder->getMock(FluidCacheInterface::class);
-	}
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $mockBuilder = new \PHPUnit_Framework_MockObject_Generator();
+        $this->variableProvider = $mockBuilder->getMock(VariableProviderInterface::class);
+        $this->viewHelperVariableContainer = $mockBuilder->getMock(ViewHelperVariableContainer::class, ['dummy']);
+        $this->viewHelperResolver = $mockBuilder->getMock(ViewHelperResolver::class, ['dummy']);
+        $this->viewHelperInvoker = $mockBuilder->getMock(ViewHelperInvoker::class, ['dummy']);
+        $this->templateParser = $mockBuilder->getMock(TemplateParser::class, ['dummy']);
+        $this->templateCompiler = $mockBuilder->getMock(TemplateCompiler::class, ['dummy']);
+        $this->templatePaths = $mockBuilder->getMock(TemplatePaths::class, ['dummy']);
+        $this->cache = $mockBuilder->getMock(FluidCacheInterface::class);
+    }
 
-	/**
-	 * Injects the template variable container containing all variables available through ObjectAccessors
-	 * in the template
-	 *
-	 * @param VariableProviderInterface $variableProvider The template variable container to set
-	 */
-	public function setVariableProvider(VariableProviderInterface $variableProvider) {
-		$this->variableProvider = $variableProvider;
-	}
+    /**
+     * Injects the template variable container containing all variables available through ObjectAccessors
+     * in the template
+     *
+     * @param VariableProviderInterface $variableProvider The template variable container to set
+     */
+    public function setVariableProvider(VariableProviderInterface $variableProvider)
+    {
+        $this->variableProvider = $variableProvider;
+    }
 
-	/**
-	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
-	 */
-	public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer) {
-		$this->viewHelperVariableContainer = $viewHelperVariableContainer;
-	}
+    /**
+     * @param ViewHelperVariableContainer $viewHelperVariableContainer
+     */
+    public function setViewHelperVariableContainer(ViewHelperVariableContainer $viewHelperVariableContainer)
+    {
+        $this->viewHelperVariableContainer = $viewHelperVariableContainer;
+    }
 
-	/**
-	 * Get the template variable container
-	 *
-	 * @return VariableProviderInterface The Template Variable Container
-	 */
-	public function getVariableProvider() {
-		return $this->variableProvider;
-	}
+    /**
+     * Get the template variable container
+     *
+     * @return VariableProviderInterface The Template Variable Container
+     */
+    public function getVariableProvider()
+    {
+        return $this->variableProvider;
+    }
 
-	/**
-	 * Get the ViewHelperVariableContainer
-	 *
-	 * @return ViewHelperVariableContainer
-	 */
-	public function getViewHelperVariableContainer() {
-		return $this->viewHelperVariableContainer;
-	}
+    /**
+     * Get the ViewHelperVariableContainer
+     *
+     * @return ViewHelperVariableContainer
+     */
+    public function getViewHelperVariableContainer()
+    {
+        return $this->viewHelperVariableContainer;
+    }
 
-	/**
-	 * @return ViewHelperResolver
-	 */
-	public function getViewHelperResolver() {
-		return $this->viewHelperResolver;
-	}
+    /**
+     * @return ViewHelperResolver
+     */
+    public function getViewHelperResolver()
+    {
+        return $this->viewHelperResolver;
+    }
 
-	/**
-	 * @param ViewHelperResolver $viewHelperResolver
-	 * @return void
-	 */
-	public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver) {
-		$this->viewHelperResolver = $viewHelperResolver;
-	}
+    /**
+     * @param ViewHelperResolver $viewHelperResolver
+     * @return void
+     */
+    public function setViewHelperResolver(ViewHelperResolver $viewHelperResolver)
+    {
+        $this->viewHelperResolver = $viewHelperResolver;
+    }
 
-	/**
-	 * @return ViewHelperInvoker
-	 */
-	public function getViewHelperInvoker() {
-		return $this->viewHelperInvoker;
-	}
+    /**
+     * @return ViewHelperInvoker
+     */
+    public function getViewHelperInvoker()
+    {
+        return $this->viewHelperInvoker;
+    }
 
-	/**
-	 * @param ViewHelperInvoker $viewHelperInvoker
-	 * @return void
-	 */
-	public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker) {
-		$this->viewHelperInvoker = $viewHelperInvoker;
-	}
+    /**
+     * @param ViewHelperInvoker $viewHelperInvoker
+     * @return void
+     */
+    public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker)
+    {
+        $this->viewHelperInvoker = $viewHelperInvoker;
+    }
 
-	/**
-	 * Inject the Template Parser
-	 *
-	 * @param TemplateParser $templateParser The template parser
-	 * @return void
-	 */
-	public function setTemplateParser(TemplateParser $templateParser) {
-		$this->templateParser = $templateParser;
-	}
+    /**
+     * Inject the Template Parser
+     *
+     * @param TemplateParser $templateParser The template parser
+     * @return void
+     */
+    public function setTemplateParser(TemplateParser $templateParser)
+    {
+        $this->templateParser = $templateParser;
+    }
 
-	/**
-	 * @return TemplateParser
-	 */
-	public function getTemplateParser() {
-		return $this->templateParser;
-	}
+    /**
+     * @return TemplateParser
+     */
+    public function getTemplateParser()
+    {
+        return $this->templateParser;
+    }
 
-	/**
-	 * @param TemplateCompiler $templateCompiler
-	 * @return void
-	 */
-	public function setTemplateCompiler(TemplateCompiler $templateCompiler) {
-		$this->templateCompiler = $templateCompiler;
-	}
+    /**
+     * @param TemplateCompiler $templateCompiler
+     * @return void
+     */
+    public function setTemplateCompiler(TemplateCompiler $templateCompiler)
+    {
+        $this->templateCompiler = $templateCompiler;
+    }
 
-	/**
-	 * @return TemplateCompiler
-	 */
-	public function getTemplateCompiler() {
-		return $this->templateCompiler;
-	}
+    /**
+     * @return TemplateCompiler
+     */
+    public function getTemplateCompiler()
+    {
+        return $this->templateCompiler;
+    }
 
-	/**
-	 * @return TemplatePaths
-	 */
-	public function getTemplatePaths() {
-		return $this->templatePaths;
-	}
+    /**
+     * @return TemplatePaths
+     */
+    public function getTemplatePaths()
+    {
+        return $this->templatePaths;
+    }
 
-	/**
-	 * @param TemplatePaths $templatePaths
-	 * @return void
-	 */
-	public function setTemplatePaths(TemplatePaths $templatePaths) {
-		$this->templatePaths = $templatePaths;
-	}
+    /**
+     * @param TemplatePaths $templatePaths
+     * @return void
+     */
+    public function setTemplatePaths(TemplatePaths $templatePaths)
+    {
+        $this->templatePaths = $templatePaths;
+    }
 
-	/**
-	 * Delegation: Set the cache used by this View's compiler
-	 *
-	 * @param FluidCacheInterface $cache
-	 * @return void
-	 */
-	public function setCache(FluidCacheInterface $cache) {
-		$this->cache = $cache;
-	}
+    /**
+     * Delegation: Set the cache used by this View's compiler
+     *
+     * @param FluidCacheInterface $cache
+     * @return void
+     */
+    public function setCache(FluidCacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
 
-	/**
-	 * @return FluidCacheInterface
-	 */
-	public function getCache() {
-		return $this->cache;
-	}
+    /**
+     * @return FluidCacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isCacheEnabled() {
-		return !$this->cacheDisabled;
-	}
+    /**
+     * @return boolean
+     */
+    public function isCacheEnabled()
+    {
+        return !$this->cacheDisabled;
+    }
 
-	/**
-	 * Delegation: Set TemplateProcessor instances in the parser
-	 * through a public API.
-	 *
-	 * @param TemplateProcessorInterface[] $templateProcessors
-	 * @return void
-	 */
-	public function setTemplateProcessors(array $templateProcessors) {
-		$this->templateProcessors = $templateProcessors;
-	}
+    /**
+     * Delegation: Set TemplateProcessor instances in the parser
+     * through a public API.
+     *
+     * @param TemplateProcessorInterface[] $templateProcessors
+     * @return void
+     */
+    public function setTemplateProcessors(array $templateProcessors)
+    {
+        $this->templateProcessors = $templateProcessors;
+    }
 
-	/**
-	 * @return TemplateProcessorInterface[]
-	 */
-	public function getTemplateProcessors() {
-		return $this->templateProcessors;
-	}
+    /**
+     * @return TemplateProcessorInterface[]
+     */
+    public function getTemplateProcessors()
+    {
+        return $this->templateProcessors;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getExpressionNodeTypes() {
-		return $this->expressionNodeTypes;
-	}
+    /**
+     * @return array
+     */
+    public function getExpressionNodeTypes()
+    {
+        return $this->expressionNodeTypes;
+    }
 
-	/**
-	 * @param array $expressionNodeTypes
-	 * @return void
-	 */
-	public function setExpressionNodeTypes(array $expressionNodeTypes) {
-		$this->expressionNodeTypes = $expressionNodeTypes;
-	}
+    /**
+     * @param array $expressionNodeTypes
+     * @return void
+     */
+    public function setExpressionNodeTypes(array $expressionNodeTypes)
+    {
+        $this->expressionNodeTypes = $expressionNodeTypes;
+    }
 
-	/**
-	 * Build parser configuration
-	 *
-	 * @return Configuration
-	 */
-	public function buildParserConfiguration() {
-		return new Configuration();
-	}
+    /**
+     * Build parser configuration
+     *
+     * @return Configuration
+     */
+    public function buildParserConfiguration()
+    {
+        return new Configuration();
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getControllerName() {
-		return $this->controllerName;
-	}
+    /**
+     * @return string
+     */
+    public function getControllerName()
+    {
+        return $this->controllerName;
+    }
 
-	/**
-	 * @param string $controllerName
-	 * @return void
-	 */
-	public function setControllerName($controllerName) {
-		$this->controllerName;
-	}
+    /**
+     * @param string $controllerName
+     * @return void
+     */
+    public function setControllerName($controllerName)
+    {
+        $this->controllerName;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getControllerAction() {
-		return $this->controllerAction;
-	}
+    /**
+     * @return string
+     */
+    public function getControllerAction()
+    {
+        return $this->controllerAction;
+    }
 
-	/**
-	 * @param string $action
-	 * @return void
-	 */
-	public function setControllerAction($action) {
-		$this->controllerAction = $action;
-	}
-
+    /**
+     * @param string $action
+     * @return void
+     */
+    public function setControllerAction($action)
+    {
+        $this->controllerAction = $action;
+    }
 }

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -24,88 +24,95 @@ use TYPO3Fluid\Fluid\View\TemplateView;
  * Testcase for ParsingState
  *
  */
-class RenderingContextTest extends UnitTestCase {
+class RenderingContextTest extends UnitTestCase
+{
 
-	/**
-	 * @var RenderingContextInterface
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
 
-	public function setUp() {
-		$this->renderingContext = new RenderingContextFixture();
-	}
+    public function setUp()
+    {
+        $this->renderingContext = new RenderingContextFixture();
+    }
 
-	/**
-	 * @param string $property
-	 * @param mixed $value
-	 * @dataProvider getPropertyNameTestValues
-	 */
-	public function testGetter($property, $value) {
-		$view = new TemplateView();
-		$subject = $this->getAccessibleMock(RenderingContext::class, array('dummy'), array($view));
-		$subject->_set($property, $value);
-		$getter = 'get' . ucfirst($property);
-		$this->assertSame($value, $subject->$getter());
-	}
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @dataProvider getPropertyNameTestValues
+     */
+    public function testGetter($property, $value)
+    {
+        $view = new TemplateView();
+        $subject = $this->getAccessibleMock(RenderingContext::class, ['dummy'], [$view]);
+        $subject->_set($property, $value);
+        $getter = 'get' . ucfirst($property);
+        $this->assertSame($value, $subject->$getter());
+    }
 
-	/**
-	 * @param string $property
-	 * @param mixed $value
-	 * @dataProvider getPropertyNameTestValues
-	 */
-	public function testSetter($property, $value) {
-		$view = new TemplateView();
-		$subject = new RenderingContext($view);
-		$setter = 'set' . ucfirst($property);
-		$subject->$setter($value);
-		$this->assertAttributeSame($value, $property, $subject);
-	}
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @dataProvider getPropertyNameTestValues
+     */
+    public function testSetter($property, $value)
+    {
+        $view = new TemplateView();
+        $subject = new RenderingContext($view);
+        $setter = 'set' . ucfirst($property);
+        $subject->$setter($value);
+        $this->assertAttributeSame($value, $property, $subject);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getPropertyNameTestValues() {
-		return array(
-			array('variableProvider', new StandardVariableProvider(array('foo' => 'bar'))),
-			array('viewHelperResolver', $this->getMock(ViewHelperResolver::class)),
-			array('viewHelperInvoker', $this->getMock(ViewHelperInvoker::class)),
-			array('controllerName', 'foobar-controllerName'),
-			array('controllerAction', 'foobar-controllerAction'),
-			array('expressionNodeTypes', array('Foo', 'Bar')),
-			array('templatePaths', $this->getMock(TemplatePaths::class)),
-			array('cache', $this->getMock(SimpleFileCache::class)),
-			array('templateParser', $this->getMock(TemplateParser::class)),
-			array('templateCompiler', $this->getMock(TemplateCompiler::class)),
-			array('templateProcessors', array($this->getMock(TemplateProcessorInterface::class), $this->getMock(TemplateProcessorInterface::class)))
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getPropertyNameTestValues()
+    {
+        return [
+            ['variableProvider', new StandardVariableProvider(['foo' => 'bar'])],
+            ['viewHelperResolver', $this->getMock(ViewHelperResolver::class)],
+            ['viewHelperInvoker', $this->getMock(ViewHelperInvoker::class)],
+            ['controllerName', 'foobar-controllerName'],
+            ['controllerAction', 'foobar-controllerAction'],
+            ['expressionNodeTypes', ['Foo', 'Bar']],
+            ['templatePaths', $this->getMock(TemplatePaths::class)],
+            ['cache', $this->getMock(SimpleFileCache::class)],
+            ['templateParser', $this->getMock(TemplateParser::class)],
+            ['templateCompiler', $this->getMock(TemplateCompiler::class)],
+            ['templateProcessors', [$this->getMock(TemplateProcessorInterface::class), $this->getMock(TemplateProcessorInterface::class)]]
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function templateVariableContainerCanBeReadCorrectly() {
-		$templateVariableContainer = $this->getMock(StandardVariableProvider::class);
-		$this->renderingContext->setVariableProvider($templateVariableContainer);
-		$this->assertSame($this->renderingContext->getVariableProvider(), $templateVariableContainer, 'Template Variable Container could not be read out again.');
-	}
+    /**
+     * @test
+     */
+    public function templateVariableContainerCanBeReadCorrectly()
+    {
+        $templateVariableContainer = $this->getMock(StandardVariableProvider::class);
+        $this->renderingContext->setVariableProvider($templateVariableContainer);
+        $this->assertSame($this->renderingContext->getVariableProvider(), $templateVariableContainer, 'Template Variable Container could not be read out again.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperVariableContainerCanBeReadCorrectly() {
-		$viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
-		$this->renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
-		$this->assertSame($viewHelperVariableContainer, $this->renderingContext->getViewHelperVariableContainer());
-	}
+    /**
+     * @test
+     */
+    public function viewHelperVariableContainerCanBeReadCorrectly()
+    {
+        $viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
+        $this->renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
+        $this->assertSame($viewHelperVariableContainer, $this->renderingContext->getViewHelperVariableContainer());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testIsCacheEnabled() {
-		$subject = new RenderingContext($this->getMock(TemplateView::class));
-		$this->assertFalse($subject->isCacheEnabled());
-		$subject->setCache($this->getMock(SimpleFileCache::class));
-		$this->assertTrue($subject->isCacheEnabled());
-	}
-
+    /**
+     * @test
+     */
+    public function testIsCacheEnabled()
+    {
+        $subject = new RenderingContext($this->getMock(TemplateView::class));
+        $this->assertFalse($subject->isCacheEnabled());
+        $subject->setCache($this->getMock(SimpleFileCache::class));
+        $this->assertTrue($subject->isCacheEnabled());
+    }
 }

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -14,112 +14,121 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for ChainedVariableContainer
  */
-class ChainedVariableProviderTest extends UnitTestCase {
+class ChainedVariableProviderTest extends UnitTestCase
+{
 
-	/**
-	 * @param array $local
-	 * @param VariableProviderInterface $chain
-	 * @param string $path
-	 * @param mixed $expected
-	 * @dataProvider getGetTestValues
-	 */
-	public function testGet(array $local, array $chain, $path, $expected) {
-		$chainedProvider = new ChainedVariableProvider($chain);
-		$chainedProvider->setSource($local);
-		$this->assertEquals($expected, $chainedProvider->get($path));
-	}
+    /**
+     * @param array $local
+     * @param VariableProviderInterface $chain
+     * @param string $path
+     * @param mixed $expected
+     * @dataProvider getGetTestValues
+     */
+    public function testGet(array $local, array $chain, $path, $expected)
+    {
+        $chainedProvider = new ChainedVariableProvider($chain);
+        $chainedProvider->setSource($local);
+        $this->assertEquals($expected, $chainedProvider->get($path));
+    }
 
-	/**
-	 * @param array $local
-	 * @param VariableProviderInterface $chain
-	 * @param string $path
-	 * @param mixed $expected
-	 * @dataProvider getGetTestValues
-	 */
-	public function testGetByPath(array $local, array $chain, $path, $expected) {
-		$chainedProvider = new ChainedVariableProvider($chain);
-		$chainedProvider->setSource($local);
-		$this->assertEquals($expected, $chainedProvider->getByPath($path));
-	}
+    /**
+     * @param array $local
+     * @param VariableProviderInterface $chain
+     * @param string $path
+     * @param mixed $expected
+     * @dataProvider getGetTestValues
+     */
+    public function testGetByPath(array $local, array $chain, $path, $expected)
+    {
+        $chainedProvider = new ChainedVariableProvider($chain);
+        $chainedProvider->setSource($local);
+        $this->assertEquals($expected, $chainedProvider->getByPath($path));
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getGetTestValues() {
-		$a = new StandardVariableProvider(array('a' => 'a'));
-		$b = new StandardVariableProvider(array('a' => 'b', 'b' => 'b'));
+    /**
+     * @return array
+     */
+    public function getGetTestValues()
+    {
+        $a = new StandardVariableProvider(['a' => 'a']);
+        $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
 
-		return array(
-			array(array('a' => 'local'), array($a, $b), 'a', 'local'),
-			array(array(), array($a, $b), 'a', 'a'),
-			array(array(), array($a, $b), 'b', 'b'),
-			array(array(), array($b, $a), 'a', 'b'),
-			array(array(), array($b, $a), 'b', 'b'),
-			array(array(), array($b, $a), 'notfound', NULL),
-		);
-	}
+        return [
+            [['a' => 'local'], [$a, $b], 'a', 'local'],
+            [[], [$a, $b], 'a', 'a'],
+            [[], [$a, $b], 'b', 'b'],
+            [[], [$b, $a], 'a', 'b'],
+            [[], [$b, $a], 'b', 'b'],
+            [[], [$b, $a], 'notfound', null],
+        ];
+    }
 
-	/**
-	 * @param array $local
-	 * @param VariableProviderInterface $chain
-	 * @param mixed $expected
-	 * @dataProvider getGetAllTestValues
-	 */
-	public function testGetAll(array $local, array $chain, $expected) {
-		$chainedProvider = new ChainedVariableProvider($chain);
-		$chainedProvider->setSource($local);
-		$this->assertEquals($expected, $chainedProvider->getAll());
-	}
+    /**
+     * @param array $local
+     * @param VariableProviderInterface $chain
+     * @param mixed $expected
+     * @dataProvider getGetAllTestValues
+     */
+    public function testGetAll(array $local, array $chain, $expected)
+    {
+        $chainedProvider = new ChainedVariableProvider($chain);
+        $chainedProvider->setSource($local);
+        $this->assertEquals($expected, $chainedProvider->getAll());
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getGetAllTestValues() {
-		$a = new StandardVariableProvider(array('a' => 'a'));
-		$b = new StandardVariableProvider(array('a' => 'b', 'b' => 'b'));
+    /**
+     * @return array
+     */
+    public function getGetAllTestValues()
+    {
+        $a = new StandardVariableProvider(['a' => 'a']);
+        $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
 
-		return array(
-			array(array('a' => 'local'), array($a, $b), array('a' => 'local', 'b' => 'b')),
-			array(array(), array($a, $b), array('a' => 'a', 'b' => 'b')),
-			array(array(), array($a, $b), array('a' => 'a', 'b' => 'b')),
-			array(array(), array($b, $a), array('a' => 'b', 'b' => 'b')),
-		);
-	}
+        return [
+            [['a' => 'local'], [$a, $b], ['a' => 'local', 'b' => 'b']],
+            [[], [$a, $b], ['a' => 'a', 'b' => 'b']],
+            [[], [$a, $b], ['a' => 'a', 'b' => 'b']],
+            [[], [$b, $a], ['a' => 'b', 'b' => 'b']],
+        ];
+    }
 
-	/**
-	 * @param array $local
-	 * @param VariableProviderInterface $chain
-	 * @param mixed $expected
-	 * @dataProvider getGetAllIdentifiersTestValues
-	 */
-	public function testGetAllIdentifiers(array $local, array $chain, $expected) {
-		$chainedProvider = new ChainedVariableProvider($chain);
-		$chainedProvider->setSource($local);
-		$this->assertEquals($expected, $chainedProvider->getAllIdentifiers());
-	}
+    /**
+     * @param array $local
+     * @param VariableProviderInterface $chain
+     * @param mixed $expected
+     * @dataProvider getGetAllIdentifiersTestValues
+     */
+    public function testGetAllIdentifiers(array $local, array $chain, $expected)
+    {
+        $chainedProvider = new ChainedVariableProvider($chain);
+        $chainedProvider->setSource($local);
+        $this->assertEquals($expected, $chainedProvider->getAllIdentifiers());
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getGetAllIdentifiersTestValues() {
-		$a = new StandardVariableProvider(array('a' => 'a'));
-		$b = new StandardVariableProvider(array('a' => 'b', 'b' => 'b'));
+    /**
+     * @return array
+     */
+    public function getGetAllIdentifiersTestValues()
+    {
+        $a = new StandardVariableProvider(['a' => 'a']);
+        $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
 
-		return array(
-			array(array('a' => 'local'), array($a, $b), array('a', 'b')),
-			array(array(), array($a, $b), array('a', 'b')),
-			array(array(), array($a, $b), array('a', 'b')),
-			array(array(), array($b, $a), array('a', 'b')),
-		);
-	}
+        return [
+            [['a' => 'local'], [$a, $b], ['a', 'b']],
+            [[], [$a, $b], ['a', 'b']],
+            [[], [$a, $b], ['a', 'b']],
+            [[], [$b, $a], ['a', 'b']],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetScopeCopy() {
-		$chain = array(new StandardVariableProvider(), new StandardVariableProvider());
-		$chainedProvider = new ChainedVariableProvider($chain);
-		$copy = $chainedProvider->getScopeCopy(array());
-		$this->assertAttributeSame($chain, 'variableProviders', $copy);
-	}
+    /**
+     * @test
+     */
+    public function testGetScopeCopy()
+    {
+        $chain = [new StandardVariableProvider(), new StandardVariableProvider()];
+        $chainedProvider = new ChainedVariableProvider($chain);
+        $copy = $chainedProvider->getScopeCopy([]);
+        $this->assertAttributeSame($chain, 'variableProviders', $copy);
+    }
 }

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -14,47 +14,50 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for JSONVariableProvider
  */
-class JSONVariableProviderTest extends UnitTestCase {
+class JSONVariableProviderTest extends UnitTestCase
+{
 
-	/**
-	 * @var vfsStreamFile
-	 */
-	protected $jsonFile;
+    /**
+     * @var vfsStreamFile
+     */
+    protected $jsonFile;
 
-	/**
-	 * Constructor
-	 */
-	public function setUp() {
-		$this->jsonFile = new vfsStreamFile('test.json');
-		$this->jsonFile->setContent('{"foo": "bar"}');
-		vfsStream::setup()->addChild($this->jsonFile);
-	}
+    /**
+     * Constructor
+     */
+    public function setUp()
+    {
+        $this->jsonFile = new vfsStreamFile('test.json');
+        $this->jsonFile->setContent('{"foo": "bar"}');
+        vfsStream::setup()->addChild($this->jsonFile);
+    }
 
-	/**
-	 * @dataProvider getOperabilityTestValues
-	 * @param string $input
-	 * @param array $expected
-	 */
-	public function testOperability($input, array $expected) {
-		$provider = new JSONVariableProvider();
-		$provider->setSource($input);
-		$this->assertEquals($input, $provider->getSource());
-		$this->assertEquals($expected, $provider->getAll());
-		$this->assertEquals(array_keys($expected), $provider->getAllIdentifiers());
-		foreach ($expected as $key => $value) {
-			$this->assertEquals($value, $provider->get($key));
-		}
-	}
+    /**
+     * @dataProvider getOperabilityTestValues
+     * @param string $input
+     * @param array $expected
+     */
+    public function testOperability($input, array $expected)
+    {
+        $provider = new JSONVariableProvider();
+        $provider->setSource($input);
+        $this->assertEquals($input, $provider->getSource());
+        $this->assertEquals($expected, $provider->getAll());
+        $this->assertEquals(array_keys($expected), $provider->getAllIdentifiers());
+        foreach ($expected as $key => $value) {
+            $this->assertEquals($value, $provider->get($key));
+        }
+    }
 
-	/**
-	 * @test
-	 */
-	public function getOperabilityTestValues() {
-		return array(
-			array('{}', array()),
-			array('{"foo": "bar"}', array('foo' => 'bar')),
-			array('vfs://root/test.json', array('foo' => 'bar')),
-		);
-	}
-
+    /**
+     * @test
+     */
+    public function getOperabilityTestValues()
+    {
+        return [
+            ['{}', []],
+            ['{"foo": "bar"}', ['foo' => 'bar']],
+            ['vfs://root/test.json', ['foo' => 'bar']],
+        ];
+    }
 }

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -12,150 +12,165 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for TemplateVariableContainer
  */
-class StandardVariableProviderTest extends UnitTestCase {
+class StandardVariableProviderTest extends UnitTestCase
+{
 
-	/**
-	 * @var StandardVariableProvider
-	 */
-	protected $variableProvider;
+    /**
+     * @var StandardVariableProvider
+     */
+    protected $variableProvider;
 
-	/**
-	 */
-	public function setUp() {
-		$this->variableProvider = $this->getMock(StandardVariableProvider::class, array('dummy'));
-	}
+    /**
+     */
+    public function setUp()
+    {
+        $this->variableProvider = $this->getMock(StandardVariableProvider::class, ['dummy']);
+    }
 
-	/**
-	 */
-	public function tearDown() {
-		unset($this->variableProvider);
-	}
+    /**
+     */
+    public function tearDown()
+    {
+        unset($this->variableProvider);
+    }
 
-	/**
-	 * @dataProvider getOperabilityTestValues
-	 * @param string $input
-	 * @param array $expected
-	 */
-	public function testOperability($input, array $expected) {
-		$provider = new StandardVariableProvider();
-		$provider->setSource($input);
-		$this->assertEquals($input, $provider->getSource());
-		$this->assertEquals($expected, $provider->getAll());
-		$this->assertEquals(array_keys($expected), $provider->getAllIdentifiers());
-		foreach ($expected as $key => $value) {
-			$this->assertEquals($value, $provider->get($key));
-		}
-	}
+    /**
+     * @dataProvider getOperabilityTestValues
+     * @param string $input
+     * @param array $expected
+     */
+    public function testOperability($input, array $expected)
+    {
+        $provider = new StandardVariableProvider();
+        $provider->setSource($input);
+        $this->assertEquals($input, $provider->getSource());
+        $this->assertEquals($expected, $provider->getAll());
+        $this->assertEquals(array_keys($expected), $provider->getAllIdentifiers());
+        foreach ($expected as $key => $value) {
+            $this->assertEquals($value, $provider->get($key));
+        }
+    }
 
-	/**
-	 * @test
-	 */
-	public function getOperabilityTestValues() {
-		return array(
-			array(array(), array()),
-			array(array('foo' => 'bar'), array('foo' => 'bar'))
-		);
-	}
+    /**
+     * @test
+     */
+    public function getOperabilityTestValues()
+    {
+        return [
+            [[], []],
+            [['foo' => 'bar'], ['foo' => 'bar']]
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSupportsDottedPath() {
-		$provider = new StandardVariableProvider();
-		$provider->setSource(array('foo' => array('bar' => 'baz')));
-		$result = $provider->getByPath('foo.bar');
-		$this->assertEquals('baz', $result);
-	}
+    /**
+     * @test
+     */
+    public function testSupportsDottedPath()
+    {
+        $provider = new StandardVariableProvider();
+        $provider->setSource(['foo' => ['bar' => 'baz']]);
+        $result = $provider->getByPath('foo.bar');
+        $this->assertEquals('baz', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testUnsetAsArrayAccess() {
-		$this->variableProvider->add('variable', 'test');
-		unset($this->variableProvider['variable']);
-		$this->assertFalse($this->variableProvider->exists('variable'));
-	}
+    /**
+     * @test
+     */
+    public function testUnsetAsArrayAccess()
+    {
+        $this->variableProvider->add('variable', 'test');
+        unset($this->variableProvider['variable']);
+        $this->assertFalse($this->variableProvider->exists('variable'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function addedObjectsCanBeRetrievedAgain() {
-		$object = 'StringObject';
-		$this->variableProvider->add('variable', $object);
-		$this->assertSame($this->variableProvider->get('variable'), $object, 'The retrieved object from the context is not the same as the stored object.');
-	}
+    /**
+     * @test
+     */
+    public function addedObjectsCanBeRetrievedAgain()
+    {
+        $object = 'StringObject';
+        $this->variableProvider->add('variable', $object);
+        $this->assertSame($this->variableProvider->get('variable'), $object, 'The retrieved object from the context is not the same as the stored object.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function addedObjectsCanBeRetrievedAgainUsingArrayAccess() {
-		$object = 'StringObject';
-		$this->variableProvider['variable'] = $object;
-		$this->assertSame($this->variableProvider->get('variable'), $object);
-		$this->assertSame($this->variableProvider['variable'], $object);
-	}
+    /**
+     * @test
+     */
+    public function addedObjectsCanBeRetrievedAgainUsingArrayAccess()
+    {
+        $object = 'StringObject';
+        $this->variableProvider['variable'] = $object;
+        $this->assertSame($this->variableProvider->get('variable'), $object);
+        $this->assertSame($this->variableProvider['variable'], $object);
+    }
 
-	/**
-	 * @test
-	 */
-	public function addedObjectsExistInArray() {
-		$object = 'StringObject';
-		$this->variableProvider->add('variable', $object);
-		$this->assertTrue($this->variableProvider->exists('variable'));
-		$this->assertTrue(isset($this->variableProvider['variable']));
-	}
+    /**
+     * @test
+     */
+    public function addedObjectsExistInArray()
+    {
+        $object = 'StringObject';
+        $this->variableProvider->add('variable', $object);
+        $this->assertTrue($this->variableProvider->exists('variable'));
+        $this->assertTrue(isset($this->variableProvider['variable']));
+    }
 
-	/**
-	 * @test
-	 */
-	public function addedObjectsExistInAllIdentifiers() {
-		$object = 'StringObject';
-		$this->variableProvider->add('variable', $object);
-		$this->assertEquals($this->variableProvider->getAllIdentifiers(), array('variable'), 'Added key is not visible in getAllIdentifiers');
-	}
+    /**
+     * @test
+     */
+    public function addedObjectsExistInAllIdentifiers()
+    {
+        $object = 'StringObject';
+        $this->variableProvider->add('variable', $object);
+        $this->assertEquals($this->variableProvider->getAllIdentifiers(), ['variable'], 'Added key is not visible in getAllIdentifiers');
+    }
 
-	/**
-	 * @test
-	 */
-	public function gettingNonexistentValueReturnsNull() {
-		$result = $this->variableProvider->get('nonexistent');
-		$this->assertNull($result);
-	}
+    /**
+     * @test
+     */
+    public function gettingNonexistentValueReturnsNull()
+    {
+        $result = $this->variableProvider->get('nonexistent');
+        $this->assertNull($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function removeReallyRemovesVariables() {
-		$this->variableProvider->add('variable', 'string1');
-		$this->variableProvider->remove('variable');
-		$result = $this->variableProvider->get('variable');
-		$this->assertNull($result);
-	}
+    /**
+     * @test
+     */
+    public function removeReallyRemovesVariables()
+    {
+        $this->variableProvider->add('variable', 'string1');
+        $this->variableProvider->remove('variable');
+        $result = $this->variableProvider->get('variable');
+        $this->assertNull($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function getAllShouldReturnAllVariables() {
-		$this->variableProvider->add('name', 'Simon');
-		$this->assertSame(array('name' => 'Simon'), $this->variableProvider->getAll());
-	}
+    /**
+     * @test
+     */
+    public function getAllShouldReturnAllVariables()
+    {
+        $this->variableProvider->add('name', 'Simon');
+        $this->assertSame(['name' => 'Simon'], $this->variableProvider->getAll());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSleepReturnsExpectedPropertyNames() {
-		$subject = new StandardVariableProvider();
-		$properties = $subject->__sleep();
-		$this->assertContains('variables', $properties);
-	}
+    /**
+     * @test
+     */
+    public function testSleepReturnsExpectedPropertyNames()
+    {
+        $subject = new StandardVariableProvider();
+        $properties = $subject->__sleep();
+        $this->assertContains('variables', $properties);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetScopeCopyReturnsCopyWithSettings() {
-		$subject = new StandardVariableProvider(array('foo' => 'bar', 'settings' => array('baz' => 'bam')));
-		$copy = $subject->getScopeCopy(array('bar' => 'foo'));
-		$this->assertAttributeEquals(array('settings' => array('baz' => 'bam'), 'bar' => 'foo'), 'variables', $copy);
-	}
-
+    /**
+     * @test
+     */
+    public function testGetScopeCopyReturnsCopyWithSettings()
+    {
+        $subject = new StandardVariableProvider(['foo' => 'bar', 'settings' => ['baz' => 'bam']]);
+        $copy = $subject->getScopeCopy(['bar' => 'foo']);
+        $this->assertAttributeEquals(['settings' => ['baz' => 'bam'], 'bar' => 'foo'], 'variables', $copy);
+    }
 }

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -14,100 +14,106 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class VariableExtractorTest
  */
-class VariableExtractorTest extends UnitTestCase {
+class VariableExtractorTest extends UnitTestCase
+{
 
-	/**
-	 * @param mixed $subject
-	 * @param string $path
-	 * @param mixed $expected
-	 * @test
-	 * @dataProvider getPathTestValues
-	 */
-	public function testGetByPath($subject, $path, $expected) {
-		$result = VariableExtractor::extract($subject, $path);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param mixed $subject
+     * @param string $path
+     * @param mixed $expected
+     * @test
+     * @dataProvider getPathTestValues
+     */
+    public function testGetByPath($subject, $path, $expected)
+    {
+        $result = VariableExtractor::extract($subject, $path);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getPathTestValues() {
-		$namedUser = new UserWithoutToString('Foobar Name');
-		$unnamedUser = new UserWithoutToString('');
-		return array(
-			array(NULL, '', NULL),
-			array(array('foo' => 'bar'), 'foo', 'bar'),
-			array(array('foo' => 'bar'), 'foo.invalid', NULL),
-			array(array('user' => $namedUser), 'user.name', 'Foobar Name'),
-			array(array('user' => $unnamedUser), 'user.name', ''),
-			array(array('user' => $namedUser), 'user.named', TRUE),
-			array(array('user' => $unnamedUser), 'user.named', FALSE),
-			array(array('user' => $namedUser), 'user.invalid', NULL),
-			array(array('foodynamicbar' => 'test', 'dyn' => 'dynamic'), 'foo{dyn}bar', 'test'),
-			array(array('foo' => array('dynamic' => array('bar' => 'test')), 'dyn' => 'dynamic'), 'foo.{dyn}.bar', 'test'),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getPathTestValues()
+    {
+        $namedUser = new UserWithoutToString('Foobar Name');
+        $unnamedUser = new UserWithoutToString('');
+        return [
+            [null, '', null],
+            [['foo' => 'bar'], 'foo', 'bar'],
+            [['foo' => 'bar'], 'foo.invalid', null],
+            [['user' => $namedUser], 'user.name', 'Foobar Name'],
+            [['user' => $unnamedUser], 'user.name', ''],
+            [['user' => $namedUser], 'user.named', true],
+            [['user' => $unnamedUser], 'user.named', false],
+            [['user' => $namedUser], 'user.invalid', null],
+            [['foodynamicbar' => 'test', 'dyn' => 'dynamic'], 'foo{dyn}bar', 'test'],
+            [['foo' => ['dynamic' => ['bar' => 'test']], 'dyn' => 'dynamic'], 'foo.{dyn}.bar', 'test'],
+        ];
+    }
 
-	/**
-	 * @param mixed $subject
-	 * @param string $path
-	 * @param mixed $expected
-	 * @test
-	 * @dataProvider getAccessorsForPathTestValues
-	 */
-	public function testGetAccessorsForPath($subject, $path, $expected) {
-		$result = VariableExtractor::extractAccessors($subject, $path);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param mixed $subject
+     * @param string $path
+     * @param mixed $expected
+     * @test
+     * @dataProvider getAccessorsForPathTestValues
+     */
+    public function testGetAccessorsForPath($subject, $path, $expected)
+    {
+        $result = VariableExtractor::extractAccessors($subject, $path);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getAccessorsForPathTestValues() {
-		$namedUser = new UserWithoutToString('Foobar Name');
-		$inArray = array('user' => $namedUser);
-		$inArrayAccess = new StandardVariableProvider($inArray);
-		$inPublic = (object) $inArray;
-		$asArray = VariableExtractor::ACCESSOR_ARRAY;
-		$asGetter = VariableExtractor::ACCESSOR_GETTER;
-		$asPublic = VariableExtractor::ACCESSOR_PUBLICPROPERTY;
-		return array(
-			array(NULL, '', array()),
-			array(array('inArray' => $inArray), 'inArray.user', array($asArray, $asArray)),
-			array(array('inArray' => $inArray), 'inArray.user.name', array($asArray, $asArray, $asGetter)),
-			array(array('inArrayAccess' => $inArrayAccess), 'inArrayAccess.user.name', array($asArray, $asArray, $asGetter)),
-			array(array('inArrayAccessWithGetter' => $inArrayAccess), 'inArrayAccessWithGetter.allIdentifiers', array($asArray, $asGetter)),
-			array(array('inPublic' => $inPublic), 'inPublic.user.name', array($asArray, $asPublic, $asGetter))
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getAccessorsForPathTestValues()
+    {
+        $namedUser = new UserWithoutToString('Foobar Name');
+        $inArray = ['user' => $namedUser];
+        $inArrayAccess = new StandardVariableProvider($inArray);
+        $inPublic = (object) $inArray;
+        $asArray = VariableExtractor::ACCESSOR_ARRAY;
+        $asGetter = VariableExtractor::ACCESSOR_GETTER;
+        $asPublic = VariableExtractor::ACCESSOR_PUBLICPROPERTY;
+        return [
+            [null, '', []],
+            [['inArray' => $inArray], 'inArray.user', [$asArray, $asArray]],
+            [['inArray' => $inArray], 'inArray.user.name', [$asArray, $asArray, $asGetter]],
+            [['inArrayAccess' => $inArrayAccess], 'inArrayAccess.user.name', [$asArray, $asArray, $asGetter]],
+            [['inArrayAccessWithGetter' => $inArrayAccess], 'inArrayAccessWithGetter.allIdentifiers', [$asArray, $asGetter]],
+            [['inPublic' => $inPublic], 'inPublic.user.name', [$asArray, $asPublic, $asGetter]]
+        ];
+    }
 
-	/**
-	 * @param mixed $subject
-	 * @param string $path
-	 * @param string $accessor
-	 * @param mixed $expected
-	 * @test
-	 * @dataProvider getExtractRedectAccessorTestValues
-	 */
-	public function testExtractRedetectsAccessorIfUnusableAccessorPassed($subject, $path, $accessor, $expected) {
-		$result = VariableExtractor::extract($subject, $path, array($accessor));
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param mixed $subject
+     * @param string $path
+     * @param string $accessor
+     * @param mixed $expected
+     * @test
+     * @dataProvider getExtractRedectAccessorTestValues
+     */
+    public function testExtractRedetectsAccessorIfUnusableAccessorPassed($subject, $path, $accessor, $expected)
+    {
+        $result = VariableExtractor::extract($subject, $path, [$accessor]);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getExtractRedectAccessorTestValues() {
-		return array(
-			array(array('test' => 'test'), 'test', NULL, 'test'),
-			array(array('test' => 'test'), 'test', 'garbageextractionname', 'test'),
-			array(array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_PUBLICPROPERTY, 'test'),
-			array(array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_GETTER, 'test'),
-			array(array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_ASSERTER, 'test'),
-			array((object) array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_ARRAY, 'test'),
-			array((object) array('test' => 'test'), 'test', VariableExtractor::ACCESSOR_ARRAY, 'test'),
-			array(new \ArrayObject(array('testProperty' => 'testValue')), 'testProperty', NULL, 'testValue'),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getExtractRedectAccessorTestValues()
+    {
+        return [
+            [['test' => 'test'], 'test', null, 'test'],
+            [['test' => 'test'], 'test', 'garbageextractionname', 'test'],
+            [['test' => 'test'], 'test', VariableExtractor::ACCESSOR_PUBLICPROPERTY, 'test'],
+            [['test' => 'test'], 'test', VariableExtractor::ACCESSOR_GETTER, 'test'],
+            [['test' => 'test'], 'test', VariableExtractor::ACCESSOR_ASSERTER, 'test'],
+            [(object) ['test' => 'test'], 'test', VariableExtractor::ACCESSOR_ARRAY, 'test'],
+            [(object) ['test' => 'test'], 'test', VariableExtractor::ACCESSOR_ARRAY, 'test'],
+            [new \ArrayObject(['testProperty' => 'testValue']), 'testProperty', null, 'testValue'],
+        ];
+    }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -20,311 +20,386 @@ use TYPO3Fluid\Fluid\ViewHelpers\ThenViewHelper;
 /**
  * Testcase for Condition ViewHelper
  */
-class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase {
+class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var AbstractConditionViewHelper|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $viewHelper;
+    /**
+     * @var AbstractConditionViewHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, array('renderChildren', 'hasArgument'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['renderChildren', 'hasArgument']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getCompileTestValues
-	 * @param array $childNodes
-	 * @param string $expected
-	 */
-	public function testCompileReturnsAndAssignsExpectedVariables(array $childNodes, $expected) {
-		$node = new ViewHelperNode($this->renderingContext, 'f', 'if', array(), new ParsingState());
-		foreach ($childNodes as $childNode) {
-			$node->addChildNode($childNode);
-		}
-		$compiler = $this->getMock(
-			TemplateCompiler::class,
-			array('wrapChildNodesInClosure', 'wrapViewHelperNodeArgumentEvaluationInClosure')
-		);
-		$compiler->setRenderingContext($this->renderingContext);
-		$compiler->expects($this->any())->method('wrapChildNodesInClosure')->willReturn('closure');
-		$compiler->expects($this->any())->method('wrapViewHelperNodeArgumentEvaluationInClosure')->willReturn('arg-closure');
-		$init = '';
-		$this->viewHelper->compile('foobar-args', 'foobar-closure', $init, $node, $compiler);
-		$this->assertEquals($expected, $init);
-	}
+    /**
+     * @test
+     * @dataProvider getCompileTestValues
+     * @param array $childNodes
+     * @param string $expected
+     */
+    public function testCompileReturnsAndAssignsExpectedVariables(array $childNodes, $expected)
+    {
+        $node = new ViewHelperNode($this->renderingContext, 'f', 'if', [], new ParsingState());
+        foreach ($childNodes as $childNode) {
+            $node->addChildNode($childNode);
+        }
+        $compiler = $this->getMock(
+            TemplateCompiler::class,
+            ['wrapChildNodesInClosure', 'wrapViewHelperNodeArgumentEvaluationInClosure']
+        );
+        $compiler->setRenderingContext($this->renderingContext);
+        $compiler->expects($this->any())->method('wrapChildNodesInClosure')->willReturn('closure');
+        $compiler->expects($this->any())->method('wrapViewHelperNodeArgumentEvaluationInClosure')->willReturn('arg-closure');
+        $init = '';
+        $this->viewHelper->compile('foobar-args', 'foobar-closure', $init, $node, $compiler);
+        $this->assertEquals($expected, $init);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getCompileTestValues() {
-		$state = new ParsingState();
-		$context = new RenderingContextFixture();
-		return array(
-			array(
-				array(),
-				'foobar-args[\'__thenClosure\'] = foobar-closure;' . chr(10)
-			),
-			array(
-				array(new ViewHelperNode($context, 'f', 'then', array(), $state)),
-				'foobar-args[\'__thenClosure\'] = closure;' . chr(10)
-			),
-			array(
-				array(new ViewHelperNode($context, 'f', 'else', array(), $state)),
-				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
-			),
-			array(
-				array(
-					new ViewHelperNode($context, 'f', 'then', array(), $state),
-					new ViewHelperNode($context, 'f', 'else', array(), $state)
-				),
-				'foobar-args[\'__thenClosure\'] = closure;' . chr(10) .
-				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
-			),
-			array(
-				array(
-					new ViewHelperNode($context, 'f', 'then', array(), $state),
-					new ViewHelperNode($context, 'f', 'else', array('if' => new BooleanNode(new RootNode())), $state),
-					new ViewHelperNode($context, 'f', 'else', array(), $state)
-				),
-				'foobar-args[\'__thenClosure\'] = closure;' . chr(10) .
-				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10) .
-				'foobar-args[\'__elseifClosures\'][] = arg-closure;' . chr(10) .
-				'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
-			),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getCompileTestValues()
+    {
+        $state = new ParsingState();
+        $context = new RenderingContextFixture();
+        return [
+            [
+                [],
+                'foobar-args[\'__thenClosure\'] = foobar-closure;' . chr(10)
+            ],
+            [
+                [new ViewHelperNode($context, 'f', 'then', [], $state)],
+                'foobar-args[\'__thenClosure\'] = closure;' . chr(10)
+            ],
+            [
+                [new ViewHelperNode($context, 'f', 'else', [], $state)],
+                'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
+            ],
+            [
+                [
+                    new ViewHelperNode($context, 'f', 'then', [], $state),
+                    new ViewHelperNode($context, 'f', 'else', [], $state)
+                ],
+                'foobar-args[\'__thenClosure\'] = closure;' . chr(10) .
+                'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
+            ],
+            [
+                [
+                    new ViewHelperNode($context, 'f', 'then', [], $state),
+                    new ViewHelperNode($context, 'f', 'else', ['if' => new BooleanNode(new RootNode())], $state),
+                    new ViewHelperNode($context, 'f', 'else', [], $state)
+                ],
+                'foobar-args[\'__thenClosure\'] = closure;' . chr(10) .
+                'foobar-args[\'__elseClosures\'][] = closure;' . chr(10) .
+                'foobar-args[\'__elseifClosures\'][] = arg-closure;' . chr(10) .
+                'foobar-args[\'__elseClosures\'][] = closure;' . chr(10)
+            ],
+        ];
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getRenderFromArgumentsTestValues
-	 * @param array $arguments
-	 * @param $expected
-	 */
-	public function testRenderFromArgumentsReturnsExpectedValue(array $arguments, $expected) {
-		$viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, array('dummy'));
-		$viewHelper->setArguments($arguments);
-		$viewHelper->setViewHelperNode(new ViewHelperNode($this->renderingContext, 'f', 'if', array(), new ParsingState()));
-		$result = AbstractConditionViewHelper::renderStatic($arguments, function() { return ''; }, $this->renderingContext);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @test
+     * @dataProvider getRenderFromArgumentsTestValues
+     * @param array $arguments
+     * @param $expected
+     */
+    public function testRenderFromArgumentsReturnsExpectedValue(array $arguments, $expected)
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['dummy']);
+        $viewHelper->setArguments($arguments);
+        $viewHelper->setViewHelperNode(new ViewHelperNode($this->renderingContext, 'f', 'if', [], new ParsingState()));
+        $result = AbstractConditionViewHelper::renderStatic($arguments, function () {
+            return '';
+        }, $this->renderingContext);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderFromArgumentsTestValues() {
-		return array(
-			array(array('condition' => FALSE), NULL),
-			array(array('condition' => TRUE, '__thenClosure' => function() { return 'foobar'; }), 'foobar'),
-			array(array('condition' => TRUE, '__elseClosures' => array(function() { return 'foobar'; })), ''),
-			array(array('condition' => TRUE), ''),
-			array(array('condition' => TRUE), NULL),
-			array(array('condition' => FALSE, '__elseClosures' => array(function() { return 'foobar'; })), 'foobar'),
-			array(array('condition' => FALSE, '__elseifClosures' => array(
-				function() { return FALSE; },
-				function() { return TRUE; }
-			), '__elseClosures' => array(
-				function() { return 'baz'; },
-				function() { return 'foobar'; }
-			)), 'foobar'),
-			array(array('condition' => FALSE, '__elseifClosures' => array(
-				function() { return FALSE; },
-				function() { return FALSE; }
-			), '__elseClosures' => array(
-				function() { return 'baz'; },
-				function() { return 'foobar'; },
-				function() { return 'barbar'; }
-			)), 'barbar'),
-			array(array('condition' => FALSE, '__thenClosure' => function() { return 'foobar'; }), ''),
-			array(array('condition' => FALSE), ''),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getRenderFromArgumentsTestValues()
+    {
+        return [
+            [['condition' => false], null],
+            [['condition' => true, '__thenClosure' => function () {
+                return 'foobar';
+            }], 'foobar'],
+            [['condition' => true, '__elseClosures' => [function () {
+                return 'foobar';
+            }]], ''],
+            [['condition' => true], ''],
+            [['condition' => true], null],
+            [['condition' => false, '__elseClosures' => [function () {
+                return 'foobar';
+            }]], 'foobar'],
+            [['condition' => false, '__elseifClosures' => [
+                function () {
+                    return false;
+                },
+                function () {
+                    return true;
+                }
+            ], '__elseClosures' => [
+                function () {
+                    return 'baz';
+                },
+                function () {
+                    return 'foobar';
+                }
+            ]], 'foobar'],
+            [['condition' => false, '__elseifClosures' => [
+                function () {
+                    return false;
+                },
+                function () {
+                    return false;
+                }
+            ], '__elseClosures' => [
+                function () {
+                    return 'baz';
+                },
+                function () {
+                    return 'foobar';
+                },
+                function () {
+                    return 'barbar';
+                }
+            ]], 'barbar'],
+            [['condition' => false, '__thenClosure' => function () {
+                return 'foobar';
+            }], ''],
+            [['condition' => false], ''],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderThenChildReturnsAllChildrenIfNoThenViewHelperChildExists() {
-		$this->viewHelper->expects($this->any())->method('renderChildren')->will($this->returnValue('foo'));
+    /**
+     * @test
+     */
+    public function renderThenChildReturnsAllChildrenIfNoThenViewHelperChildExists()
+    {
+        $this->viewHelper->expects($this->any())->method('renderChildren')->will($this->returnValue('foo'));
 
-		$actualResult = $this->viewHelper->_call('renderThenChild');
-		$this->assertEquals('foo', $actualResult);
-	}
+        $actualResult = $this->viewHelper->_call('renderThenChild');
+        $this->assertEquals('foo', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderThenChildReturnsThenViewHelperChildIfConditionIsTrueAndThenViewHelperChildExists() {
-		$mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', FALSE);
-		$mockThenViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ThenViewHelper::class));
-		$mockThenViewHelperNode->expects($this->at(1))->method('evaluate')->with($this->renderingContext)->will($this->returnValue('ThenViewHelperResults'));
+    /**
+     * @test
+     */
+    public function renderThenChildReturnsThenViewHelperChildIfConditionIsTrueAndThenViewHelperChildExists()
+    {
+        $mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate'], [], '', false);
+        $mockThenViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ThenViewHelper::class));
+        $mockThenViewHelperNode->expects($this->at(1))->method('evaluate')->with($this->renderingContext)->will($this->returnValue('ThenViewHelperResults'));
 
-		$this->viewHelper->setChildNodes(array($mockThenViewHelperNode));
-		$actualResult = $this->viewHelper->_call('renderThenChild');
-		$this->assertEquals('ThenViewHelperResults', $actualResult);
-	}
+        $this->viewHelper->setChildNodes([$mockThenViewHelperNode]);
+        $actualResult = $this->viewHelper->_call('renderThenChild');
+        $this->assertEquals('ThenViewHelperResults', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderThenChildReturnsValueOfThenArgumentIfItIsSpecified() {
-		$this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('then')->will($this->returnValue(TRUE));
-		$this->arguments['then'] = 'ThenArgument';
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
+    /**
+     * @test
+     */
+    public function renderThenChildReturnsValueOfThenArgumentIfItIsSpecified()
+    {
+        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('then')->will($this->returnValue(true));
+        $this->arguments['then'] = 'ThenArgument';
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
-		$actualResult = $this->viewHelper->_call('renderThenChild');
-		$this->assertEquals('ThenArgument', $actualResult);
-	}
+        $actualResult = $this->viewHelper->_call('renderThenChild');
+        $this->assertEquals('ThenArgument', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderThenChildReturnsEmptyStringIfChildNodesOnlyContainElseViewHelper() {
-		$mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', FALSE);
-		$mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
-		$this->viewHelper->setChildNodes(array($mockElseViewHelperNode));
-		$this->viewHelper->expects($this->never())->method('renderChildren')->will($this->returnValue('Child nodes'));
+    /**
+     * @test
+     */
+    public function renderThenChildReturnsEmptyStringIfChildNodesOnlyContainElseViewHelper()
+    {
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate'], [], '', false);
+        $mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
+        $this->viewHelper->setChildNodes([$mockElseViewHelperNode]);
+        $this->viewHelper->expects($this->never())->method('renderChildren')->will($this->returnValue('Child nodes'));
 
-		$actualResult = $this->viewHelper->_call('renderThenChild');
-		$this->assertEquals('', $actualResult);
-	}
+        $actualResult = $this->viewHelper->_call('renderThenChild');
+        $this->assertEquals('', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderElseChildReturnsEmptyStringIfConditionIsFalseAndNoElseViewHelperChildExists() {
-		$actualResult = $this->viewHelper->_call('renderElseChild');
-		$this->assertEquals('', $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderElseChildReturnsEmptyStringIfConditionIsFalseAndNoElseViewHelperChildExists()
+    {
+        $actualResult = $this->viewHelper->_call('renderElseChild');
+        $this->assertEquals('', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderElseChildRendersElseViewHelperChildIfConditionIsFalseAndNoThenViewHelperChildExists() {
-		$mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', FALSE);
-		$mockElseViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
-		$mockElseViewHelperNode->expects($this->at(1))->method('evaluate')->with($this->renderingContext)->will($this->returnValue('ElseViewHelperResults'));
+    /**
+     * @test
+     */
+    public function renderElseChildRendersElseViewHelperChildIfConditionIsFalseAndNoThenViewHelperChildExists()
+    {
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate', 'setRenderingContext'], [], '', false);
+        $mockElseViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
+        $mockElseViewHelperNode->expects($this->at(1))->method('evaluate')->with($this->renderingContext)->will($this->returnValue('ElseViewHelperResults'));
 
-		$this->viewHelper->setChildNodes(array($mockElseViewHelperNode));
-		$actualResult = $this->viewHelper->_call('renderElseChild');
-		$this->assertEquals('ElseViewHelperResults', $actualResult);
-	}
+        $this->viewHelper->setChildNodes([$mockElseViewHelperNode]);
+        $actualResult = $this->viewHelper->_call('renderElseChild');
+        $this->assertEquals('ElseViewHelperResults', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function thenArgumentHasPriorityOverChildNodesIfConditionIsTrue() {
-		$mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', FALSE);
-		$mockThenViewHelperNode->expects($this->never())->method('evaluate');
+    /**
+     * @test
+     */
+    public function thenArgumentHasPriorityOverChildNodesIfConditionIsTrue()
+    {
+        $mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate', 'setRenderingContext'], [], '', false);
+        $mockThenViewHelperNode->expects($this->never())->method('evaluate');
 
-		$this->viewHelper->setChildNodes(array($mockThenViewHelperNode));
+        $this->viewHelper->setChildNodes([$mockThenViewHelperNode]);
 
-		$this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('then')->will($this->returnValue(TRUE));
-		$this->arguments['then'] = 'ThenArgument';
+        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('then')->will($this->returnValue(true));
+        $this->arguments['then'] = 'ThenArgument';
 
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
-		$actualResult = $this->viewHelper->_call('renderThenChild');
-		$this->assertEquals('ThenArgument', $actualResult);
-	}
+        $actualResult = $this->viewHelper->_call('renderThenChild');
+        $this->assertEquals('ThenArgument', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsValueOfElseArgumentIfConditionIsFalse() {
-		$this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('else')->will($this->returnValue(TRUE));
-		$this->arguments['else'] = 'ElseArgument';
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
+    /**
+     * @test
+     */
+    public function renderReturnsValueOfElseArgumentIfConditionIsFalse()
+    {
+        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('else')->will($this->returnValue(true));
+        $this->arguments['else'] = 'ElseArgument';
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
-		$actualResult = $this->viewHelper->_call('renderElseChild');
-		$this->assertEquals('ElseArgument', $actualResult);
-	}
+        $actualResult = $this->viewHelper->_call('renderElseChild');
+        $this->assertEquals('ElseArgument', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function elseArgumentHasPriorityOverChildNodesIfConditionIsFalse() {
-		$mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', FALSE);
-		$mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
-		$mockElseViewHelperNode->expects($this->never())->method('evaluate');
+    /**
+     * @test
+     */
+    public function elseArgumentHasPriorityOverChildNodesIfConditionIsFalse()
+    {
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate', 'setRenderingContext'], [], '', false);
+        $mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
+        $mockElseViewHelperNode->expects($this->never())->method('evaluate');
 
-		$this->viewHelper->setChildNodes(array($mockElseViewHelperNode));
+        $this->viewHelper->setChildNodes([$mockElseViewHelperNode]);
 
-		$this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('else')->will($this->returnValue(TRUE));
-		$this->arguments['else'] = 'ElseArgument';
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('else')->will($this->returnValue(true));
+        $this->arguments['else'] = 'ElseArgument';
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
-		$actualResult = $this->viewHelper->_call('renderElseChild');
-		$this->assertEquals('ElseArgument', $actualResult);
-	}
+        $actualResult = $this->viewHelper->_call('renderElseChild');
+        $this->assertEquals('ElseArgument', $actualResult);
+    }
 
-	/**
-	 * @param array $arguments
-	 * @param mixed $expected
-	 * @test
-	 * @dataProvider getRenderStaticTestValues
-	 */
-	public function testRenderStatic(array $arguments, $expected) {
-		$this->viewHelper->setArguments($arguments);
-		$result = call_user_func_array(
-			array($this->viewHelper, 'renderStatic'),
-			array($arguments, function() { return ''; }, new RenderingContextFixture())
-		);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param array $arguments
+     * @param mixed $expected
+     * @test
+     * @dataProvider getRenderStaticTestValues
+     */
+    public function testRenderStatic(array $arguments, $expected)
+    {
+        $this->viewHelper->setArguments($arguments);
+        $result = call_user_func_array(
+            [$this->viewHelper, 'renderStatic'],
+            [$arguments, function () {
+                return '';
+            }, new RenderingContextFixture()]
+        );
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderStaticTestValues() {
-		return array(
-			'standard then argument' => array(array('condition' => TRUE, 'then' => 'yes'), 'yes'),
-			'then argument closure' => array(array('condition' => TRUE, '__thenClosure' => function() { return 'yes'; }), 'yes'),
-			'standard else argument' => array(array('condition' => FALSE, 'else' => 'no'), 'no'),
-			'single else argument closure' => array(array('condition' => FALSE, '__elseClosures' => array(function() { return 'no'; })), 'no'),
-			'else if closures first match true' => array(
-				array(
-					'condition' => FALSE,
-					'__elseClosures' => array(
-						function() { return 'first-else'; },
-						function() { return 'second-else'; }
-					),
-					'__elseifClosures' => array(
-						function() { return TRUE; },
-						function() { throw new \RuntimeException('Test called closure which must not be called'); }
-					)
-				),
-				'first-else'
-			),
-			'else if closures second match true' => array(
-				array(
-					'condition' => FALSE,
-					'__elseClosures' => array(
-						function() { return 'first-else'; },
-						function() { return 'second-else'; }
-					),
-					'__elseifClosures' => array(
-						function() { return FALSE; },
-						function() { return TRUE; }
-					)
-				),
-				'second-else'
-			),
-			'else if closures none match' => array(
-				array(
-					'condition' => FALSE,
-					'__elseClosures' => array(
-						function() { return 'first-else'; },
-						function() { return 'second-else'; }
-					),
-					'__elseifClosures' => array(
-						function() { return FALSE; },
-						function() { return FALSE; }
-					)
-				),
-				''
-			),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getRenderStaticTestValues()
+    {
+        return [
+            'standard then argument' => [['condition' => true, 'then' => 'yes'], 'yes'],
+            'then argument closure' => [['condition' => true, '__thenClosure' => function () {
+                return 'yes';
+            }], 'yes'],
+            'standard else argument' => [['condition' => false, 'else' => 'no'], 'no'],
+            'single else argument closure' => [['condition' => false, '__elseClosures' => [function () {
+                return 'no';
+            }]], 'no'],
+            'else if closures first match true' => [
+                [
+                    'condition' => false,
+                    '__elseClosures' => [
+                        function () {
+                            return 'first-else';
+                        },
+                        function () {
+                            return 'second-else';
+                        }
+                    ],
+                    '__elseifClosures' => [
+                        function () {
+                            return true;
+                        },
+                        function () {
+                            throw new \RuntimeException('Test called closure which must not be called');
+                        }
+                    ]
+                ],
+                'first-else'
+            ],
+            'else if closures second match true' => [
+                [
+                    'condition' => false,
+                    '__elseClosures' => [
+                        function () {
+                            return 'first-else';
+                        },
+                        function () {
+                            return 'second-else';
+                        }
+                    ],
+                    '__elseifClosures' => [
+                        function () {
+                            return false;
+                        },
+                        function () {
+                            return true;
+                        }
+                    ]
+                ],
+                'second-else'
+            ],
+            'else if closures none match' => [
+                [
+                    'condition' => false,
+                    '__elseClosures' => [
+                        function () {
+                            return 'first-else';
+                        },
+                        function () {
+                            return 'second-else';
+                        }
+                    ],
+                    '__elseifClosures' => [
+                        function () {
+                            return false;
+                        },
+                        function () {
+                            return false;
+                        }
+                    ]
+                ],
+                ''
+            ],
+        ];
+    }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -14,166 +14,190 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for TagBasedViewHelper
  */
-class AbstractTagBasedViewHelperTest extends UnitTestCase {
+class AbstractTagBasedViewHelperTest extends UnitTestCase
+{
 
-	public function setUp() {
-		$this->viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, array('dummy'), array(), '', FALSE);
-	}
+    public function setUp()
+    {
+        $this->viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, ['dummy'], [], '', false);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testConstructorSetsTagBuilder() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractTagBasedViewHelper::class,
-			array('dummy'),
-			array(), '', TRUE
-		);
-		$this->assertAttributeInstanceOf(TagBuilder::class, 'tag', $viewHelper);
-	}
+    /**
+     * @test
+     */
+    public function testConstructorSetsTagBuilder()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            true
+        );
+        $this->assertAttributeInstanceOf(TagBuilder::class, 'tag', $viewHelper);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetTagBuilderSetsTagBuilder() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractTagBasedViewHelper::class,
-			array('dummy'),
-			array(), '', FALSE
-		);
-		$tagBuilder = new TagBuilder('div');
-		$viewHelper->setTagBuilder($tagBuilder);
-		$this->assertAttributeSame($tagBuilder, 'tag', $viewHelper);
-	}
+    /**
+     * @test
+     */
+    public function testSetTagBuilderSetsTagBuilder()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            false
+        );
+        $tagBuilder = new TagBuilder('div');
+        $viewHelper->setTagBuilder($tagBuilder);
+        $this->assertAttributeSame($tagBuilder, 'tag', $viewHelper);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderCallsRenderOnTagBuilder() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractTagBasedViewHelper::class,
-			array('dummy'),
-			array(), '', FALSE
-		);
-		$tagBuilder = $this->getMock(TagBuilder::class, array('render'));
-		$tagBuilder->expects($this->once())->method('render')->willReturn('foobar');
-		$viewHelper->setTagBuilder($tagBuilder);
-		$this->assertEquals('foobar', $viewHelper->render());
-	}
+    /**
+     * @test
+     */
+    public function testRenderCallsRenderOnTagBuilder()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            false
+        );
+        $tagBuilder = $this->getMock(TagBuilder::class, ['render']);
+        $tagBuilder->expects($this->once())->method('render')->willReturn('foobar');
+        $viewHelper->setTagBuilder($tagBuilder);
+        $this->assertEquals('foobar', $viewHelper->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArgumentsRegistersExpectedArguments() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractTagBasedViewHelper::class,
-			array('registerArgument'),
-			array(), '', FALSE
-		);
-		$viewHelper->expects($this->at(0))->method('registerArgument')->with('additionalAttributes');
-		$viewHelper->expects($this->at(1))->method('registerArgument')->with('data');
-		$viewHelper->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['registerArgument'],
+            [],
+            '',
+            false
+        );
+        $viewHelper->expects($this->at(0))->method('registerArgument')->with('additionalAttributes');
+        $viewHelper->expects($this->at(1))->method('registerArgument')->with('data');
+        $viewHelper->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function oneTagAttributeIsRenderedCorrectly() {
-		$mockTagBuilder = $this->getMock(TagBuilder::class, array('addAttribute'), array(), '', FALSE);
-		$mockTagBuilder->expects($this->once())->method('addAttribute')->with('foo', 'bar');
-		$this->viewHelper->setTagBuilder($mockTagBuilder);
+    /**
+     * @test
+     */
+    public function oneTagAttributeIsRenderedCorrectly()
+    {
+        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
+        $mockTagBuilder->expects($this->once())->method('addAttribute')->with('foo', 'bar');
+        $this->viewHelper->setTagBuilder($mockTagBuilder);
 
-		$this->viewHelper->_call('registerTagAttribute', 'foo', 'string', 'Description', FALSE);
-		$arguments = array('foo' => 'bar');
-		$this->viewHelper->setArguments($arguments);
-		$this->viewHelper->initialize();
-	}
+        $this->viewHelper->_call('registerTagAttribute', 'foo', 'string', 'Description', false);
+        $arguments = ['foo' => 'bar'];
+        $this->viewHelper->setArguments($arguments);
+        $this->viewHelper->initialize();
+    }
 
-	/**
-	 * @test
-	 */
-	public function additionalTagAttributesAreRenderedCorrectly() {
-		$mockTagBuilder = $this->getMock(TagBuilder::class, array('addAttribute'), array(), '', FALSE);
-		$mockTagBuilder->expects($this->once())->method('addAttribute')->with('foo', 'bar');
-		$this->viewHelper->setTagBuilder($mockTagBuilder);
+    /**
+     * @test
+     */
+    public function additionalTagAttributesAreRenderedCorrectly()
+    {
+        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
+        $mockTagBuilder->expects($this->once())->method('addAttribute')->with('foo', 'bar');
+        $this->viewHelper->setTagBuilder($mockTagBuilder);
 
-		$this->viewHelper->_call('registerTagAttribute', 'foo', 'string', 'Description', FALSE);
-		$arguments = array('additionalAttributes' => array('foo' => 'bar'));
-		$this->viewHelper->setArguments($arguments);
-		$this->viewHelper->initialize();
-	}
+        $this->viewHelper->_call('registerTagAttribute', 'foo', 'string', 'Description', false);
+        $arguments = ['additionalAttributes' => ['foo' => 'bar']];
+        $this->viewHelper->setArguments($arguments);
+        $this->viewHelper->initialize();
+    }
 
-	/**
-	 * @test
-	 */
-	public function dataAttributesAreRenderedCorrectly() {
-		$mockTagBuilder = $this->getMock(TagBuilder::class, array('addAttribute'), array(), '', FALSE);
-		$mockTagBuilder->expects($this->at(0))->method('addAttribute')->with('data-foo', 'bar');
-		$mockTagBuilder->expects($this->at(1))->method('addAttribute')->with('data-baz', 'foos');
-		$this->viewHelper->setTagBuilder($mockTagBuilder);
+    /**
+     * @test
+     */
+    public function dataAttributesAreRenderedCorrectly()
+    {
+        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
+        $mockTagBuilder->expects($this->at(0))->method('addAttribute')->with('data-foo', 'bar');
+        $mockTagBuilder->expects($this->at(1))->method('addAttribute')->with('data-baz', 'foos');
+        $this->viewHelper->setTagBuilder($mockTagBuilder);
 
-		$arguments = array('data' => array('foo' => 'bar', 'baz' => 'foos'));
-		$this->viewHelper->setArguments($arguments);
-		$this->viewHelper->initialize();
-	}
+        $arguments = ['data' => ['foo' => 'bar', 'baz' => 'foos']];
+        $this->viewHelper->setArguments($arguments);
+        $this->viewHelper->initialize();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testValidateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractTagBasedViewHelper::class,
-			array('dummy'),
-			array(), '', FALSE
-		);
-		$this->setExpectedException(Exception::class);
-		$viewHelper->validateAdditionalArguments(array('foo' => 'bar'));
-	}
+    /**
+     * @test
+     */
+    public function testValidateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            false
+        );
+        $this->setExpectedException(Exception::class);
+        $viewHelper->validateAdditionalArguments(['foo' => 'bar']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testHandleAdditionalArgumentsSetsTagAttributesForDataArguments() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractTagBasedViewHelper::class,
-			array('dummy'),
-			array(), '', FALSE
-		);
-		$tagBuilder = $this->getMock(TagBuilder::class, array('addAttribute'));
-		$tagBuilder->expects($this->at(0))->method('addAttribute')->with('data-foo', 'foo');
-		$tagBuilder->expects($this->at(1))->method('addAttribute')->with('data-bar', 'bar');
-		$viewHelper->setTagBuilder($tagBuilder);
-		$viewHelper->handleAdditionalArguments(array('data-foo' => 'foo', 'data-bar' => 'bar'));
-	}
+    /**
+     * @test
+     */
+    public function testHandleAdditionalArgumentsSetsTagAttributesForDataArguments()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            false
+        );
+        $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
+        $tagBuilder->expects($this->at(0))->method('addAttribute')->with('data-foo', 'foo');
+        $tagBuilder->expects($this->at(1))->method('addAttribute')->with('data-bar', 'bar');
+        $viewHelper->setTagBuilder($tagBuilder);
+        $viewHelper->handleAdditionalArguments(['data-foo' => 'foo', 'data-bar' => 'bar']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function standardTagAttributesAreRegistered() {
-		$mockTagBuilder = $this->getMock(TagBuilder::class, array('addAttribute'), array(), '', FALSE);
-		$mockTagBuilder->expects($this->at(0))->method('addAttribute')->with('class', 'classAttribute');
-		$mockTagBuilder->expects($this->at(1))->method('addAttribute')->with('dir', 'dirAttribute');
-		$mockTagBuilder->expects($this->at(2))->method('addAttribute')->with('id', 'idAttribute');
-		$mockTagBuilder->expects($this->at(3))->method('addAttribute')->with('lang', 'langAttribute');
-		$mockTagBuilder->expects($this->at(4))->method('addAttribute')->with('style', 'styleAttribute');
-		$mockTagBuilder->expects($this->at(5))->method('addAttribute')->with('title', 'titleAttribute');
-		$mockTagBuilder->expects($this->at(6))->method('addAttribute')->with('accesskey', 'accesskeyAttribute');
-		$mockTagBuilder->expects($this->at(7))->method('addAttribute')->with('tabindex', 'tabindexAttribute');
-		$this->viewHelper->setTagBuilder($mockTagBuilder);
+    /**
+     * @test
+     */
+    public function standardTagAttributesAreRegistered()
+    {
+        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
+        $mockTagBuilder->expects($this->at(0))->method('addAttribute')->with('class', 'classAttribute');
+        $mockTagBuilder->expects($this->at(1))->method('addAttribute')->with('dir', 'dirAttribute');
+        $mockTagBuilder->expects($this->at(2))->method('addAttribute')->with('id', 'idAttribute');
+        $mockTagBuilder->expects($this->at(3))->method('addAttribute')->with('lang', 'langAttribute');
+        $mockTagBuilder->expects($this->at(4))->method('addAttribute')->with('style', 'styleAttribute');
+        $mockTagBuilder->expects($this->at(5))->method('addAttribute')->with('title', 'titleAttribute');
+        $mockTagBuilder->expects($this->at(6))->method('addAttribute')->with('accesskey', 'accesskeyAttribute');
+        $mockTagBuilder->expects($this->at(7))->method('addAttribute')->with('tabindex', 'tabindexAttribute');
+        $this->viewHelper->setTagBuilder($mockTagBuilder);
 
-		$arguments = array(
-			'class' => 'classAttribute',
-			'dir' => 'dirAttribute',
-			'id' => 'idAttribute',
-			'lang' => 'langAttribute',
-			'style' => 'styleAttribute',
-			'title' => 'titleAttribute',
-			'accesskey' => 'accesskeyAttribute',
-			'tabindex' => 'tabindexAttribute'
-		);
-		$this->viewHelper->_call('registerUniversalTagAttributes');
-		$this->viewHelper->setArguments($arguments);
-		$this->viewHelper->initializeArguments();
-		$this->viewHelper->initialize();
-	}
+        $arguments = [
+            'class' => 'classAttribute',
+            'dir' => 'dirAttribute',
+            'id' => 'idAttribute',
+            'lang' => 'langAttribute',
+            'style' => 'styleAttribute',
+            'title' => 'titleAttribute',
+            'accesskey' => 'accesskeyAttribute',
+            'tabindex' => 'tabindexAttribute'
+        ];
+        $this->viewHelper->_call('registerUniversalTagAttributes');
+        $this->viewHelper->setArguments($arguments);
+        $this->viewHelper->initializeArguments();
+        $this->viewHelper->initialize();
+    }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -23,342 +23,371 @@ use TYPO3Fluid\Fluid\View\TemplateView;
  * Testcase for AbstractViewHelper
  *
  */
-class AbstractViewHelperTest extends UnitTestCase {
+class AbstractViewHelperTest extends UnitTestCase
+{
 
-	/**
-	 * @var array
-	 */
-	protected $fixtureMethodParameters = array(
-		'param1' => array(
-			'position' => 0,
-			'optional' => FALSE,
-			'type' => 'integer',
-			'defaultValue' => NULL
-		),
-		'param2' => array(
-			'position' => 1,
-			'optional' => FALSE,
-			'type' => 'array',
-			'array' => TRUE,
-			'defaultValue' => NULL
-		),
-		'param3' => array(
-			'position' => 2,
-			'optional' => TRUE,
-			'type' => 'string',
-			'array' => FALSE,
-			'defaultValue' => 'default'
-		),
-	);
+    /**
+     * @var array
+     */
+    protected $fixtureMethodParameters = [
+        'param1' => [
+            'position' => 0,
+            'optional' => false,
+            'type' => 'integer',
+            'defaultValue' => null
+        ],
+        'param2' => [
+            'position' => 1,
+            'optional' => false,
+            'type' => 'array',
+            'array' => true,
+            'defaultValue' => null
+        ],
+        'param3' => [
+            'position' => 2,
+            'optional' => true,
+            'type' => 'string',
+            'array' => false,
+            'defaultValue' => 'default'
+        ],
+    ];
 
-	/**
-	 * @var array
-	 */
-	protected $fixtureMethodTags = array(
-		'param' => array(
-			'integer $param1 P1 Stuff',
-			'array $param2 P2 Stuff',
-			'string $param3 P3 Stuff'
-		)
-	);
+    /**
+     * @var array
+     */
+    protected $fixtureMethodTags = [
+        'param' => [
+            'integer $param1 P1 Stuff',
+            'array $param2 P2 Stuff',
+            'string $param3 P3 Stuff'
+        ]
+    ];
 
     /**
      * @param mixed $input
      * @param mixed $expected
      * @dataProvider getFirstElementOfNonEmptyTestValues
      */
-    public function testGetFirstElementOfNonEmpty($input, $expected) {
-        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('dummy'));
+    public function testGetFirstElementOfNonEmpty($input, $expected)
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['dummy']);
         $this->assertEquals($expected, $viewHelper->_call('getFirstElementOfNonEmpty', $input));
     }
 
     /**
      * @return array
      */
-    public function getFirstElementOfNonEmptyTestValues() {
-        return array(
-            'plain array' => array(array('foo', 'bar'), 'foo'),
-            'iterator w/o arrayaccess' => array(new \IteratorIterator(new \ArrayIterator(array('foo', 'bar'))), 'foo'),
-            'unsupported value' => array('unsupported value', NULL)
-        );
+    public function getFirstElementOfNonEmptyTestValues()
+    {
+        return [
+            'plain array' => [['foo', 'bar'], 'foo'],
+            'iterator w/o arrayaccess' => [new \IteratorIterator(new \ArrayIterator(['foo', 'bar'])), 'foo'],
+            'unsupported value' => ['unsupported value', null]
+        ];
     }
 
-	/**
-	 * @test
-	 */
-	public function argumentsCanBeRegistered() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, NULL, array(), '', FALSE);
+    /**
+     * @test
+     */
+    public function argumentsCanBeRegistered()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
 
-		$name = 'This is a name';
-		$description = 'Example desc';
-		$type = 'string';
-		$isRequired = TRUE;
-		$expected = new ArgumentDefinition($name, $type, $description, $isRequired);
+        $name = 'This is a name';
+        $description = 'Example desc';
+        $type = 'string';
+        $isRequired = true;
+        $expected = new ArgumentDefinition($name, $type, $description, $isRequired);
 
-		$viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
-		$this->assertEquals(array($name => $expected), $viewHelper->prepareArguments(), 'Argument definitions not returned correctly.');
-	}
+        $viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
+        $this->assertEquals([$name => $expected], $viewHelper->prepareArguments(), 'Argument definitions not returned correctly.');
+    }
 
-	/**
-	 * @test
-	 * @expectedException Exception
-	 */
-	public function registeringTheSameArgumentNameAgainThrowsException() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, NULL, array(), '', FALSE);
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function registeringTheSameArgumentNameAgainThrowsException()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
 
-		$name = 'shortName';
-		$description = 'Example desc';
-		$type = 'string';
-		$isRequired = TRUE;
+        $name = 'shortName';
+        $description = 'Example desc';
+        $type = 'string';
+        $isRequired = true;
 
-		$viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
-		$viewHelper->_call('registerArgument', $name, 'integer', $description, $isRequired);
-	}
+        $viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
+        $viewHelper->_call('registerArgument', $name, 'integer', $description, $isRequired);
+    }
 
-	/**
-	 * @test
-	 */
-	public function overrideArgumentOverwritesExistingArgumentDefinition() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, NULL, array(), '', FALSE);
+    /**
+     * @test
+     */
+    public function overrideArgumentOverwritesExistingArgumentDefinition()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
 
-		$name = 'argumentName';
-		$description = 'argument description';
-		$overriddenDescription = 'overwritten argument description';
-		$type = 'string';
-		$overriddenType = 'integer';
-		$isRequired = TRUE;
-		$expected = new ArgumentDefinition($name, $overriddenType, $overriddenDescription, $isRequired);
+        $name = 'argumentName';
+        $description = 'argument description';
+        $overriddenDescription = 'overwritten argument description';
+        $type = 'string';
+        $overriddenType = 'integer';
+        $isRequired = true;
+        $expected = new ArgumentDefinition($name, $overriddenType, $overriddenDescription, $isRequired);
 
-		$viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
-		$viewHelper->_call('overrideArgument', $name, $overriddenType, $overriddenDescription, $isRequired);
-		$this->assertEquals($viewHelper->prepareArguments(), array($name => $expected), 'Argument definitions not returned correctly. The original ArgumentDefinition could not be overridden.');
-	}
+        $viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
+        $viewHelper->_call('overrideArgument', $name, $overriddenType, $overriddenDescription, $isRequired);
+        $this->assertEquals($viewHelper->prepareArguments(), [$name => $expected], 'Argument definitions not returned correctly. The original ArgumentDefinition could not be overridden.');
+    }
 
-	/**
-	 * @test
-	 * @expectedException Exception
-	 */
-	public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, NULL, array(), '', FALSE);
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
 
-		$viewHelper->_call('overrideArgument', 'argumentName', 'string', 'description', TRUE);
-	}
+        $viewHelper->_call('overrideArgument', 'argumentName', 'string', 'description', true);
+    }
 
-	/**
-	 * @test
-	 */
-	public function prepareArgumentsCallsInitializeArguments() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('initializeArguments'), array(), '', FALSE);
+    /**
+     * @test
+     */
+    public function prepareArgumentsCallsInitializeArguments()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['initializeArguments'], [], '', false);
 
-		$viewHelper->expects($this->once())->method('initializeArguments');
+        $viewHelper->expects($this->once())->method('initializeArguments');
 
-		$viewHelper->prepareArguments();
-	}
+        $viewHelper->prepareArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function validateArgumentsCallsPrepareArguments() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('prepareArguments'), array(), '', FALSE);
+    /**
+     * @test
+     */
+    public function validateArgumentsCallsPrepareArguments()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['prepareArguments'], [], '', false);
 
-		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array()));
+        $viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue([]));
 
-		$viewHelper->validateArguments();
-	}
+        $viewHelper->validateArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function validateArgumentsAcceptsAllObjectsImplemtingArrayAccessAsAnArray() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('prepareArguments'), array(), '', FALSE);
+    /**
+     * @test
+     */
+    public function validateArgumentsAcceptsAllObjectsImplemtingArrayAccessAsAnArray()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['prepareArguments'], [], '', false);
 
-		$viewHelper->setArguments(array('test' => new \ArrayObject));
-		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array('test' => new ArgumentDefinition('test', 'array', FALSE, 'documentation'))));
-		$viewHelper->validateArguments();
-	}
+        $viewHelper->setArguments(['test' => new \ArrayObject]);
+        $viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(['test' => new ArgumentDefinition('test', 'array', false, 'documentation')]));
+        $viewHelper->validateArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function validateArgumentsCallsTheRightValidators() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('prepareArguments'), array(), '', FALSE);
+    /**
+     * @test
+     */
+    public function validateArgumentsCallsTheRightValidators()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['prepareArguments'], [], '', false);
 
-		$viewHelper->setArguments(array('test' => 'Value of argument'));
+        $viewHelper->setArguments(['test' => 'Value of argument']);
 
-		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array(
-			'test' => new ArgumentDefinition('test', 'string', FALSE, 'documentation')
-		)));
+        $viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue([
+            'test' => new ArgumentDefinition('test', 'string', false, 'documentation')
+        ]));
 
-		$viewHelper->validateArguments();
-	}
+        $viewHelper->validateArguments();
+    }
 
-	/**
-	 * @test
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('prepareArguments'), array(), '', FALSE);
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['prepareArguments'], [], '', false);
 
-		$viewHelper->setArguments(array('test' => 'test'));
+        $viewHelper->setArguments(['test' => 'test']);
 
-		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array(
-			'test' => new ArgumentDefinition('test', 'stdClass', FALSE, 'documentation')
-		)));
+        $viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue([
+            'test' => new ArgumentDefinition('test', 'stdClass', false, 'documentation')
+        ]));
 
-		$viewHelper->validateArguments();
-	}
+        $viewHelper->validateArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function initializeArgumentsAndRenderCallsTheCorrectSequenceOfMethods() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('validateArguments', 'initialize', 'callRenderMethod'));
-		$viewHelper->expects($this->at(0))->method('validateArguments');
-		$viewHelper->expects($this->at(1))->method('initialize');
-		$viewHelper->expects($this->at(2))->method('callRenderMethod')->will($this->returnValue('Output'));
+    /**
+     * @test
+     */
+    public function initializeArgumentsAndRenderCallsTheCorrectSequenceOfMethods()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['validateArguments', 'initialize', 'callRenderMethod']);
+        $viewHelper->expects($this->at(0))->method('validateArguments');
+        $viewHelper->expects($this->at(1))->method('initialize');
+        $viewHelper->expects($this->at(2))->method('callRenderMethod')->will($this->returnValue('Output'));
 
-		$expectedOutput = 'Output';
-		$actualOutput = $viewHelper->initializeArgumentsAndRender(array('argument1' => 'value1'));
-		$this->assertEquals($expectedOutput, $actualOutput);
-	}
+        $expectedOutput = 'Output';
+        $actualOutput = $viewHelper->initializeArgumentsAndRender(['argument1' => 'value1']);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
 
-	/**
-	 * @test
-	 */
-	public function setRenderingContextShouldSetInnerVariables() {
-		$templateVariableContainer = $this->getMock(StandardVariableProvider::class);
-		$viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
+    /**
+     * @test
+     */
+    public function setRenderingContextShouldSetInnerVariables()
+    {
+        $templateVariableContainer = $this->getMock(StandardVariableProvider::class);
+        $viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
 
-		$view = new TemplateView();
-		$renderingContext = new RenderingContext($view);
-		$renderingContext->setVariableProvider($templateVariableContainer);
-		$renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
+        $view = new TemplateView();
+        $renderingContext = new RenderingContext($view);
+        $renderingContext->setVariableProvider($templateVariableContainer);
+        $renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
 
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('prepareArguments'), array(), '', FALSE);
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['prepareArguments'], [], '', false);
 
-		$viewHelper->setRenderingContext($renderingContext);
+        $viewHelper->setRenderingContext($renderingContext);
 
-		$this->assertSame($viewHelper->_get('templateVariableContainer'), $templateVariableContainer);
-		$this->assertSame($viewHelper->_get('viewHelperVariableContainer'), $viewHelperVariableContainer);
-	}
+        $this->assertSame($viewHelper->_get('templateVariableContainer'), $templateVariableContainer);
+        $this->assertSame($viewHelper->_get('viewHelperVariableContainer'), $viewHelperVariableContainer);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderChildrenCallsRenderChildrenClosureIfSet() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, NULL, array(), '', FALSE);
-		$viewHelper->setRenderChildrenClosure(function() { return 'foobar'; });
-		$result = $viewHelper->renderChildren();
-		$this->assertEquals('foobar', $result);
-	}
+    /**
+     * @test
+     */
+    public function testRenderChildrenCallsRenderChildrenClosureIfSet()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
+        $viewHelper->setRenderChildrenClosure(function () {
+            return 'foobar';
+        });
+        $result = $viewHelper->renderChildren();
+        $this->assertEquals('foobar', $result);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getValidateArgumentsTestValues
-	 * @param ArgumentDefinition $argument
-	 * @param mixed $value
-	 */
-	public function testValidateArguments(ArgumentDefinition $argument, $value) {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractViewHelper::class,
-			array('hasArgument', 'prepareArguments'),
-			array(), '', FALSE
-		);
-		$viewHelper->expects($this->once())->method('prepareArguments')->willReturn(
-			array($argument->getName() => $argument, 'second' => $argument)
-		);
-		$viewHelper->setArguments(array($argument->getName() => $value, 'second' => $value));
-		$viewHelper->expects($this->at(1))->method('hasArgument')->with($argument->getName())->willReturn(TRUE);
-		$viewHelper->expects($this->at(2))->method('hasArgument')->with('second')->willReturn(TRUE);
-		$viewHelper->validateArguments();
-	}
+    /**
+     * @test
+     * @dataProvider getValidateArgumentsTestValues
+     * @param ArgumentDefinition $argument
+     * @param mixed $value
+     */
+    public function testValidateArguments(ArgumentDefinition $argument, $value)
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractViewHelper::class,
+            ['hasArgument', 'prepareArguments'],
+            [],
+            '',
+            false
+        );
+        $viewHelper->expects($this->once())->method('prepareArguments')->willReturn(
+            [$argument->getName() => $argument, 'second' => $argument]
+        );
+        $viewHelper->setArguments([$argument->getName() => $value, 'second' => $value]);
+        $viewHelper->expects($this->at(1))->method('hasArgument')->with($argument->getName())->willReturn(true);
+        $viewHelper->expects($this->at(2))->method('hasArgument')->with('second')->willReturn(true);
+        $viewHelper->validateArguments();
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getValidateArgumentsTestValues() {
-		return array(
-			array(new ArgumentDefinition('test', 'boolean', '', TRUE, FALSE), FALSE),
-			array(new ArgumentDefinition('test', 'boolean', '', TRUE), TRUE),
-			array(new ArgumentDefinition('test', 'string', '', TRUE), 'foobar'),
-			array(new ArgumentDefinition('test', 'string', '', TRUE), new UserWithToString('foobar')),
-			array(new ArgumentDefinition('test', 'array', '', TRUE), array('foobar')),
-			array(new ArgumentDefinition('test', 'mixed', '', TRUE), new \DateTime('now')),
-			array(new ArgumentDefinition('test', 'DateTime[]', '', TRUE), array(new \DateTime('now'), 'test')),
-			array(new ArgumentDefinition('test', 'string[]', '', TRUE), array()),
-			array(new ArgumentDefinition('test', 'string[]', '', TRUE), array('foobar')),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getValidateArgumentsTestValues()
+    {
+        return [
+            [new ArgumentDefinition('test', 'boolean', '', true, false), false],
+            [new ArgumentDefinition('test', 'boolean', '', true), true],
+            [new ArgumentDefinition('test', 'string', '', true), 'foobar'],
+            [new ArgumentDefinition('test', 'string', '', true), new UserWithToString('foobar')],
+            [new ArgumentDefinition('test', 'array', '', true), ['foobar']],
+            [new ArgumentDefinition('test', 'mixed', '', true), new \DateTime('now')],
+            [new ArgumentDefinition('test', 'DateTime[]', '', true), [new \DateTime('now'), 'test']],
+            [new ArgumentDefinition('test', 'string[]', '', true), []],
+            [new ArgumentDefinition('test', 'string[]', '', true), ['foobar']],
+        ];
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getValidateArgumentsErrorsTestValues
-	 * @param ArgumentDefinition $argument
-	 * @param mixed $value
-	 */
-	public function testValidateArgumentsErrors(ArgumentDefinition $argument, $value) {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractViewHelper::class,
-			array('hasArgument', 'prepareArguments'),
-			array(), '', FALSE
-		);
-		$viewHelper->expects($this->once())->method('prepareArguments')->willReturn(array($argument->getName() => $argument));
-		$viewHelper->expects($this->once())->method('hasArgument')->with($argument->getName())->willReturn(TRUE);
-		$viewHelper->setArguments(array($argument->getName() => $value));
-		$this->setExpectedException('InvalidArgumentException');
-		$viewHelper->validateArguments();
-	}
+    /**
+     * @test
+     * @dataProvider getValidateArgumentsErrorsTestValues
+     * @param ArgumentDefinition $argument
+     * @param mixed $value
+     */
+    public function testValidateArgumentsErrors(ArgumentDefinition $argument, $value)
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractViewHelper::class,
+            ['hasArgument', 'prepareArguments'],
+            [],
+            '',
+            false
+        );
+        $viewHelper->expects($this->once())->method('prepareArguments')->willReturn([$argument->getName() => $argument]);
+        $viewHelper->expects($this->once())->method('hasArgument')->with($argument->getName())->willReturn(true);
+        $viewHelper->setArguments([$argument->getName() => $value]);
+        $this->setExpectedException('InvalidArgumentException');
+        $viewHelper->validateArguments();
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getValidateArgumentsErrorsTestValues() {
-		return array(
-			array(new ArgumentDefinition('test', 'boolean', '', TRUE), array('bad')),
-			array(new ArgumentDefinition('test', 'string', '', TRUE), new \ArrayIterator(array('bar'))),
-			array(new ArgumentDefinition('test', 'DateTime', '', TRUE), new \ArrayIterator(array('bar'))),
-			array(new ArgumentDefinition('test', 'DateTime', '', TRUE), 'test'),
-			array(new ArgumentDefinition('test', 'integer', '', TRUE), new \ArrayIterator(array('bar'))),
-			array(new ArgumentDefinition('test', 'object', '', TRUE), 'test'),
-			array(new ArgumentDefinition('test', 'string[]', '', TRUE), array(new \DateTime('now'),'test')),
-			array(new ArgumentDefinition('test', 'string[]', '', TRUE), array(null)),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getValidateArgumentsErrorsTestValues()
+    {
+        return [
+            [new ArgumentDefinition('test', 'boolean', '', true), ['bad']],
+            [new ArgumentDefinition('test', 'string', '', true), new \ArrayIterator(['bar'])],
+            [new ArgumentDefinition('test', 'DateTime', '', true), new \ArrayIterator(['bar'])],
+            [new ArgumentDefinition('test', 'DateTime', '', true), 'test'],
+            [new ArgumentDefinition('test', 'integer', '', true), new \ArrayIterator(['bar'])],
+            [new ArgumentDefinition('test', 'object', '', true), 'test'],
+            [new ArgumentDefinition('test', 'string[]', '', true), [new \DateTime('now'),'test']],
+            [new ArgumentDefinition('test', 'string[]', '', true), [null]],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testValidateAdditionalArgumentsThrowsExceptionIfNotEmpty() {
-		$viewHelper = $this->getAccessibleMock(
-			AbstractViewHelper::class,
-			array('dummy'),
-			array(), '', FALSE
-		);
-		$this->setExpectedException(Exception::class);
-		$viewHelper->validateAdditionalArguments(array('foo' => 'bar'));
-	}
+    /**
+     * @test
+     */
+    public function testValidateAdditionalArgumentsThrowsExceptionIfNotEmpty()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            false
+        );
+        $this->setExpectedException(Exception::class);
+        $viewHelper->validateAdditionalArguments(['foo' => 'bar']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCompileReturnsAndAssignsExpectedPhpCode() {
-		$view = new TemplateView();
-		$context = new RenderingContext($view);
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('dummy'), array(), '', FALSE);
-		$node = new ViewHelperNode($context, 'f', 'comment', array(), new ParsingState());
-		$init = '';
-		$compiler = new TemplateCompiler();
-		$result = $viewHelper->compile('foobar', 'baz', $init, $node, $compiler);
-		$this->assertEmpty($init);
-		$this->assertEquals(get_class($viewHelper) . '::renderStatic(foobar, baz, $renderingContext)', $result);
-	}
+    /**
+     * @test
+     */
+    public function testCompileReturnsAndAssignsExpectedPhpCode()
+    {
+        $view = new TemplateView();
+        $context = new RenderingContext($view);
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['dummy'], [], '', false);
+        $node = new ViewHelperNode($context, 'f', 'comment', [], new ParsingState());
+        $init = '';
+        $compiler = new TemplateCompiler();
+        $result = $viewHelper->compile('foobar', 'baz', $init, $node, $compiler);
+        $this->assertEmpty($init);
+        $this->assertEquals(get_class($viewHelper) . '::renderStatic(foobar, baz, $renderingContext)', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testDefaultResetStateMethodDoesNothing() {
-		$viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, array('dummy'), array(), '', FALSE);
-		$this->assertNull($viewHelper->resetState());
-	}
-
+    /**
+     * @test
+     */
+    public function testDefaultResetStateMethodDoesNothing()
+    {
+        $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['dummy'], [], '', false);
+        $this->assertNull($viewHelper->resetState());
+    }
 }

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -12,22 +12,24 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for \TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition
  */
-class ArgumentDefinitionTest extends UnitTestCase {
+class ArgumentDefinitionTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function objectStoresDataCorrectly() {
-		$name = 'This is a name';
-		$description = 'Example desc';
-		$type = 'string';
-		$isRequired = TRUE;
-		$isMethodParameter = TRUE;
-		$argumentDefinition = new ArgumentDefinition($name, $type, $description, $isRequired, NULL);
+    /**
+     * @test
+     */
+    public function objectStoresDataCorrectly()
+    {
+        $name = 'This is a name';
+        $description = 'Example desc';
+        $type = 'string';
+        $isRequired = true;
+        $isMethodParameter = true;
+        $argumentDefinition = new ArgumentDefinition($name, $type, $description, $isRequired, null);
 
-		$this->assertEquals($argumentDefinition->getName(), $name, 'Name could not be retrieved correctly.');
-		$this->assertEquals($argumentDefinition->getDescription(), $description, 'Description could not be retrieved correctly.');
-		$this->assertEquals($argumentDefinition->getType(), $type, 'Type could not be retrieved correctly');
-		$this->assertEquals($argumentDefinition->isRequired(), $isRequired, 'Required flag could not be retrieved correctly.');
-	}
+        $this->assertEquals($argumentDefinition->getName(), $name, 'Name could not be retrieved correctly.');
+        $this->assertEquals($argumentDefinition->getDescription(), $description, 'Description could not be retrieved correctly.');
+        $this->assertEquals($argumentDefinition->getType(), $type, 'Type could not be retrieved correctly');
+        $this->assertEquals($argumentDefinition->isRequired(), $isRequired, 'Required flag could not be retrieved correctly.');
+    }
 }

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -12,205 +12,227 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Testcase for TagBuilder
  */
-class TagBuilderTest extends UnitTestCase {
+class TagBuilderTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function constructorSetsTagName() {
-		$tagBuilder = new TagBuilder('someTagName');
-		$this->assertEquals('someTagName', $tagBuilder->getTagName());
-	}
+    /**
+     * @test
+     */
+    public function constructorSetsTagName()
+    {
+        $tagBuilder = new TagBuilder('someTagName');
+        $this->assertEquals('someTagName', $tagBuilder->getTagName());
+    }
 
-	/**
-	 * @test
-	 */
-	public function constructorSetsTagContent() {
-		$tagBuilder = new TagBuilder('', '<some text>');
-		$this->assertEquals('<some text>', $tagBuilder->getContent());
-	}
+    /**
+     * @test
+     */
+    public function constructorSetsTagContent()
+    {
+        $tagBuilder = new TagBuilder('', '<some text>');
+        $this->assertEquals('<some text>', $tagBuilder->getContent());
+    }
 
-	/**
-	 * @test
-	 */
-	public function setContentDoesNotEscapeValue() {
-		$tagBuilder = new TagBuilder();
-		$tagBuilder->setContent('<to be escaped>', FALSE);
-		$this->assertEquals('<to be escaped>', $tagBuilder->getContent());
-	}
+    /**
+     * @test
+     */
+    public function setContentDoesNotEscapeValue()
+    {
+        $tagBuilder = new TagBuilder();
+        $tagBuilder->setContent('<to be escaped>', false);
+        $this->assertEquals('<to be escaped>', $tagBuilder->getContent());
+    }
 
-	/**
-	 * @test
-	 */
-	public function hasContentReturnsTrueIfTagContainsText() {
-		$tagBuilder = new TagBuilder('', 'foo');
-		$this->assertTrue($tagBuilder->hasContent());
-	}
+    /**
+     * @test
+     */
+    public function hasContentReturnsTrueIfTagContainsText()
+    {
+        $tagBuilder = new TagBuilder('', 'foo');
+        $this->assertTrue($tagBuilder->hasContent());
+    }
 
-	/**
-	 * @test
-	 */
-	public function hasContentReturnsFalseIfContentIsNull() {
-		$tagBuilder = new TagBuilder();
-		$tagBuilder->setContent(NULL);
-		$this->assertFalse($tagBuilder->hasContent());
-	}
+    /**
+     * @test
+     */
+    public function hasContentReturnsFalseIfContentIsNull()
+    {
+        $tagBuilder = new TagBuilder();
+        $tagBuilder->setContent(null);
+        $this->assertFalse($tagBuilder->hasContent());
+    }
 
-	/**
-	 * @test
-	 */
-	public function hasContentReturnsFalseIfContentIsAnEmptyString() {
-		$tagBuilder = new TagBuilder();
-		$tagBuilder->setContent('');
-		$this->assertFalse($tagBuilder->hasContent());
-	}
+    /**
+     * @test
+     */
+    public function hasContentReturnsFalseIfContentIsAnEmptyString()
+    {
+        $tagBuilder = new TagBuilder();
+        $tagBuilder->setContent('');
+        $this->assertFalse($tagBuilder->hasContent());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsEmptyStringByDefault() {
-		$tagBuilder = new TagBuilder();
-		$this->assertEquals('', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsEmptyStringByDefault()
+    {
+        $tagBuilder = new TagBuilder();
+        $this->assertEquals('', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsSelfClosingTagIfNoContentIsSpecified() {
-		$tagBuilder = new TagBuilder('tag');
-		$this->assertEquals('<tag />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsSelfClosingTagIfNoContentIsSpecified()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $this->assertEquals('<tag />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function contentCanBeRemoved() {
-		$tagBuilder = new TagBuilder('tag', 'some content');
-		$tagBuilder->setContent(NULL);
-		$this->assertEquals('<tag />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function contentCanBeRemoved()
+    {
+        $tagBuilder = new TagBuilder('tag', 'some content');
+        $tagBuilder->setContent(null);
+        $this->assertEquals('<tag />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsOpeningAndClosingTagIfNoContentIsSpecifiedButForceClosingTagIsTrue() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->forceClosingTag(TRUE);
-		$this->assertEquals('<tag></tag>', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsOpeningAndClosingTagIfNoContentIsSpecifiedButForceClosingTagIsTrue()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->forceClosingTag(true);
+        $this->assertEquals('<tag></tag>', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function attributesAreProperlyRendered() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->addAttribute('attribute1', 'attribute1value');
-		$tagBuilder->addAttribute('attribute2', 'attribute2value');
-		$tagBuilder->addAttribute('attribute3', 'attribute3value');
-		$this->assertEquals('<tag attribute1="attribute1value" attribute2="attribute2value" attribute3="attribute3value" />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function attributesAreProperlyRendered()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('attribute1', 'attribute1value');
+        $tagBuilder->addAttribute('attribute2', 'attribute2value');
+        $tagBuilder->addAttribute('attribute3', 'attribute3value');
+        $this->assertEquals('<tag attribute1="attribute1value" attribute2="attribute2value" attribute3="attribute3value" />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function attributeValuesAreEscapedByDefault() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->addAttribute('foo', '<to be escaped>');
-		$this->assertEquals('<tag foo="&lt;to be escaped&gt;" />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function attributeValuesAreEscapedByDefault()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('foo', '<to be escaped>');
+        $this->assertEquals('<tag foo="&lt;to be escaped&gt;" />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function attributeValuesAreNotEscapedIfDisabled() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->addAttribute('foo', '<not to be escaped>', FALSE);
-		$this->assertEquals('<tag foo="<not to be escaped>" />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function attributeValuesAreNotEscapedIfDisabled()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('foo', '<not to be escaped>', false);
+        $this->assertEquals('<tag foo="<not to be escaped>" />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function attributesCanBeRemoved() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->addAttribute('attribute1', 'attribute1value');
-		$tagBuilder->addAttribute('attribute2', 'attribute2value');
-		$tagBuilder->addAttribute('attribute3', 'attribute3value');
-		$tagBuilder->removeAttribute('attribute2');
-		$this->assertEquals('<tag attribute1="attribute1value" attribute3="attribute3value" />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function attributesCanBeRemoved()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('attribute1', 'attribute1value');
+        $tagBuilder->addAttribute('attribute2', 'attribute2value');
+        $tagBuilder->addAttribute('attribute3', 'attribute3value');
+        $tagBuilder->removeAttribute('attribute2');
+        $this->assertEquals('<tag attribute1="attribute1value" attribute3="attribute3value" />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function attributesCanBeAccessed() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->addAttribute('attribute1', 'attribute1value');
-		$attributeValue = $tagBuilder->getAttribute('attribute1');
-		$this->assertSame('attribute1value', $attributeValue);
-	}
+    /**
+     * @test
+     */
+    public function attributesCanBeAccessed()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('attribute1', 'attribute1value');
+        $attributeValue = $tagBuilder->getAttribute('attribute1');
+        $this->assertSame('attribute1value', $attributeValue);
+    }
 
-	/**
-	 * @test
-	 */
-	public function attributesCanBeAccessedBulk() {
-		$tagBuilder = new TagBuilder('tag');
-		$tagBuilder->addAttribute('attribute1', 'attribute1value');
-		$attributeValues = $tagBuilder->getAttributes();
-		$this->assertEquals(array('attribute1' => 'attribute1value'), $attributeValues);
-	}
+    /**
+     * @test
+     */
+    public function attributesCanBeAccessedBulk()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('attribute1', 'attribute1value');
+        $attributeValues = $tagBuilder->getAttributes();
+        $this->assertEquals(['attribute1' => 'attribute1value'], $attributeValues);
+    }
 
-	/**
-	 * @test
-	 */
-	public function getAttributeWithMissingAttributeReturnsNull() {
-		$tagBuilder = new TagBuilder('tag');
-		$attributeValue = $tagBuilder->getAttribute('missingattribute');
-		$this->assertNull($attributeValue);
-	}
+    /**
+     * @test
+     */
+    public function getAttributeWithMissingAttributeReturnsNull()
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $attributeValue = $tagBuilder->getAttribute('missingattribute');
+        $this->assertNull($attributeValue);
+    }
 
-	/**
-	 * @test
-	 */
-	public function resetResetsTagBuilder() {
-		$tagBuilder = $this->getAccessibleMock(TagBuilder::class, array('dummy'));
-		$tagBuilder->setTagName('tagName');
-		$tagBuilder->setContent('some content');
-		$tagBuilder->forceClosingTag(TRUE);
-		$tagBuilder->addAttribute('attribute1', 'attribute1value');
-		$tagBuilder->addAttribute('attribute2', 'attribute2value');
-		$tagBuilder->reset();
+    /**
+     * @test
+     */
+    public function resetResetsTagBuilder()
+    {
+        $tagBuilder = $this->getAccessibleMock(TagBuilder::class, ['dummy']);
+        $tagBuilder->setTagName('tagName');
+        $tagBuilder->setContent('some content');
+        $tagBuilder->forceClosingTag(true);
+        $tagBuilder->addAttribute('attribute1', 'attribute1value');
+        $tagBuilder->addAttribute('attribute2', 'attribute2value');
+        $tagBuilder->reset();
 
-		$this->assertEquals('', $tagBuilder->_get('tagName'));
-		$this->assertEquals('', $tagBuilder->_get('content'));
-		$this->assertEquals(array(), $tagBuilder->_get('attributes'));
-		$this->assertFalse($tagBuilder->_get('forceClosingTag'));
-	}
+        $this->assertEquals('', $tagBuilder->_get('tagName'));
+        $this->assertEquals('', $tagBuilder->_get('content'));
+        $this->assertEquals([], $tagBuilder->_get('attributes'));
+        $this->assertFalse($tagBuilder->_get('forceClosingTag'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function tagNameCanBeOverridden() {
-		$tagBuilder = new TagBuilder('foo');
-		$tagBuilder->setTagName('bar');
-		$this->assertEquals('<bar />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function tagNameCanBeOverridden()
+    {
+        $tagBuilder = new TagBuilder('foo');
+        $tagBuilder->setTagName('bar');
+        $this->assertEquals('<bar />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function tagContentCanBeOverridden() {
-		$tagBuilder = new TagBuilder('foo', 'some content');
-		$tagBuilder->setContent('');
-		$this->assertEquals('<foo />', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function tagContentCanBeOverridden()
+    {
+        $tagBuilder = new TagBuilder('foo', 'some content');
+        $tagBuilder->setContent('');
+        $this->assertEquals('<foo />', $tagBuilder->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function tagIsNotRenderedIfTagNameIsEmpty() {
-		$tagBuilder = new TagBuilder('foo');
-		$tagBuilder->setTagName('');
-		$this->assertEquals('', $tagBuilder->render());
-	}
+    /**
+     * @test
+     */
+    public function tagIsNotRenderedIfTagNameIsEmpty()
+    {
+        $tagBuilder = new TagBuilder('foo');
+        $tagBuilder->setTagName('');
+        $this->assertEquals('', $tagBuilder->render());
+    }
 }

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -17,36 +17,38 @@ use TYPO3Fluid\Fluid\ViewHelpers\CountViewHelper;
 /**
  * Class ViewHelperInvokerTest
  */
-class ViewHelperInvokerTest extends UnitTestCase {
+class ViewHelperInvokerTest extends UnitTestCase
+{
 
-	/**
-	 * @param string $viewHelperClassName
-	 * @param array $arguments
-	 * @param mixed $expectedOutput
-	 * @param string|NULL $expectedException
-	 * @test
-	 * @dataProvider getInvocationTestValues
-	 */
-	public function testInvokeViewHelper($viewHelperClassName, array $arguments, $expectedOutput, $expectedException) {
-		$view = new TemplateView();
-		$resolver = new ViewHelperResolver();
-		$invoker = new ViewHelperInvoker($resolver);
-		$renderingContext = new RenderingContext($view);
-		if ($expectedException) {
-			$this->setExpectedException($expectedException);
-		}
-		$result = $invoker->invoke($viewHelperClassName, $arguments, $renderingContext);
-		$this->assertEquals($expectedOutput, $result);
-	}
+    /**
+     * @param string $viewHelperClassName
+     * @param array $arguments
+     * @param mixed $expectedOutput
+     * @param string|NULL $expectedException
+     * @test
+     * @dataProvider getInvocationTestValues
+     */
+    public function testInvokeViewHelper($viewHelperClassName, array $arguments, $expectedOutput, $expectedException)
+    {
+        $view = new TemplateView();
+        $resolver = new ViewHelperResolver();
+        $invoker = new ViewHelperInvoker($resolver);
+        $renderingContext = new RenderingContext($view);
+        if ($expectedException) {
+            $this->setExpectedException($expectedException);
+        }
+        $result = $invoker->invoke($viewHelperClassName, $arguments, $renderingContext);
+        $this->assertEquals($expectedOutput, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getInvocationTestValues() {
-		return array(
-			array(TestViewHelper::class, array('param1' => 'foo', 'param2' => array('bar')), 'foo', NULL),
-			array(TestViewHelper::class, array('param1' => 'foo', 'param2' => array('bar'), 'add1' => 'baz', 'add2' => 'zap'), 'foo', NULL),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getInvocationTestValues()
+    {
+        return [
+            [TestViewHelper::class, ['param1' => 'foo', 'param2' => ['bar']], 'foo', null],
+            [TestViewHelper::class, ['param1' => 'foo', 'param2' => ['bar'], 'add1' => 'baz', 'add2' => 'zap'], 'foo', null],
+        ];
+    }
 }

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -13,249 +13,270 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Class ViewHelperResolverTest
  */
-class ViewHelperResolverTest extends UnitTestCase {
+class ViewHelperResolverTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testAddNamespaceWithStringRecordsNamespace() {
-		$resolver = new ViewHelperResolver();
-		$resolver->addNamespace('t', 'test');
-		$this->assertAttributeContains(array('test'), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testAddNamespaceWithStringRecordsNamespace()
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->addNamespace('t', 'test');
+        $this->assertAttributeContains(['test'], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddNamespaceWithArrayRecordsNamespace() {
-		$resolver = new ViewHelperResolver();
-		$resolver->addNamespace('t', array('test'));
-		$this->assertAttributeContains(array('test'), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testAddNamespaceWithArrayRecordsNamespace()
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->addNamespace('t', ['test']);
+        $this->assertAttributeContains(['test'], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetNamespacesSetsNamespaces() {
-		$resolver = new ViewHelperResolver();
-		$resolver->setNamespaces(array('t' => array('test')));
-		$this->assertAttributeEquals(array('t' => array('test')), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testSetNamespacesSetsNamespaces()
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->setNamespaces(['t' => ['test']]);
+        $this->assertAttributeEquals(['t' => ['test']], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSetNamespacesSetsNamespacesAndConvertsStringNamespaceToArray() {
-		$resolver = new ViewHelperResolver();
-		$resolver->setNamespaces(array('t' => 'test'));
-		$this->assertAttributeEquals(array('t' => array('test')), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testSetNamespacesSetsNamespacesAndConvertsStringNamespaceToArray()
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->setNamespaces(['t' => 'test']);
+        $this->assertAttributeEquals(['t' => ['test']], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testIsNamespaceReturnsFalseIfNamespaceNotValid() {
-		$resolver = new ViewHelperResolver();
-		$result = $resolver->isNamespaceValid('test2');
-		$this->assertFalse($result);
-	}
+    /**
+     * @test
+     */
+    public function testIsNamespaceReturnsFalseIfNamespaceNotValid()
+    {
+        $resolver = new ViewHelperResolver();
+        $result = $resolver->isNamespaceValid('test2');
+        $this->assertFalse($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testResolveViewHelperClassNameThrowsExceptionIfClassNotResolved() {
-		$resolver = $this->getMock(ViewHelperResolver::class, array('resolveViewHelperName'));
-		$resolver->expects($this->once())->method('resolveViewHelperName')->willReturn(FALSE);
-		$this->setExpectedException(Exception::class);
-		$resolver->resolveViewHelperClassName('f', 'invalid');
-	}
+    /**
+     * @test
+     */
+    public function testResolveViewHelperClassNameThrowsExceptionIfClassNotResolved()
+    {
+        $resolver = $this->getMock(ViewHelperResolver::class, ['resolveViewHelperName']);
+        $resolver->expects($this->once())->method('resolveViewHelperName')->willReturn(false);
+        $this->setExpectedException(Exception::class);
+        $resolver->resolveViewHelperClassName('f', 'invalid');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testResolveViewHelperClassNameSupportsMultipleNamespaces() {
-		$resolver = $this->getAccessibleMock(ViewHelperResolver::class, array('dummy'));
-		$resolver->_set('namespaces', array(
-			'f' => array(
-				'FluidTYPO3\\Fluid\\ViewHelpers',
-				'Foo\\Bar'
-			)
-		));
-		$result = $resolver->_call('resolveViewHelperName', 'f', 'render');
-		$this->assertEquals('FluidTYPO3\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
-	}
+    /**
+     * @test
+     */
+    public function testResolveViewHelperClassNameSupportsMultipleNamespaces()
+    {
+        $resolver = $this->getAccessibleMock(ViewHelperResolver::class, ['dummy']);
+        $resolver->_set('namespaces', [
+            'f' => [
+                'FluidTYPO3\\Fluid\\ViewHelpers',
+                'Foo\\Bar'
+            ]
+        ]);
+        $result = $resolver->_call('resolveViewHelperName', 'f', 'render');
+        $this->assertEquals('FluidTYPO3\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testResolveViewHelperClassNameTrimsBackslashSuffixFromNamespace() {
-		$resolver = $this->getAccessibleMock(ViewHelperResolver::class, array('dummy'));
-		$resolver->_set('namespaces', array('f' => array('FluidTYPO3\\Fluid\\ViewHelpers\\')));
-		$result = $resolver->_call('resolveViewHelperName', 'f', 'render');
-		$this->assertEquals('FluidTYPO3\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
-	}
+    /**
+     * @test
+     */
+    public function testResolveViewHelperClassNameTrimsBackslashSuffixFromNamespace()
+    {
+        $resolver = $this->getAccessibleMock(ViewHelperResolver::class, ['dummy']);
+        $resolver->_set('namespaces', ['f' => ['FluidTYPO3\\Fluid\\ViewHelpers\\']]);
+        $result = $resolver->_call('resolveViewHelperName', 'f', 'render');
+        $this->assertEquals('FluidTYPO3\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddNamespaceWithString() {
-		$resolver = $this->getMock(ViewHelperResolver::class, array('dummy'));
-		$resolver->addNamespace('f', 'Foo\\Bar');
-		$this->assertAttributeEquals(array(
-			'f' => array(
-				'TYPO3Fluid\\Fluid\\ViewHelpers',
-				'Foo\\Bar'
-			)
-		), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testAddNamespaceWithString()
+    {
+        $resolver = $this->getMock(ViewHelperResolver::class, ['dummy']);
+        $resolver->addNamespace('f', 'Foo\\Bar');
+        $this->assertAttributeEquals([
+            'f' => [
+                'TYPO3Fluid\\Fluid\\ViewHelpers',
+                'Foo\\Bar'
+            ]
+        ], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddNamespaceWithArray() {
-		$resolver = $this->getMock(ViewHelperResolver::class, array('dummy'));
-		$resolver->addNamespace('f', array('Foo\\Bar'));
-		$this->assertAttributeEquals(array(
-			'f' => array(
-				'TYPO3Fluid\\Fluid\\ViewHelpers',
-				'Foo\\Bar'
-			)
-		), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testAddNamespaceWithArray()
+    {
+        $resolver = $this->getMock(ViewHelperResolver::class, ['dummy']);
+        $resolver->addNamespace('f', ['Foo\\Bar']);
+        $this->assertAttributeEquals([
+            'f' => [
+                'TYPO3Fluid\\Fluid\\ViewHelpers',
+                'Foo\\Bar'
+            ]
+        ], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAddNamespaces() {
-		$resolver = $this->getMock(ViewHelperResolver::class, array('dummy'));
-		$resolver->addNamespaces(array('f' => 'Foo\\Bar'));
-		$this->assertAttributeEquals(array(
-			'f' => array(
-				'TYPO3Fluid\\Fluid\\ViewHelpers',
-				'Foo\\Bar'
-			)
-		), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function testAddNamespaces()
+    {
+        $resolver = $this->getMock(ViewHelperResolver::class, ['dummy']);
+        $resolver->addNamespaces(['f' => 'Foo\\Bar']);
+        $this->assertAttributeEquals([
+            'f' => [
+                'TYPO3Fluid\\Fluid\\ViewHelpers',
+                'Foo\\Bar'
+            ]
+        ], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @param string $input
-	 * @param string $expected
-	 * @test
-	 * @dataProvider getResolvePhpNamespaceFromFluidNamespaceTestValues
-	 */
-	public function testResolvePhpNamespaceFromFluidNamespace($input, $expected) {
-		$resolver = new ViewHelperResolver();
-		$this->assertEquals($expected, $resolver->resolvePhpNamespaceFromFluidNamespace($input));
-	}
+    /**
+     * @param string $input
+     * @param string $expected
+     * @test
+     * @dataProvider getResolvePhpNamespaceFromFluidNamespaceTestValues
+     */
+    public function testResolvePhpNamespaceFromFluidNamespace($input, $expected)
+    {
+        $resolver = new ViewHelperResolver();
+        $this->assertEquals($expected, $resolver->resolvePhpNamespaceFromFluidNamespace($input));
+    }
 
-	public function getResolvePhpNamespaceFromFluidNamespaceTestValues() {
-		return array(
-			array('Foo\\Bar', 'Foo\\Bar\\ViewHelpers'),
-			array('Foo\\Bar\\ViewHelpers', 'Foo\\Bar\\ViewHelpers'),
-			array('http://typo3.org/ns/Foo/Bar/ViewHelpers', 'Foo\\Bar\\ViewHelpers'),
-		);
-	}
+    public function getResolvePhpNamespaceFromFluidNamespaceTestValues()
+    {
+        return [
+            ['Foo\\Bar', 'Foo\\Bar\\ViewHelpers'],
+            ['Foo\\Bar\\ViewHelpers', 'Foo\\Bar\\ViewHelpers'],
+            ['http://typo3.org/ns/Foo/Bar/ViewHelpers', 'Foo\\Bar\\ViewHelpers'],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCreateViewHelperInstance() {
-		$resolver = $this->getMock(
-			ViewHelperResolver::class,
-			array('resolveViewHelperClassName', 'createViewHelperInstanceFromClassName')
-		);
-		$resolver->expects($this->once())->method('resolveViewHelperClassName')->with('foo', 'bar')->willReturn('foobar');
-		$resolver->expects($this->once())->method('createViewHelperInstanceFromClassName')->with('foobar')->willReturn('baz');
-		$this->assertEquals('baz', $resolver->createViewHelperInstance('foo', 'bar'));
-	}
+    /**
+     * @test
+     */
+    public function testCreateViewHelperInstance()
+    {
+        $resolver = $this->getMock(
+            ViewHelperResolver::class,
+            ['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName']
+        );
+        $resolver->expects($this->once())->method('resolveViewHelperClassName')->with('foo', 'bar')->willReturn('foobar');
+        $resolver->expects($this->once())->method('createViewHelperInstanceFromClassName')->with('foobar')->willReturn('baz');
+        $this->assertEquals('baz', $resolver->createViewHelperInstance('foo', 'bar'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function addNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace() {
-		$resolver = new ViewHelperResolver();
-		$resolver->addNamespace('foo', 'Some\Namespace');
-		$this->assertAttributeEquals(array('f' => array('TYPO3Fluid\Fluid\ViewHelpers'), 'foo' => array('Some\Namespace')), 'namespaces', $resolver);
-		$resolver->addNamespace('foo', 'Some\Namespace');
-		$this->assertAttributeEquals(array('f' => array('TYPO3Fluid\Fluid\ViewHelpers'), 'foo' => array('Some\Namespace')), 'namespaces', $resolver);
-	}
+    /**
+     * @test
+     */
+    public function addNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace()
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->addNamespace('foo', 'Some\Namespace');
+        $this->assertAttributeEquals(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], 'namespaces', $resolver);
+        $resolver->addNamespace('foo', 'Some\Namespace');
+        $this->assertAttributeEquals(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], 'namespaces', $resolver);
+    }
 
-	/**
-	 * @param array $namespaces
-	 * @param string $subject
-	 * @param boolean $expected
-	 * @test
-	 * @dataProvider getIsNamespaceValidTestValues
-	 */
-	public function testIsNamespaceValidOrIgnored(array $namespaces, $subject, $expected) {
-		$resolver = new ViewHelperResolver();
-		$resolver->setNamespaces($namespaces);
-		$result = $resolver->isNamespaceValid($subject);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param array $namespaces
+     * @param string $subject
+     * @param boolean $expected
+     * @test
+     * @dataProvider getIsNamespaceValidTestValues
+     */
+    public function testIsNamespaceValidOrIgnored(array $namespaces, $subject, $expected)
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->setNamespaces($namespaces);
+        $result = $resolver->isNamespaceValid($subject);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getIsNamespaceValidTestValues() {
-		return array(
-			array(array('foo' => NULL), 'foo', FALSE),
-			array(array('foo' => array('test')), 'foo', TRUE),
-			array(array('foo' => array('test')), 'foobar', FALSE),
-			array(array('foo*' => NULL), 'foo', FALSE),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getIsNamespaceValidTestValues()
+    {
+        return [
+            [['foo' => null], 'foo', false],
+            [['foo' => ['test']], 'foo', true],
+            [['foo' => ['test']], 'foobar', false],
+            [['foo*' => null], 'foo', false],
+        ];
+    }
 
-	/**
-	 * @param array $namespaces
-	 * @param string $subject
-	 * @param boolean $expected
-	 * @test
-	 * @dataProvider getIsNamespaceIgnoredTestValues
-	 */
-	public function testIsNamespaceIgnored(array $namespaces, $subject, $expected) {
-		$resolver = new ViewHelperResolver();
-		$resolver->setNamespaces($namespaces);
-		$result = $resolver->isNamespaceIgnored($subject);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param array $namespaces
+     * @param string $subject
+     * @param boolean $expected
+     * @test
+     * @dataProvider getIsNamespaceIgnoredTestValues
+     */
+    public function testIsNamespaceIgnored(array $namespaces, $subject, $expected)
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->setNamespaces($namespaces);
+        $result = $resolver->isNamespaceIgnored($subject);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getIsNamespaceIgnoredTestValues() {
-		return array(
-			array(array('foo' => NULL), 'foo', TRUE),
-			array(array('foo' => array('test')), 'foo', FALSE),
-			array(array('foo' => array('test')), 'foobar', FALSE),
-			array(array('foo*' => NULL), 'foobar', TRUE),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getIsNamespaceIgnoredTestValues()
+    {
+        return [
+            [['foo' => null], 'foo', true],
+            [['foo' => ['test']], 'foo', false],
+            [['foo' => ['test']], 'foobar', false],
+            [['foo*' => null], 'foobar', true],
+        ];
+    }
 
-	/**
-	 * @param array $namespaces
-	 * @param string $subject
-	 * @param boolean $expected
-	 * @test
-	 * @dataProvider getIsNamespaceValidOrIgnoredTestValues
-	 */
-	public function testIsNamespaceValidOrIgnoredTestValues(array $namespaces, $subject, $expected) {
-		$resolver = new ViewHelperResolver();
-		$resolver->setNamespaces($namespaces);
-		$result = $resolver->isNamespaceValidOrIgnored($subject);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param array $namespaces
+     * @param string $subject
+     * @param boolean $expected
+     * @test
+     * @dataProvider getIsNamespaceValidOrIgnoredTestValues
+     */
+    public function testIsNamespaceValidOrIgnoredTestValues(array $namespaces, $subject, $expected)
+    {
+        $resolver = new ViewHelperResolver();
+        $resolver->setNamespaces($namespaces);
+        $result = $resolver->isNamespaceValidOrIgnored($subject);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getIsNamespaceValidOrIgnoredTestValues() {
-		return array(
-			array(array('foo' => NULL), 'foo', TRUE),
-			array(array('foo' => array('test')), 'foo', TRUE),
-			array(array('foo' => array('test')), 'foobar', FALSE),
-			array(array('foo*' => NULL), 'foobar', TRUE),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getIsNamespaceValidOrIgnoredTestValues()
+    {
+        return [
+            [['foo' => null], 'foo', true],
+            [['foo' => ['test']], 'foo', true],
+            [['foo' => ['test']], 'foobar', false],
+            [['foo*' => null], 'foobar', true],
+        ];
+    }
 }

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -14,102 +14,113 @@ use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 /**
  * Testcase for AbstractViewHelper
  */
-class ViewHelperVariableContainerTest extends UnitTestCase {
+class ViewHelperVariableContainerTest extends UnitTestCase
+{
 
-	/**
-	 * @var ViewHelperVariableContainer
-	 */
-	protected $viewHelperVariableContainer;
+    /**
+     * @var ViewHelperVariableContainer
+     */
+    protected $viewHelperVariableContainer;
 
-	protected function setUp() {
-		$this->viewHelperVariableContainer = new ViewHelperVariableContainer();
-	}
+    protected function setUp()
+    {
+        $this->viewHelperVariableContainer = new ViewHelperVariableContainer();
+    }
 
-	/**
-	 * @test
-	 */
-	public function storedDataCanBeReadOutAgain() {
-		$variable = 'Hello world';
-		$this->assertFalse($this->viewHelperVariableContainer->exists(TestViewHelper::class, 'test'));
-		$this->viewHelperVariableContainer->add(TestViewHelper::class, 'test', $variable);
-		$this->assertTrue($this->viewHelperVariableContainer->exists(TestViewHelper::class, 'test'));
+    /**
+     * @test
+     */
+    public function storedDataCanBeReadOutAgain()
+    {
+        $variable = 'Hello world';
+        $this->assertFalse($this->viewHelperVariableContainer->exists(TestViewHelper::class, 'test'));
+        $this->viewHelperVariableContainer->add(TestViewHelper::class, 'test', $variable);
+        $this->assertTrue($this->viewHelperVariableContainer->exists(TestViewHelper::class, 'test'));
 
-		$this->assertEquals($variable, $this->viewHelperVariableContainer->get(TestViewHelper::class, 'test'));
-	}
+        $this->assertEquals($variable, $this->viewHelperVariableContainer->get(TestViewHelper::class, 'test'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function addOrUpdateSetsAKeyIfItDoesNotExistYet() {
-		$this->viewHelperVariableContainer->add('Foo\Bar', 'nonExistentKey', 'value1');
-		$this->assertEquals($this->viewHelperVariableContainer->get('Foo\Bar', 'nonExistentKey'), 'value1');
-	}
+    /**
+     * @test
+     */
+    public function addOrUpdateSetsAKeyIfItDoesNotExistYet()
+    {
+        $this->viewHelperVariableContainer->add('Foo\Bar', 'nonExistentKey', 'value1');
+        $this->assertEquals($this->viewHelperVariableContainer->get('Foo\Bar', 'nonExistentKey'), 'value1');
+    }
 
-	/**
-	 * @test
-	 */
-	public function addOrUpdateOverridesAnExistingKey() {
-		$this->viewHelperVariableContainer->add('Foo\Bar', 'someKey', 'value1');
-		$this->viewHelperVariableContainer->addOrUpdate('Foo\Bar', 'someKey', 'value2');
-		$this->assertEquals($this->viewHelperVariableContainer->get('Foo\Bar', 'someKey'), 'value2');
-	}
+    /**
+     * @test
+     */
+    public function addOrUpdateOverridesAnExistingKey()
+    {
+        $this->viewHelperVariableContainer->add('Foo\Bar', 'someKey', 'value1');
+        $this->viewHelperVariableContainer->addOrUpdate('Foo\Bar', 'someKey', 'value2');
+        $this->assertEquals($this->viewHelperVariableContainer->get('Foo\Bar', 'someKey'), 'value2');
+    }
 
-	/**
-	 * @test
-	 */
-	public function aSetValueCanBeRemovedAgain() {
-		$this->viewHelperVariableContainer->add('Foo\Bar', 'nonExistentKey', 'value1');
-		$this->viewHelperVariableContainer->remove('Foo\Bar', 'nonExistentKey');
-		$this->assertFalse($this->viewHelperVariableContainer->exists('Foo\Bar', 'nonExistentKey'));
-	}
+    /**
+     * @test
+     */
+    public function aSetValueCanBeRemovedAgain()
+    {
+        $this->viewHelperVariableContainer->add('Foo\Bar', 'nonExistentKey', 'value1');
+        $this->viewHelperVariableContainer->remove('Foo\Bar', 'nonExistentKey');
+        $this->assertFalse($this->viewHelperVariableContainer->exists('Foo\Bar', 'nonExistentKey'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function existsReturnsFalseIfTheSpecifiedKeyDoesNotExist() {
-		$this->assertFalse($this->viewHelperVariableContainer->exists('Foo\Bar', 'nonExistentKey'));
-	}
+    /**
+     * @test
+     */
+    public function existsReturnsFalseIfTheSpecifiedKeyDoesNotExist()
+    {
+        $this->assertFalse($this->viewHelperVariableContainer->exists('Foo\Bar', 'nonExistentKey'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function existsReturnsTrueIfTheSpecifiedKeyExists() {
-		$this->viewHelperVariableContainer->add('Foo\Bar', 'someKey', 'someValue');
-		$this->assertTrue($this->viewHelperVariableContainer->exists('Foo\Bar', 'someKey'));
-	}
+    /**
+     * @test
+     */
+    public function existsReturnsTrueIfTheSpecifiedKeyExists()
+    {
+        $this->viewHelperVariableContainer->add('Foo\Bar', 'someKey', 'someValue');
+        $this->assertTrue($this->viewHelperVariableContainer->exists('Foo\Bar', 'someKey'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function existsReturnsTrueIfTheSpecifiedKeyExistsAndIsNull() {
-		$this->viewHelperVariableContainer->add('Foo\Bar', 'someKey', NULL);
-		$this->assertTrue($this->viewHelperVariableContainer->exists('Foo\Bar', 'someKey'));
-	}
+    /**
+     * @test
+     */
+    public function existsReturnsTrueIfTheSpecifiedKeyExistsAndIsNull()
+    {
+        $this->viewHelperVariableContainer->add('Foo\Bar', 'someKey', null);
+        $this->assertTrue($this->viewHelperVariableContainer->exists('Foo\Bar', 'someKey'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewCanBeReadOutAgain() {
-		$view = $this->getMockForAbstractClass(AbstractTemplateView::class);
-		$this->viewHelperVariableContainer->setView($view);
-		$this->assertSame($view, $this->viewHelperVariableContainer->getView());
-	}
+    /**
+     * @test
+     */
+    public function viewCanBeReadOutAgain()
+    {
+        $view = $this->getMockForAbstractClass(AbstractTemplateView::class);
+        $this->viewHelperVariableContainer->setView($view);
+        $this->assertSame($view, $this->viewHelperVariableContainer->getView());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testSleepReturnsExpectedPropertyNames() {
-		$subject = new ViewHelperVariableContainer();
-		$properties = $subject->__sleep();
-		$this->assertContains('objects', $properties);
-	}
+    /**
+     * @test
+     */
+    public function testSleepReturnsExpectedPropertyNames()
+    {
+        $subject = new ViewHelperVariableContainer();
+        $properties = $subject->__sleep();
+        $this->assertContains('objects', $properties);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetReturnsDefaultIfRequestedVariableDoesNotExist() {
-		$subject = new ViewHelperVariableContainer();
-		$this->assertEquals('test', $subject->get('foo', 'bar', 'test'));
-	}
-
+    /**
+     * @test
+     */
+    public function testGetReturnsDefaultIfRequestedVariableDoesNotExist()
+    {
+        $subject = new ViewHelperVariableContainer();
+        $this->assertEquals('test', $subject->get('foo', 'bar', 'test'));
+    }
 }

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -20,184 +20,211 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 /**
  * Testcase for the TemplateView
  */
-class AbstractTemplateViewTest extends UnitTestCase {
+class AbstractTemplateViewTest extends UnitTestCase
+{
 
-	/**
-	 * @var AbstractTemplateView
-	 */
-	protected $view;
+    /**
+     * @var AbstractTemplateView
+     */
+    protected $view;
 
-	/**
-	 * @var RenderingContext
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
 
-	/**
-	 * @var ViewHelperVariableContainer
-	 */
-	protected $viewHelperVariableContainer;
+    /**
+     * @var ViewHelperVariableContainer
+     */
+    protected $viewHelperVariableContainer;
 
-	/**
-	 * @var TemplateVariableContainer
-	 */
-	protected $templateVariableContainer;
+    /**
+     * @var TemplateVariableContainer
+     */
+    protected $templateVariableContainer;
 
-	/**
-	 * Sets up this test case
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-		$this->templateVariableContainer = $this->getMock(StandardVariableProvider::class);
-		$this->viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class, array('setView'));
-		$this->renderingContext = new RenderingContextFixture();
-		$this->renderingContext->viewHelperVariableContainer = $this->viewHelperVariableContainer;
-		$this->renderingContext->variableProvider = $this->templateVariableContainer;
-		$this->view = $this->getMockForAbstractClass(AbstractTemplateView::class);
-		$this->view->setRenderingContext($this->renderingContext);
-	}
+    /**
+     * Sets up this test case
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->templateVariableContainer = $this->getMock(StandardVariableProvider::class);
+        $this->viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class, ['setView']);
+        $this->renderingContext = new RenderingContextFixture();
+        $this->renderingContext->viewHelperVariableContainer = $this->viewHelperVariableContainer;
+        $this->renderingContext->variableProvider = $this->templateVariableContainer;
+        $this->view = $this->getMockForAbstractClass(AbstractTemplateView::class);
+        $this->view->setRenderingContext($this->renderingContext);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetRenderingContextReturnsExpectedRenderingContext() {
-		$result = $this->view->getRenderingContext();
-		$this->assertSame($this->renderingContext, $result);
-	}
+    /**
+     * @test
+     */
+    public function testGetRenderingContextReturnsExpectedRenderingContext()
+    {
+        $result = $this->view->getRenderingContext();
+        $this->assertSame($this->renderingContext, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetViewHelperResolverReturnsExpectedViewHelperResolver() {
-		$viewHelperResolver = $this->getMock(ViewHelperResolver::class);
-		$this->renderingContext->setViewHelperResolver($viewHelperResolver);
-		$result = $this->view->getViewHelperResolver();
-		$this->assertSame($viewHelperResolver, $result);
-	}
+    /**
+     * @test
+     */
+    public function testGetViewHelperResolverReturnsExpectedViewHelperResolver()
+    {
+        $viewHelperResolver = $this->getMock(ViewHelperResolver::class);
+        $this->renderingContext->setViewHelperResolver($viewHelperResolver);
+        $result = $this->view->getViewHelperResolver();
+        $this->assertSame($viewHelperResolver, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function assignAddsValueToTemplateVariableContainer() {
-		$this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
-		$this->templateVariableContainer->expects($this->at(1))->method('add')->with('bar', 'BarValue');
+    /**
+     * @test
+     */
+    public function assignAddsValueToTemplateVariableContainer()
+    {
+        $this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
+        $this->templateVariableContainer->expects($this->at(1))->method('add')->with('bar', 'BarValue');
 
-		$this->view
-			->assign('foo', 'FooValue')
-			->assign('bar', 'BarValue');
-	}
+        $this->view
+            ->assign('foo', 'FooValue')
+            ->assign('bar', 'BarValue');
+    }
 
-	/**
-	 * @test
-	 */
-	public function assignCanOverridePreviouslyAssignedValues() {
-		$this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
-		$this->templateVariableContainer->expects($this->at(1))->method('add')->with('foo', 'FooValueOverridden');
+    /**
+     * @test
+     */
+    public function assignCanOverridePreviouslyAssignedValues()
+    {
+        $this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
+        $this->templateVariableContainer->expects($this->at(1))->method('add')->with('foo', 'FooValueOverridden');
 
-		$this->view->assign('foo', 'FooValue');
-		$this->view->assign('foo', 'FooValueOverridden');
-	}
+        $this->view->assign('foo', 'FooValue');
+        $this->view->assign('foo', 'FooValueOverridden');
+    }
 
-	/**
-	 * @test
-	 */
-	public function assignMultipleAddsValuesToTemplateVariableContainer() {
-		$this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
-		$this->templateVariableContainer->expects($this->at(1))->method('add')->with('bar', 'BarValue');
-		$this->templateVariableContainer->expects($this->at(2))->method('add')->with('baz', 'BazValue');
+    /**
+     * @test
+     */
+    public function assignMultipleAddsValuesToTemplateVariableContainer()
+    {
+        $this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
+        $this->templateVariableContainer->expects($this->at(1))->method('add')->with('bar', 'BarValue');
+        $this->templateVariableContainer->expects($this->at(2))->method('add')->with('baz', 'BazValue');
 
-		$this->view
-			->assignMultiple(array('foo' => 'FooValue', 'bar' => 'BarValue'))
-			->assignMultiple(array('baz' => 'BazValue'));
-	}
+        $this->view
+            ->assignMultiple(['foo' => 'FooValue', 'bar' => 'BarValue'])
+            ->assignMultiple(['baz' => 'BazValue']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function assignMultipleCanOverridePreviouslyAssignedValues() {
-		$this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
-		$this->templateVariableContainer->expects($this->at(1))->method('add')->with('foo', 'FooValueOverridden');
-		$this->templateVariableContainer->expects($this->at(2))->method('add')->with('bar', 'BarValue');
+    /**
+     * @test
+     */
+    public function assignMultipleCanOverridePreviouslyAssignedValues()
+    {
+        $this->templateVariableContainer->expects($this->at(0))->method('add')->with('foo', 'FooValue');
+        $this->templateVariableContainer->expects($this->at(1))->method('add')->with('foo', 'FooValueOverridden');
+        $this->templateVariableContainer->expects($this->at(2))->method('add')->with('bar', 'BarValue');
 
-		$this->view->assign('foo', 'FooValue');
-		$this->view->assignMultiple(array('foo' => 'FooValueOverridden', 'bar' => 'BarValue'));
-	}
+        $this->view->assign('foo', 'FooValue');
+        $this->view->assignMultiple(['foo' => 'FooValueOverridden', 'bar' => 'BarValue']);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getRenderSectionExceptionTestValues
-	 * @param boolean $compiled
-	 * @test
-	 */
-	public function testRenderSectionThrowsExceptionIfSectionMissingAndNotIgnoringUnknown($compiled) {
-		$parsedTemplate = $this->getMockForAbstractClass(
-			AbstractCompiledTemplate::class,
-			array(), '', FALSE, FALSE, TRUE,
-			array('isCompiled', 'getVariableContainer')
-		);
-		$parsedTemplate->expects($this->once())->method('isCompiled')->willReturn($compiled);
-		$parsedTemplate->expects($this->any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(
-			array('sections' => array())
-		));
-		$view = $this->getMockForAbstractClass(
-			AbstractTemplateView::class,
-			array(), '', FALSE, FALSE, TRUE,
-			array('getCurrentParsedTemplate', 'getCurrentRenderingType', 'getCurrentRenderingContext')
-		);
-		$view->expects($this->once())->method('getCurrentRenderingContext')->willReturn($this->renderingContext);
-		$view->expects($this->once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
-		$view->expects($this->once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
-		$this->setExpectedException(InvalidSectionException::class);
-		$view->renderSection('Missing');
-	}
+    /**
+     * @test
+     * @dataProvider getRenderSectionExceptionTestValues
+     * @param boolean $compiled
+     * @test
+     */
+    public function testRenderSectionThrowsExceptionIfSectionMissingAndNotIgnoringUnknown($compiled)
+    {
+        $parsedTemplate = $this->getMockForAbstractClass(
+            AbstractCompiledTemplate::class,
+            [],
+            '',
+            false,
+            false,
+            true,
+            ['isCompiled', 'getVariableContainer']
+        );
+        $parsedTemplate->expects($this->once())->method('isCompiled')->willReturn($compiled);
+        $parsedTemplate->expects($this->any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(
+            ['sections' => []]
+        ));
+        $view = $this->getMockForAbstractClass(
+            AbstractTemplateView::class,
+            [],
+            '',
+            false,
+            false,
+            true,
+            ['getCurrentParsedTemplate', 'getCurrentRenderingType', 'getCurrentRenderingContext']
+        );
+        $view->expects($this->once())->method('getCurrentRenderingContext')->willReturn($this->renderingContext);
+        $view->expects($this->once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
+        $view->expects($this->once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
+        $this->setExpectedException(InvalidSectionException::class);
+        $view->renderSection('Missing');
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderSectionExceptionTestValues() {
-		return array(
-			array(TRUE),
-			array(FALSE)
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getRenderSectionExceptionTestValues()
+    {
+        return [
+            [true],
+            [false]
+        ];
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getRenderSectionCompiledTestValues
-	 * @param boolean $exists
-	 * @test
-	 */
-	public function testRenderSectionOnCompiledTemplate($exists) {
-		if ($exists) {
-			$sectionMethodName = 'section_' . sha1('Section');
-		} else {
-			$sectionMethodName = 'test';
-		}
-		$parsedTemplate = $this->getMockForAbstractClass(
-			AbstractCompiledTemplate::class,
-			array(), '', FALSE, FALSE, TRUE,
-			array('isCompiled', 'getVariableContainer', $sectionMethodName)
-		);
-		$parsedTemplate->expects($this->once())->method('isCompiled')->willReturn(TRUE);
-		$view = $this->getMockForAbstractClass(
-			AbstractTemplateView::class,
-			array(), '', FALSE, FALSE, TRUE,
-			array('getCurrentParsedTemplate', 'getCurrentRenderingType', 'getCurrentRenderingContext')
-		);
-		$view->expects($this->once())->method('getCurrentRenderingContext')->willReturn($this->renderingContext);
-		$view->expects($this->once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
-		$view->expects($this->once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
-		$view->renderSection('Section', array(), TRUE);
-	}
+    /**
+     * @test
+     * @dataProvider getRenderSectionCompiledTestValues
+     * @param boolean $exists
+     * @test
+     */
+    public function testRenderSectionOnCompiledTemplate($exists)
+    {
+        if ($exists) {
+            $sectionMethodName = 'section_' . sha1('Section');
+        } else {
+            $sectionMethodName = 'test';
+        }
+        $parsedTemplate = $this->getMockForAbstractClass(
+            AbstractCompiledTemplate::class,
+            [],
+            '',
+            false,
+            false,
+            true,
+            ['isCompiled', 'getVariableContainer', $sectionMethodName]
+        );
+        $parsedTemplate->expects($this->once())->method('isCompiled')->willReturn(true);
+        $view = $this->getMockForAbstractClass(
+            AbstractTemplateView::class,
+            [],
+            '',
+            false,
+            false,
+            true,
+            ['getCurrentParsedTemplate', 'getCurrentRenderingType', 'getCurrentRenderingContext']
+        );
+        $view->expects($this->once())->method('getCurrentRenderingContext')->willReturn($this->renderingContext);
+        $view->expects($this->once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
+        $view->expects($this->once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
+        $view->renderSection('Section', [], true);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderSectionCompiledTestValues() {
-		return array(
-			array(TRUE),
-			array(FALSE)
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getRenderSectionCompiledTestValues()
+    {
+        return [
+            [true],
+            [false]
+        ];
+    }
 }

--- a/tests/Unit/View/AbstractViewTest.php
+++ b/tests/Unit/View/AbstractViewTest.php
@@ -12,33 +12,36 @@ use TYPO3Fluid\Fluid\View\AbstractView;
 /**
  * Testcase for the AbstractView
  */
-class AbstractViewViewTest extends UnitTestCase {
+class AbstractViewViewTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function testParentRenderMethodReturnsEmptyString() {
-		$instance = $this->getMockForAbstractClass(AbstractView::class);
-		$result = $instance->render();
-		$this->assertEquals('', $result);
-	}
+    /**
+     * @test
+     */
+    public function testParentRenderMethodReturnsEmptyString()
+    {
+        $instance = $this->getMockForAbstractClass(AbstractView::class);
+        $result = $instance->render();
+        $this->assertEquals('', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAssignsVariableAndReturnsSelf() {
-		$mock = $this->getMockForAbstractClass(AbstractView::class);
-		$mock->assign('test', 'foobar');
-		$this->assertAttributeEquals(array('test' => 'foobar'), 'variables', $mock);
-	}
+    /**
+     * @test
+     */
+    public function testAssignsVariableAndReturnsSelf()
+    {
+        $mock = $this->getMockForAbstractClass(AbstractView::class);
+        $mock->assign('test', 'foobar');
+        $this->assertAttributeEquals(['test' => 'foobar'], 'variables', $mock);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testAssignsMultipleVariablesAndReturnsSelf() {
-		$mock = $this->getMockForAbstractClass(AbstractView::class);
-		$mock->assignMultiple(array('test' => 'foobar', 'baz' => 'barfoo'));
-		$this->assertAttributeEquals(array('test' => 'foobar', 'baz' => 'barfoo'), 'variables', $mock);
-	}
-
+    /**
+     * @test
+     */
+    public function testAssignsMultipleVariablesAndReturnsSelf()
+    {
+        $mock = $this->getMockForAbstractClass(AbstractView::class);
+        $mock->assignMultiple(['test' => 'foobar', 'baz' => 'barfoo']);
+        $this->assertAttributeEquals(['test' => 'foobar', 'baz' => 'barfoo'], 'variables', $mock);
+    }
 }

--- a/tests/Unit/View/Fixtures/TransparentSyntaxTreeNode.php
+++ b/tests/Unit/View/Fixtures/TransparentSyntaxTreeNode.php
@@ -13,9 +13,11 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * [Enter description here]
  *
  */
-class TransparentSyntaxTreeNode extends AbstractNode {
-	public $variableContainer;
+class TransparentSyntaxTreeNode extends AbstractNode
+{
+    public $variableContainer;
 
-	public function evaluate(RenderingContextInterface $renderingContext) {
-	}
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+    }
 }

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -15,228 +15,246 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 /**
  * Class TemplatePathsTest
  */
-class TemplatePathsTest extends BaseTestCase {
+class TemplatePathsTest extends BaseTestCase
+{
 
-	/**
-	 * @param string|array $input
-	 * @param string|array $expected
-	 * @test
-	 * @dataProvider getSanitizePathTestValues
-	 */
-	public function testSanitizePath($input, $expected) {
-		$instance = new TemplatePaths();
-		$method = new \ReflectionMethod($instance, 'sanitizePath');
-		$method->setAccessible(TRUE);
-		$output = $method->invokeArgs($instance, array($input));
-		$this->assertEquals($expected, $output);
-	}
+    /**
+     * @param string|array $input
+     * @param string|array $expected
+     * @test
+     * @dataProvider getSanitizePathTestValues
+     */
+    public function testSanitizePath($input, $expected)
+    {
+        $instance = new TemplatePaths();
+        $method = new \ReflectionMethod($instance, 'sanitizePath');
+        $method->setAccessible(true);
+        $output = $method->invokeArgs($instance, [$input]);
+        $this->assertEquals($expected, $output);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getSanitizePathTestValues() {
-		return array(
-			array('', ''),
-			array('/foo/bar/baz', '/foo/bar/baz'),
-			array('C:\\foo\\bar\baz', 'C:/foo/bar/baz'),
-			array(__FILE__, strtr(__FILE__, '\\', '/')),
-			array(__DIR__, strtr(__DIR__, '\\', '/') . '/'),
-			array('composer.json', strtr(getcwd(), '\\', '/') . '/composer.json'),
-            array('php://stdin', 'php://stdin')
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getSanitizePathTestValues()
+    {
+        return [
+            ['', ''],
+            ['/foo/bar/baz', '/foo/bar/baz'],
+            ['C:\\foo\\bar\baz', 'C:/foo/bar/baz'],
+            [__FILE__, strtr(__FILE__, '\\', '/')],
+            [__DIR__, strtr(__DIR__, '\\', '/') . '/'],
+            ['composer.json', strtr(getcwd(), '\\', '/') . '/composer.json'],
+            ['php://stdin', 'php://stdin']
+        ];
+    }
 
-	/**
-	 * @param string|array $input
-	 * @param string|array $expected
-	 * @test
-	 * @dataProvider getSanitizePathsTestValues
-	 */
-	public function testSanitizePaths($input, $expected) {
-		$instance = new TemplatePaths();
-		$method = new \ReflectionMethod($instance, 'sanitizePaths');
-		$method->setAccessible(TRUE);
-		$output = $method->invokeArgs($instance, array($input));
-		$this->assertEquals($expected, $output);
-	}
+    /**
+     * @param string|array $input
+     * @param string|array $expected
+     * @test
+     * @dataProvider getSanitizePathsTestValues
+     */
+    public function testSanitizePaths($input, $expected)
+    {
+        $instance = new TemplatePaths();
+        $method = new \ReflectionMethod($instance, 'sanitizePaths');
+        $method->setAccessible(true);
+        $output = $method->invokeArgs($instance, [$input]);
+        $this->assertEquals($expected, $output);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getSanitizePathsTestValues() {
-		return array(
-			array(array('/foo/bar/baz', 'C:\\foo\\bar\\baz'), array('/foo/bar/baz', 'C:/foo/bar/baz')),
-			array(array(__FILE__, __DIR__), array(strtr(__FILE__, '\\', '/'), strtr(__DIR__, '\\', '/') . '/')),
-			array(array('', 'composer.json'), array('', strtr(getcwd(), '\\', '/') . '/composer.json')),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getSanitizePathsTestValues()
+    {
+        return [
+            [['/foo/bar/baz', 'C:\\foo\\bar\\baz'], ['/foo/bar/baz', 'C:/foo/bar/baz']],
+            [[__FILE__, __DIR__], [strtr(__FILE__, '\\', '/'), strtr(__DIR__, '\\', '/') . '/']],
+            [['', 'composer.json'], ['', strtr(getcwd(), '\\', '/') . '/composer.json']],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function setsLayoutPathAndFilename() {
-		$instance = $this->getMock(TemplatePaths::class, array('sanitizePath'));
-		$instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
-		$instance->setLayoutPathAndFilename('foobar');
-		$this->assertAttributeEquals('foobar', 'layoutPathAndFilename', $instance);
-	}
+    /**
+     * @test
+     */
+    public function setsLayoutPathAndFilename()
+    {
+        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
+        $instance->setLayoutPathAndFilename('foobar');
+        $this->assertAttributeEquals('foobar', 'layoutPathAndFilename', $instance);
+    }
 
-	/**
-	 * @test
-	 */
-	public function setsTemplatePathAndFilename() {
-		$instance = $this->getMock(TemplatePaths::class, array('sanitizePath'));
-		$instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
-		$instance->setTemplatePathAndFilename('foobar');
-		$this->assertAttributeEquals('foobar', 'templatePathAndFilename', $instance);
-	}
+    /**
+     * @test
+     */
+    public function setsTemplatePathAndFilename()
+    {
+        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
+        $instance->setTemplatePathAndFilename('foobar');
+        $this->assertAttributeEquals('foobar', 'templatePathAndFilename', $instance);
+    }
 
-	/**
-	 * @dataProvider getGetterAndSetterTestValues
-	 * @param string $property
-	 * @param mixed $value
-	 */
-	public function testGetterAndSetter($property, $value) {
-		$getter = 'get' . ucfirst($property);
-		$setter = 'set' . ucfirst($property);
-		$instance = $this->getMock(TemplatePaths::class, array('sanitizePath'));
-		$instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
-		$instance->$setter($value);
-		$this->assertEquals($value, $instance->$getter());
-	}
+    /**
+     * @dataProvider getGetterAndSetterTestValues
+     * @param string $property
+     * @param mixed $value
+     */
+    public function testGetterAndSetter($property, $value)
+    {
+        $getter = 'get' . ucfirst($property);
+        $setter = 'set' . ucfirst($property);
+        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
+        $instance->$setter($value);
+        $this->assertEquals($value, $instance->$getter());
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getGetterAndSetterTestValues() {
-		return array(
-			array('layoutRootPaths', array('foo' => 'bar')),
-			array('templateRootPaths', array('foo' => 'bar')),
-			array('partialRootPaths', array('foo' => 'bar'))
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getGetterAndSetterTestValues()
+    {
+        return [
+            ['layoutRootPaths', ['foo' => 'bar']],
+            ['templateRootPaths', ['foo' => 'bar']],
+            ['partialRootPaths', ['foo' => 'bar']]
+        ];
+    }
 
-	/**
-	 * @return void
-	 */
-	public function testFillByPackageName() {
-		$instance = new TemplatePaths('FluidTYPO3.Flux');
-		$this->assertNotEmpty($instance->getTemplateRootPaths());
-	}
+    /**
+     * @return void
+     */
+    public function testFillByPackageName()
+    {
+        $instance = new TemplatePaths('FluidTYPO3.Flux');
+        $this->assertNotEmpty($instance->getTemplateRootPaths());
+    }
 
-	/**
-	 * @return void
-	 */
-	public function testFillByConfigurationArray() {
-		$instance = new TemplatePaths(array(
-			TemplatePaths::CONFIG_TEMPLATEROOTPATHS => array('Resources/Private/Templates/'),
-			TemplatePaths::CONFIG_LAYOUTROOTPATHS => array('Resources/Private/Layouts/'),
-			TemplatePaths::CONFIG_PARTIALROOTPATHS => array('Resources/Private/Partials/'),
-			TemplatePaths::CONFIG_FORMAT => 'xml'
-		));
-		$this->assertNotEmpty($instance->getTemplateRootPaths());
-	}
+    /**
+     * @return void
+     */
+    public function testFillByConfigurationArray()
+    {
+        $instance = new TemplatePaths([
+            TemplatePaths::CONFIG_TEMPLATEROOTPATHS => ['Resources/Private/Templates/'],
+            TemplatePaths::CONFIG_LAYOUTROOTPATHS => ['Resources/Private/Layouts/'],
+            TemplatePaths::CONFIG_PARTIALROOTPATHS => ['Resources/Private/Partials/'],
+            TemplatePaths::CONFIG_FORMAT => 'xml'
+        ]);
+        $this->assertNotEmpty($instance->getTemplateRootPaths());
+    }
 
-	/**
-	 * @dataProvider getResolveFilesMethodTestValues
-	 * @param string $method
-	 */
-	public function testResolveFilesMethodCallsResolveFilesInFolders($method, $pathsMethod) {
-		$instance = $this->getMock(TemplatePaths::class, array('resolveFilesInFolders'));
-		$instance->$pathsMethod(array('foo'));
-		$instance->expects($this->once())->method('resolveFilesInFolders')->with($this->anything(), 'format');
-		$instance->$method('format', 'format');
-	}
+    /**
+     * @dataProvider getResolveFilesMethodTestValues
+     * @param string $method
+     */
+    public function testResolveFilesMethodCallsResolveFilesInFolders($method, $pathsMethod)
+    {
+        $instance = $this->getMock(TemplatePaths::class, ['resolveFilesInFolders']);
+        $instance->$pathsMethod(['foo']);
+        $instance->expects($this->once())->method('resolveFilesInFolders')->with($this->anything(), 'format');
+        $instance->$method('format', 'format');
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getResolveFilesMethodTestValues() {
-		return array(
-			array('resolveAvailableTemplateFiles', 'setTemplateRootPaths'),
-			array('resolveAvailablePartialFiles', 'setPartialRootPaths'),
-			array('resolveAvailableLayoutFiles', 'setLayoutRootPaths')
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getResolveFilesMethodTestValues()
+    {
+        return [
+            ['resolveAvailableTemplateFiles', 'setTemplateRootPaths'],
+            ['resolveAvailablePartialFiles', 'setPartialRootPaths'],
+            ['resolveAvailableLayoutFiles', 'setLayoutRootPaths']
+        ];
+    }
 
-	/**
-	 * @return void
-	 */
-	public function testToArray() {
-		$instance = $this->getMock(TemplatePaths::class, array('sanitizePath'));
-		$instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
-		$instance->setTemplateRootPaths(array('1'));
-		$instance->setLayoutRootPaths(array('2'));
-		$instance->setPartialRootPaths(array('3'));
-		$result = $instance->toArray();
-		$expected = array(
-			TemplatePaths::CONFIG_TEMPLATEROOTPATHS => array(1),
-			TemplatePaths::CONFIG_LAYOUTROOTPATHS => array(2),
-			TemplatePaths::CONFIG_PARTIALROOTPATHS => array(3)
-		);
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @return void
+     */
+    public function testToArray()
+    {
+        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
+        $instance->setTemplateRootPaths(['1']);
+        $instance->setLayoutRootPaths(['2']);
+        $instance->setPartialRootPaths(['3']);
+        $result = $instance->toArray();
+        $expected = [
+            TemplatePaths::CONFIG_TEMPLATEROOTPATHS => [1],
+            TemplatePaths::CONFIG_LAYOUTROOTPATHS => [2],
+            TemplatePaths::CONFIG_PARTIALROOTPATHS => [3]
+        ];
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testResolveFilesInFolders() {
-		$instance = new TemplatePaths();
-		$method = new \ReflectionMethod($instance, 'resolveFilesInFolders');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs(
-			$instance,
-			array(array('examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'), 'html')
-		);
-		$this->assertEquals(
-			array(
-				'examples/Resources/Private/Layouts/Default.html',
-				'examples/Resources/Private/Layouts/Dynamic.html',
-				'examples/Resources/Private/Templates/Default/Default.html',
-			),
-			$result
-		);
-	}
+    /**
+     * @test
+     */
+    public function testResolveFilesInFolders()
+    {
+        $instance = new TemplatePaths();
+        $method = new \ReflectionMethod($instance, 'resolveFilesInFolders');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs(
+            $instance,
+            [['examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'], 'html']
+        );
+        $this->assertEquals(
+            [
+                'examples/Resources/Private/Layouts/Default.html',
+                'examples/Resources/Private/Layouts/Dynamic.html',
+                'examples/Resources/Private/Templates/Default/Default.html',
+            ],
+            $result
+        );
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetTemplateSourceThrowsExceptionIfFileNotFound() {
-		$instance = new TemplatePaths();
-		$this->setExpectedException(InvalidTemplateResourceException::class);
-		$instance->getTemplateSource();
-	}
+    /**
+     * @test
+     */
+    public function testGetTemplateSourceThrowsExceptionIfFileNotFound()
+    {
+        $instance = new TemplatePaths();
+        $this->setExpectedException(InvalidTemplateResourceException::class);
+        $instance->getTemplateSource();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetTemplateSourceReadsStreamWrappers() {
-		$fixture = __DIR__ . '/Fixtures/LayoutFixture.html';
-		$instance = new TemplatePaths();
-		$stream = fopen($fixture, 'r');
-		$instance->setTemplateSource($stream);
-		$this->assertEquals(stream_get_contents($stream), $instance->getTemplateSource());
-		fclose($stream);
-	}
+    /**
+     * @test
+     */
+    public function testGetTemplateSourceReadsStreamWrappers()
+    {
+        $fixture = __DIR__ . '/Fixtures/LayoutFixture.html';
+        $instance = new TemplatePaths();
+        $stream = fopen($fixture, 'r');
+        $instance->setTemplateSource($stream);
+        $this->assertEquals(stream_get_contents($stream), $instance->getTemplateSource());
+        fclose($stream);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testResolveFileInPathsThrowsExceptionIfFileNotFound() {
-		$instance = new TemplatePaths();
-		$method = new \ReflectionMethod($instance, 'resolveFileInPaths');
-		$method->setAccessible(TRUE);
-		$this->setExpectedException(InvalidTemplateResourceException::class);
-		$method->invokeArgs($instance, array(array('/not/', '/found/'), 'notfound.html'));
-	}
+    /**
+     * @test
+     */
+    public function testResolveFileInPathsThrowsExceptionIfFileNotFound()
+    {
+        $instance = new TemplatePaths();
+        $method = new \ReflectionMethod($instance, 'resolveFileInPaths');
+        $method->setAccessible(true);
+        $this->setExpectedException(InvalidTemplateResourceException::class);
+        $method->invokeArgs($instance, [['/not/', '/found/'], 'notfound.html']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testGetTemplateIdentifierReturnsSourceChecksumWithControllerAndActionAndFormat() {
-		$instance = new TemplatePaths();
-		$instance->setTemplateSource('foobar');
-		$this->assertEquals('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
-	}
-
+    /**
+     * @test
+     */
+    public function testGetTemplateIdentifierReturnsSourceChecksumWithControllerAndActionAndFormat()
+    {
+        $instance = new TemplatePaths();
+        $instance->setTemplateSource('foobar');
+        $this->assertEquals('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
+    }
 }

--- a/tests/Unit/ViewHelpers/AliasViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/AliasViewHelperTest.php
@@ -12,72 +12,83 @@ use TYPO3Fluid\Fluid\ViewHelpers\AliasViewHelper;
 /**
  * Testcase for AliasViewHelper
  */
-class AliasViewHelperTest extends ViewHelperBaseTestcase {
+class AliasViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArgumentsRegistersExpectedArguments() {
-		$instance = $this->getMock(AliasViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('map', 'array', $this->anything(), TRUE);
-		$instance->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $instance = $this->getMock(AliasViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with('map', 'array', $this->anything(), true);
+        $instance->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderAddsSingleValueToTemplateVariableContainerAndRemovesItAfterRendering() {
-		$viewHelper = new AliasViewHelper();
+    /**
+     * @test
+     */
+    public function renderAddsSingleValueToTemplateVariableContainerAndRemovesItAfterRendering()
+    {
+        $viewHelper = new AliasViewHelper();
 
-		$mockViewHelperNode = $this->getMock(
-			ViewHelperNode::class,
-			array('evaluateChildNodes'),
-			array(), '', FALSE
-		);
-		$mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
+        $mockViewHelperNode = $this->getMock(
+            ViewHelperNode::class,
+            ['evaluateChildNodes'],
+            [],
+            '',
+            false
+        );
+        $mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
 
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($mockViewHelperNode);
-		$viewHelper->setArguments(array('map' => array('someAlias' => 'someValue')));
-		$viewHelper->render();
-	}
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($mockViewHelperNode);
+        $viewHelper->setArguments(['map' => ['someAlias' => 'someValue']]);
+        $viewHelper->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderAddsMultipleValuesToTemplateVariableContainerAndRemovesThemAfterRendering() {
-		$viewHelper = new AliasViewHelper();
+    /**
+     * @test
+     */
+    public function renderAddsMultipleValuesToTemplateVariableContainerAndRemovesThemAfterRendering()
+    {
+        $viewHelper = new AliasViewHelper();
 
-		$mockViewHelperNode = $this->getMock(
-			ViewHelperNode::class,
-			array('evaluateChildNodes'),
-			array(), '', FALSE
-		);
-		$mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
+        $mockViewHelperNode = $this->getMock(
+            ViewHelperNode::class,
+            ['evaluateChildNodes'],
+            [],
+            '',
+            false
+        );
+        $mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
 
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($mockViewHelperNode);
-		$viewHelper->setArguments(array('map' => array('someAlias' => 'someValue', 'someOtherAlias' => 'someOtherValue')));
-		$viewHelper->render();
-	}
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($mockViewHelperNode);
+        $viewHelper->setArguments(['map' => ['someAlias' => 'someValue', 'someOtherAlias' => 'someOtherValue']]);
+        $viewHelper->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderDoesNotTouchTemplateVariableContainerAndReturnsChildNodesIfMapIsEmpty() {
-		$viewHelper = new AliasViewHelper();
+    /**
+     * @test
+     */
+    public function renderDoesNotTouchTemplateVariableContainerAndReturnsChildNodesIfMapIsEmpty()
+    {
+        $viewHelper = new AliasViewHelper();
 
-		$mockViewHelperNode = $this->getMock(
-			ViewHelperNode::class,
-			array('evaluateChildNodes'), array(), '',
-			FALSE
-		);
-		$mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
+        $mockViewHelperNode = $this->getMock(
+            ViewHelperNode::class,
+            ['evaluateChildNodes'],
+            [],
+            '',
+            false
+        );
+        $mockViewHelperNode->expects($this->once())->method('evaluateChildNodes')->will($this->returnValue('foo'));
 
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($mockViewHelperNode);
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($mockViewHelperNode);
 
-		$viewHelper->setArguments(array('map' => array()));
-		$this->assertEquals('foo', $viewHelper->render());
-	}
+        $viewHelper->setArguments(['map' => []]);
+        $this->assertEquals('foo', $viewHelper->render());
+    }
 }

--- a/tests/Unit/ViewHelpers/Cache/DisableViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Cache/DisableViewHelperTest.php
@@ -15,31 +15,33 @@ use TYPO3Fluid\Fluid\ViewHelpers\Cache\DisableViewHelper;
 /**
  * Testcase for DisableViewHelper
  */
-class DisableViewHelperTest extends ViewHelperBaseTestcase {
+class DisableViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testRenderCallsRenderChildren() {
-		$subject = $this->getMockBuilder(DisableViewHelper::class)->setMethods(array('renderChildren'))->getMock();
-		$subject->expects($this->once())->method('renderChildren')->willReturn('test');
-		$this->assertEquals('test', $subject->render());
-	}
+    /**
+     * @test
+     */
+    public function testRenderCallsRenderChildren()
+    {
+        $subject = $this->getMockBuilder(DisableViewHelper::class)->setMethods(['renderChildren'])->getMock();
+        $subject->expects($this->once())->method('renderChildren')->willReturn('test');
+        $this->assertEquals('test', $subject->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCompile() {
-		$subject = new DisableViewHelper();
-		$subject->setRenderingContext(new RenderingContextFixture());
-		$node = $this->getMockBuilder(ViewHelperNode::class)
-			->setMethods(array('dummy'))
-			->disableOriginalConstructor()
-			->getMock();
-		$compiler = $this->getMockBuilder(TemplateCompiler::class)->setMethods(array('disable'))->getMock();
-		$compiler->expects($this->once())->method('disable');
-		$code = '';
-		$subject->compile('test', 'test', $code, $node, $compiler);
-	}
-
+    /**
+     * @test
+     */
+    public function testCompile()
+    {
+        $subject = new DisableViewHelper();
+        $subject->setRenderingContext(new RenderingContextFixture());
+        $node = $this->getMockBuilder(ViewHelperNode::class)
+            ->setMethods(['dummy'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $compiler = $this->getMockBuilder(TemplateCompiler::class)->setMethods(['disable'])->getMock();
+        $compiler->expects($this->once())->method('disable');
+        $code = '';
+        $subject->compile('test', 'test', $code, $node, $compiler);
+    }
 }

--- a/tests/Unit/ViewHelpers/Cache/StaticViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Cache/StaticViewHelperTest.php
@@ -16,32 +16,34 @@ use TYPO3Fluid\Fluid\ViewHelpers\Cache\StaticViewHelper;
 /**
  * Testcase for StaticViewHelper
  */
-class StaticViewHelperTest extends ViewHelperBaseTestcase {
+class StaticViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testRenderCallsRenderChildren() {
-		$subject = $this->getMockBuilder(StaticViewHelper::class)->setMethods(array('renderChildren'))->getMock();
-		$subject->expects($this->once())->method('renderChildren')->willReturn('test');
-		$this->assertEquals('test', $subject->render());
-	}
+    /**
+     * @test
+     */
+    public function testRenderCallsRenderChildren()
+    {
+        $subject = $this->getMockBuilder(StaticViewHelper::class)->setMethods(['renderChildren'])->getMock();
+        $subject->expects($this->once())->method('renderChildren')->willReturn('test');
+        $this->assertEquals('test', $subject->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCompile() {
-		$subject = new StaticViewHelper();
-		$subject->setRenderingContext(new RenderingContextFixture());
-		$node = $this->getMockBuilder(ViewHelperNode::class)
-			->setMethods(array('evaluateChildNodes'))
-			->disableOriginalConstructor()
-			->getMock();
-		$node->expects($this->once())->method('evaluateChildNodes');
-		$compiler = new TemplateCompiler();
-		$this->setExpectedException(StopCompilingChildrenException::class);
-		$code = '';
-		$subject->compile('test', 'test', $code, $node, $compiler);
-	}
-
+    /**
+     * @test
+     */
+    public function testCompile()
+    {
+        $subject = new StaticViewHelper();
+        $subject->setRenderingContext(new RenderingContextFixture());
+        $node = $this->getMockBuilder(ViewHelperNode::class)
+            ->setMethods(['evaluateChildNodes'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node->expects($this->once())->method('evaluateChildNodes');
+        $compiler = new TemplateCompiler();
+        $this->setExpectedException(StopCompilingChildrenException::class);
+        $code = '';
+        $subject->compile('test', 'test', $code, $node, $compiler);
+    }
 }

--- a/tests/Unit/ViewHelpers/Cache/WarmupViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Cache/WarmupViewHelperTest.php
@@ -18,60 +18,69 @@ use TYPO3Fluid\Fluid\ViewHelpers\Cache\WarmupViewHelper;
 /**
  * Testcase for StaticViewHelper
  */
-class WarmupViewHelperTest extends ViewHelperBaseTestcase {
+class WarmupViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testCompileThrowsStopCompilingChildrenException() {
-		$subject = new WarmupViewHelper();
-		$subject->initializeArguments();
-		$subject->setRenderChildrenClosure(function() { return 'test'; });
-		$subject->setArguments(array('variables' => array('foo' => 'bar')));
-		$renderingContext = new RenderingContextFixture();
-		$renderingContext->setVariableProvider(new StandardVariableProvider());
-		$subject->setRenderingContext($renderingContext);
-		$viewHelperNode = $this->getMock(ViewHelperNode::class, array('dummy'), array(), '', FALSE);
-		$initializationCode = '';
-		$this->setExpectedException(StopCompilingChildrenException::class);
-		$subject->compile(
-			'argumentName',
-			'closureName',
-			$initializationCode,
-			$viewHelperNode,
-			new TemplateCompiler()
-		);
-	}
+    /**
+     * @test
+     */
+    public function testCompileThrowsStopCompilingChildrenException()
+    {
+        $subject = new WarmupViewHelper();
+        $subject->initializeArguments();
+        $subject->setRenderChildrenClosure(function () {
+            return 'test';
+        });
+        $subject->setArguments(['variables' => ['foo' => 'bar']]);
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->setVariableProvider(new StandardVariableProvider());
+        $subject->setRenderingContext($renderingContext);
+        $viewHelperNode = $this->getMock(ViewHelperNode::class, ['dummy'], [], '', false);
+        $initializationCode = '';
+        $this->setExpectedException(StopCompilingChildrenException::class);
+        $subject->compile(
+            'argumentName',
+            'closureName',
+            $initializationCode,
+            $viewHelperNode,
+            new TemplateCompiler()
+        );
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderReturnsContentDirectlyOutsideWarmupMode() {
-		$compiler = $this->getMock(TemplateCompiler::class, array('isWarmupMode'));
-		$compiler->expects($this->once())->method('isWarmupMode')->willReturn(FALSE);
-		$renderingContext = $this->getMock(RenderingContextFixture::class, array('setVariableProvider'));
-		$renderingContext->expects($this->never())->method('setVariableProvider');
-		$renderingContext->setTemplateCompiler($compiler);
-		$subject = new WarmupViewHelper();
-		$subject->setRenderChildrenClosure(function() { return 'test'; });
-		$subject->setRenderingContext($renderingContext);
-		$this->assertEquals('test', $subject->render());
-	}
+    /**
+     * @test
+     */
+    public function testRenderReturnsContentDirectlyOutsideWarmupMode()
+    {
+        $compiler = $this->getMock(TemplateCompiler::class, ['isWarmupMode']);
+        $compiler->expects($this->once())->method('isWarmupMode')->willReturn(false);
+        $renderingContext = $this->getMock(RenderingContextFixture::class, ['setVariableProvider']);
+        $renderingContext->expects($this->never())->method('setVariableProvider');
+        $renderingContext->setTemplateCompiler($compiler);
+        $subject = new WarmupViewHelper();
+        $subject->setRenderChildrenClosure(function () {
+            return 'test';
+        });
+        $subject->setRenderingContext($renderingContext);
+        $this->assertEquals('test', $subject->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderOverlaysAndRestoresVariableProviderAndReturnsContentInsideWarmupMode() {
-		$compiler = $this->getMock(TemplateCompiler::class, array('isWarmupMode'));
-		$compiler->expects($this->once())->method('isWarmupMode')->willReturn(TRUE);
-		$renderingContext = $this->getMock(RenderingContextFixture::class, array('setVariableProvider'));
-		$renderingContext->expects($this->exactly(2))->method('setVariableProvider');
-		$renderingContext->setTemplateCompiler($compiler);
-		$subject = new WarmupViewHelper();
-		$subject->setArguments(array('variables' => array('foo' => 'bar')));
-		$subject->setRenderChildrenClosure(function() { return 'test'; });
-		$subject->setRenderingContext($renderingContext);
-		$this->assertEquals('test', $subject->render());
-	}
-
+    /**
+     * @test
+     */
+    public function testRenderOverlaysAndRestoresVariableProviderAndReturnsContentInsideWarmupMode()
+    {
+        $compiler = $this->getMock(TemplateCompiler::class, ['isWarmupMode']);
+        $compiler->expects($this->once())->method('isWarmupMode')->willReturn(true);
+        $renderingContext = $this->getMock(RenderingContextFixture::class, ['setVariableProvider']);
+        $renderingContext->expects($this->exactly(2))->method('setVariableProvider');
+        $renderingContext->setTemplateCompiler($compiler);
+        $subject = new WarmupViewHelper();
+        $subject->setArguments(['variables' => ['foo' => 'bar']]);
+        $subject->setRenderChildrenClosure(function () {
+            return 'test';
+        });
+        $subject->setRenderingContext($renderingContext);
+        $this->assertEquals('test', $subject->render());
+    }
 }

--- a/tests/Unit/ViewHelpers/CaseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CaseViewHelperTest.php
@@ -11,46 +11,50 @@ use TYPO3Fluid\Fluid\ViewHelpers\SwitchViewHelper;
 /**
  * Testcase for CaseViewHelper
  */
-class CaseViewHelperTest extends ViewHelperBaseTestcase {
+class CaseViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var CaseViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var CaseViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getMock(CaseViewHelper::class, array('renderChildren'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getMock(CaseViewHelper::class, ['renderChildren']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
-	 */
-	public function renderThrowsExceptionIfSwitchExpressionIsNotSetInViewHelperVariableContainer() {
-		$this->viewHelper->setArguments(array('value' => 'foo'));
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     */
+    public function renderThrowsExceptionIfSwitchExpressionIsNotSetInViewHelperVariableContainer()
+    {
+        $this->viewHelper->setArguments(['value' => 'foo']);
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsChildNodesIfTheSpecifiedValueIsEqualToTheSwitchExpression() {
-		$this->viewHelperVariableContainer->addOrUpdate(SwitchViewHelper::class, 'switchExpression', 'someValue');
-		$renderedChildNodes = 'ChildNodes';
-		$this->viewHelper->setArguments(array('value' => 'someValue'));
-		$this->viewHelper->expects($this->once())->method('renderChildren')->willReturn($renderedChildNodes);
-		$this->assertSame($renderedChildNodes, $this->viewHelper->render());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsChildNodesIfTheSpecifiedValueIsEqualToTheSwitchExpression()
+    {
+        $this->viewHelperVariableContainer->addOrUpdate(SwitchViewHelper::class, 'switchExpression', 'someValue');
+        $renderedChildNodes = 'ChildNodes';
+        $this->viewHelper->setArguments(['value' => 'someValue']);
+        $this->viewHelper->expects($this->once())->method('renderChildren')->willReturn($renderedChildNodes);
+        $this->assertSame($renderedChildNodes, $this->viewHelper->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsAnEmptyStringIfTheSpecifiedValueIsNotEqualToTheSwitchExpression() {
-		$this->viewHelperVariableContainer->addOrUpdate(SwitchViewHelper::class, 'switchExpression', 'someValue');
-		$this->viewHelper->setArguments(array('value' => 'someOtherValue'));
-		$this->assertSame('', $this->viewHelper->initializeArgumentsAndRender());
-	}
-
+    /**
+     * @test
+     */
+    public function renderReturnsAnEmptyStringIfTheSpecifiedValueIsNotEqualToTheSwitchExpression()
+    {
+        $this->viewHelperVariableContainer->addOrUpdate(SwitchViewHelper::class, 'switchExpression', 'someValue');
+        $this->viewHelper->setArguments(['value' => 'someOtherValue']);
+        $this->assertSame('', $this->viewHelper->initializeArgumentsAndRender());
+    }
 }

--- a/tests/Unit/ViewHelpers/CommentViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CommentViewHelperTest.php
@@ -11,15 +11,16 @@ use TYPO3Fluid\Fluid\ViewHelpers\CommentViewHelper;
 /**
  * Testcase for CommentViewHelper
  */
-class CommentViewHelperTest extends ViewHelperBaseTestcase {
+class CommentViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testRenderReturnsNull() {
-		$instance = new CommentViewHelper();
-		$result = $instance->render();
-		$this->assertNull($result);
-	}
-
+    /**
+     * @test
+     */
+    public function testRenderReturnsNull()
+    {
+        $instance = new CommentViewHelper();
+        $result = $instance->render();
+        $this->assertNull($result);
+    }
 }

--- a/tests/Unit/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CountViewHelperTest.php
@@ -11,87 +11,99 @@ use TYPO3Fluid\Fluid\ViewHelpers\CountViewHelper;
 /**
  * Testcase for CountViewHelper
  */
-class CountViewHelperTest extends ViewHelperBaseTestcase {
+class CountViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var CountViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var CountViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getAccessibleMock(CountViewHelper::class, array('buildRenderChildrenClosure'));
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getAccessibleMock(CountViewHelper::class, ['buildRenderChildrenClosure']);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsNumberOfElementsInAnArray() {
-		$this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
-		$expectedResult = 3;
-		$this->arguments = array('subject' => array('foo', 'bar', 'Baz'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertSame($expectedResult, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsNumberOfElementsInAnArray()
+    {
+        $this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
+        $expectedResult = 3;
+        $this->arguments = ['subject' => ['foo', 'bar', 'Baz']];
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsNumberOfElementsInAnArrayObject() {
-		$this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
-		$expectedResult = 2;
-		$this->arguments = array('subject' => new \ArrayObject(array('foo', 'bar')));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertSame($expectedResult, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsNumberOfElementsInAnArrayObject()
+    {
+        $this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
+        $expectedResult = 2;
+        $this->arguments = ['subject' => new \ArrayObject(['foo', 'bar'])];
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsZeroIfGivenArrayIsEmpty() {
-		$this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
-		$expectedResult = 0;
-		$this->arguments = array('subject' => array());
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$actualResult = $this->viewHelper->render();
-		$this->assertSame($expectedResult, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsZeroIfGivenArrayIsEmpty()
+    {
+        $this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
+        $expectedResult = 0;
+        $this->arguments = ['subject' => []];
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $actualResult = $this->viewHelper->render();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderUsesChildrenAsSubjectIfGivenSubjectIsNull() {
-		$this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')
-			->will($this->returnValue(function() { return array('foo', 'baz', 'bar'); }));
-		$expectedResult = 3;
-		$this->arguments = array('subject' => NULL);
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertSame($expectedResult, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderUsesChildrenAsSubjectIfGivenSubjectIsNull()
+    {
+        $this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')
+            ->will($this->returnValue(function () {
+                return ['foo', 'baz', 'bar'];
+            }));
+        $expectedResult = 3;
+        $this->arguments = ['subject' => null];
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsZeroIfGivenSubjectIsNullAndRenderChildrenReturnsNull() {
-		$this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')
-			->will($this->returnValue(function() { return NULL; }));
-		$this->viewHelper->setArguments(array('subject' => NULL));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$expectedResult = 0;
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertSame($expectedResult, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsZeroIfGivenSubjectIsNullAndRenderChildrenReturnsNull()
+    {
+        $this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')
+            ->will($this->returnValue(function () {
+                return null;
+            }));
+        $this->viewHelper->setArguments(['subject' => null]);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $expectedResult = 0;
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 
-	/**
-	 * @test
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function renderThrowsExceptionIfGivenSubjectIsNotCountable() {
-		$object = new \stdClass();
-		$this->viewHelper->setArguments(array('subject' => $object));
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function renderThrowsExceptionIfGivenSubjectIsNotCountable()
+    {
+        $object = new \stdClass();
+        $this->viewHelper->setArguments(['subject' => $object]);
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 }

--- a/tests/Unit/ViewHelpers/CycleViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CycleViewHelperTest.php
@@ -11,65 +11,72 @@ use TYPO3Fluid\Fluid\ViewHelpers\CycleViewHelper;
 /**
  * Testcase for CycleViewHelper
  */
-class CycleViewHelperTest extends ViewHelperBaseTestcase {
+class CycleViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var CycleViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var CycleViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getMock(CycleViewHelper::class, array('renderChildren'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$this->viewHelper->initializeArguments();
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getMock(CycleViewHelper::class, ['renderChildren']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $this->viewHelper->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderAddsCurrentValueToTemplateVariableContainerAndRemovesItAfterRendering() {
-		$values = array('bar', 'Fluid');
-		$this->viewHelper->setArguments(array('values' => $values, 'as' => 'innerVariable'));
-		$this->viewHelper->render();
-	}
+    /**
+     * @test
+     */
+    public function renderAddsCurrentValueToTemplateVariableContainerAndRemovesItAfterRendering()
+    {
+        $values = ['bar', 'Fluid'];
+        $this->viewHelper->setArguments(['values' => $values, 'as' => 'innerVariable']);
+        $this->viewHelper->render();
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
-	 */
-	public function renderThrowsExceptionWhenPassingObjectsToValuesThatAreNotTraversable() {
-		$object = new \stdClass();
-		$this->viewHelper->setArguments(array('values' => $object, 'as' => 'innerVariable'));
-		$this->viewHelper->render();
-	}
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     */
+    public function renderThrowsExceptionWhenPassingObjectsToValuesThatAreNotTraversable()
+    {
+        $object = new \stdClass();
+        $this->viewHelper->setArguments(['values' => $object, 'as' => 'innerVariable']);
+        $this->viewHelper->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsChildNodesIfValuesIsNull() {
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Child nodes'));
-		$this->viewHelper->setArguments(array('values' => NULL, 'as' => 'foo'));
-		$this->assertEquals('Child nodes', $this->viewHelper->render(NULL, 'foo'));
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsChildNodesIfValuesIsNull()
+    {
+        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Child nodes'));
+        $this->viewHelper->setArguments(['values' => null, 'as' => 'foo']);
+        $this->assertEquals('Child nodes', $this->viewHelper->render(null, 'foo'));
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsChildNodesIfValuesIsAnEmptyArray() {
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Child nodes'));
-		$this->viewHelper->setArguments(array('values' => array(), 'as' => 'foo'));
-		$this->assertEquals('Child nodes', $this->viewHelper->render());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsChildNodesIfValuesIsAnEmptyArray()
+    {
+        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Child nodes'));
+        $this->viewHelper->setArguments(['values' => [], 'as' => 'foo']);
+        $this->assertEquals('Child nodes', $this->viewHelper->render());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderIteratesThroughElementsOfTraversableObjects() {
-		$traversableObject = new \ArrayObject(array('key1' => 'value1', 'key2' => 'value2'));
-		$this->viewHelper->setArguments(array('values' => $traversableObject, 'as' => 'innerVariable'));
-		$this->viewHelper->render();
-		$this->viewHelper->render();
-		$this->viewHelper->render();
-	}
+    /**
+     * @test
+     */
+    public function renderIteratesThroughElementsOfTraversableObjects()
+    {
+        $traversableObject = new \ArrayObject(['key1' => 'value1', 'key2' => 'value2']);
+        $this->viewHelper->setArguments(['values' => $traversableObject, 'as' => 'innerVariable']);
+        $this->viewHelper->render();
+        $this->viewHelper->render();
+        $this->viewHelper->render();
+    }
 }

--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -13,97 +13,100 @@ use TYPO3Fluid\Fluid\ViewHelpers\DebugViewHelper;
 /**
  * Testcase for DebugViewHelper
  */
-class DebugViewHelperTest extends ViewHelperBaseTestcase {
+class DebugViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArgumentsRegistersExpectedArguments() {
-		$instance = $this->getMock(DebugViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('typeOnly', 'boolean', $this->anything(), FALSE, FALSE);
-		$instance->setRenderingContext(new RenderingContextFixture());
-		$instance->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $instance = $this->getMock(DebugViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with('typeOnly', 'boolean', $this->anything(), false, false);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $instance->initializeArguments();
+    }
 
-	/**
-	 * @dataProvider getRenderTestValues
-	 * @param mixed $value
-	 * @param array $arguments
-	 * @param string $expected
-	 */
-	public function testRender($value, array $arguments, $expected) {
-		$instance = $this->getMock(DebugViewHelper::class, array('renderChildren'));
-		$instance->expects($this->once())->method('renderChildren')->willReturn($value);
-		$instance->setArguments($arguments);
-		$instance->setRenderingContext(new RenderingContextFixture());
-		$result = $instance->render();
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @dataProvider getRenderTestValues
+     * @param mixed $value
+     * @param array $arguments
+     * @param string $expected
+     */
+    public function testRender($value, array $arguments, $expected)
+    {
+        $instance = $this->getMock(DebugViewHelper::class, ['renderChildren']);
+        $instance->expects($this->once())->method('renderChildren')->willReturn($value);
+        $instance->setArguments($arguments);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $result = $instance->render();
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array('test', array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 1), "string 'test'" . PHP_EOL),
-			array('test', array('typeOnly' => TRUE, 'html' => FALSE, 'levels' => 1), 'string'),
-			array(
-				'test<strong>bold</strong>',
-				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 1),
-				'<code>string = \'test&lt;strong&gt;bold&lt;/strong&gt;\'</code>'
-			),
-			array(
-				array('nested' => 'test<strong>bold</strong>'),
-				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 1),
-				'<code>array</code><ul><li>nested: <code>string = \'test&lt;strong&gt;bold&lt;/strong&gt;\'</code></li></ul>'
-			),
-			array(
-				array('foo' => 'bar'),
-				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 2),
-				'<code>array</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
-			),
-			array(
-				new \ArrayObject(array('foo' => 'bar')),
-				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 2),
-				'<code>ArrayObject</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
-			),
-			array(
-				new \ArrayIterator(array('foo' => 'bar')),
-				array('typeOnly' => FALSE, 'html' => TRUE, 'levels' => 2),
-				'<code>ArrayIterator</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
-			),
-			array(
-				array('foo' => 'bar'),
-				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
-				'array: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
-			),
-			array(
-				new \ArrayObject(array('foo' => 'bar')),
-				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
-				'ArrayObject: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
-			),
-			array(
-				new \ArrayIterator(array('foo' => 'bar')),
-				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
-				'ArrayIterator: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
-			),
-			array(
-				new UserWithoutToString('username'),
-				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
-				UserWithoutToString::class . ': ' . PHP_EOL . '  "name": string \'username\'' . PHP_EOL
-			),
-			array(
-				NULL,
-				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
-				'null' . PHP_EOL
-			),
-			array(
-				\DateTime::createFromFormat('U', '1468328915'),
-				array('typeOnly' => FALSE, 'html' => FALSE, 'levels' => 3),
-				'DateTime: ' . PHP_EOL . '  "class": string \'DateTime\'' . PHP_EOL .
-				'  "ISO8601": string \'2016-07-12T13:08:35+0000\'' . PHP_EOL . '  "UNIXTIME": integer 1468328915' . PHP_EOL
-			)
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getRenderTestValues()
+    {
+        return [
+            ['test', ['typeOnly' => false, 'html' => false, 'levels' => 1], "string 'test'" . PHP_EOL],
+            ['test', ['typeOnly' => true, 'html' => false, 'levels' => 1], 'string'],
+            [
+                'test<strong>bold</strong>',
+                ['typeOnly' => false, 'html' => true, 'levels' => 1],
+                '<code>string = \'test&lt;strong&gt;bold&lt;/strong&gt;\'</code>'
+            ],
+            [
+                ['nested' => 'test<strong>bold</strong>'],
+                ['typeOnly' => false, 'html' => true, 'levels' => 1],
+                '<code>array</code><ul><li>nested: <code>string = \'test&lt;strong&gt;bold&lt;/strong&gt;\'</code></li></ul>'
+            ],
+            [
+                ['foo' => 'bar'],
+                ['typeOnly' => false, 'html' => true, 'levels' => 2],
+                '<code>array</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
+            ],
+            [
+                new \ArrayObject(['foo' => 'bar']),
+                ['typeOnly' => false, 'html' => true, 'levels' => 2],
+                '<code>ArrayObject</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
+            ],
+            [
+                new \ArrayIterator(['foo' => 'bar']),
+                ['typeOnly' => false, 'html' => true, 'levels' => 2],
+                '<code>ArrayIterator</code><ul><li>foo: <code>string = \'bar\'</code></li></ul>'
+            ],
+            [
+                ['foo' => 'bar'],
+                ['typeOnly' => false, 'html' => false, 'levels' => 3],
+                'array: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
+            ],
+            [
+                new \ArrayObject(['foo' => 'bar']),
+                ['typeOnly' => false, 'html' => false, 'levels' => 3],
+                'ArrayObject: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
+            ],
+            [
+                new \ArrayIterator(['foo' => 'bar']),
+                ['typeOnly' => false, 'html' => false, 'levels' => 3],
+                'ArrayIterator: ' . PHP_EOL . '  "foo": string \'bar\'' . PHP_EOL
+            ],
+            [
+                new UserWithoutToString('username'),
+                ['typeOnly' => false, 'html' => false, 'levels' => 3],
+                UserWithoutToString::class . ': ' . PHP_EOL . '  "name": string \'username\'' . PHP_EOL
+            ],
+            [
+                null,
+                ['typeOnly' => false, 'html' => false, 'levels' => 3],
+                'null' . PHP_EOL
+            ],
+            [
+                \DateTime::createFromFormat('U', '1468328915'),
+                ['typeOnly' => false, 'html' => false, 'levels' => 3],
+                'DateTime: ' . PHP_EOL . '  "class": string \'DateTime\'' . PHP_EOL .
+                '  "ISO8601": string \'2016-07-12T13:08:35+0000\'' . PHP_EOL . '  "UNIXTIME": integer 1468328915' . PHP_EOL
+            ]
+        ];
+    }
 }

--- a/tests/Unit/ViewHelpers/DefaultCaseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DefaultCaseViewHelperTest.php
@@ -13,30 +13,32 @@ use TYPO3Fluid\Fluid\ViewHelpers\DefaultCaseViewHelper;
 /**
  * Testcase for DefaultCaseViewHelper
  */
-class DefaultCaseViewHelperTest extends ViewHelperBaseTestcase {
+class DefaultCaseViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testThrowsExceptionIfUsedOutsideSwitch() {
-		$viewHelper = new DefaultCaseViewHelper();
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$this->setExpectedException(Exception::class);
-		$viewHelper->render();
-	}
+    /**
+     * @test
+     */
+    public function testThrowsExceptionIfUsedOutsideSwitch()
+    {
+        $viewHelper = new DefaultCaseViewHelper();
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $this->setExpectedException(Exception::class);
+        $viewHelper->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCallsRenderChildrenWhenUsedInsideSwitch() {
-		$viewHelper = $this->getAccessibleMock(DefaultCaseViewHelper::class, array('renderChildren'));
-		$viewHelper->expects($this->once())->method('renderChildren');
-		$renderingContext = $this->getMock(RenderingContext::class, array('getViewHelperVariableContainer'), array(), '', FALSE);
-		$variableContainer = $this->getMock(ViewHelperVariableContainer::class, array('exists'));
-		$variableContainer->expects($this->once())->method('exists')->willReturn(TRUE);
-		$renderingContext->expects($this->once())->method('getViewHelperVariableContainer')->willReturn($variableContainer);
-		$viewHelper->_set('renderingContext', $renderingContext);
-		$viewHelper->render();
-	}
-
+    /**
+     * @test
+     */
+    public function testCallsRenderChildrenWhenUsedInsideSwitch()
+    {
+        $viewHelper = $this->getAccessibleMock(DefaultCaseViewHelper::class, ['renderChildren']);
+        $viewHelper->expects($this->once())->method('renderChildren');
+        $renderingContext = $this->getMock(RenderingContext::class, ['getViewHelperVariableContainer'], [], '', false);
+        $variableContainer = $this->getMock(ViewHelperVariableContainer::class, ['exists']);
+        $variableContainer->expects($this->once())->method('exists')->willReturn(true);
+        $renderingContext->expects($this->once())->method('getViewHelperVariableContainer')->willReturn($variableContainer);
+        $viewHelper->_set('renderingContext', $renderingContext);
+        $viewHelper->render();
+    }
 }

--- a/tests/Unit/ViewHelpers/ElseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ElseViewHelperTest.php
@@ -12,39 +12,42 @@ use TYPO3Fluid\Fluid\ViewHelpers\ElseViewHelper;
 /**
  * Testcase for ElseViewHelper
  */
-class ElseViewHelperTest extends ViewHelperBaseTestcase {
+class ElseViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArgumentsRegistersExpectedArguments() {
-		$instance = $this->getMock(ElseViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('if', 'boolean', $this->anything());
-		$instance->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $instance = $this->getMock(ElseViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with('if', 'boolean', $this->anything());
+        $instance->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderRendersChildren() {
-		$viewHelper = $this->getMock(ElseViewHelper::class, array('renderChildren'));
+    /**
+     * @test
+     */
+    public function renderRendersChildren()
+    {
+        $viewHelper = $this->getMock(ElseViewHelper::class, ['renderChildren']);
 
-		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
-		$actualResult = $viewHelper->render();
-		$this->assertEquals('foo', $actualResult);
-	}
+        $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
+        $actualResult = $viewHelper->render();
+        $this->assertEquals('foo', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCompilesToEmptyString() {
-		$viewHelper = new ElseViewHelper();
-		$node = $this->getMock(ViewHelperNode::class, array(), array(), '', FALSE);
-		$compiler = $this->getMock(TemplateCompiler::class);
-		$init = '';
-		$result = $viewHelper->compile('', '', $init, $node, $compiler);
-		$this->assertEmpty($init);
-		$this->assertEquals('\'\'', $result);
-	}
-
+    /**
+     * @test
+     */
+    public function testCompilesToEmptyString()
+    {
+        $viewHelper = new ElseViewHelper();
+        $node = $this->getMock(ViewHelperNode::class, [], [], '', false);
+        $compiler = $this->getMock(TemplateCompiler::class);
+        $init = '';
+        $result = $viewHelper->compile('', '', $init, $node, $compiler);
+        $this->assertEmpty($init);
+        $this->assertEquals('\'\'', $result);
+    }
 }

--- a/tests/Unit/ViewHelpers/Fixtures/ConstraintSyntaxTreeNode.php
+++ b/tests/Unit/ViewHelpers/Fixtures/ConstraintSyntaxTreeNode.php
@@ -14,22 +14,26 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
 /**
  * Constraint syntax tree node fixture
  */
-class ConstraintSyntaxTreeNode extends ViewHelperNode {
-	public $callProtocol = array();
+class ConstraintSyntaxTreeNode extends ViewHelperNode
+{
+    public $callProtocol = [];
 
-	public function __construct(VariableProviderInterface $variableContainer) {
-		$this->variableContainer = $variableContainer;
-	}
+    public function __construct(VariableProviderInterface $variableContainer)
+    {
+        $this->variableContainer = $variableContainer;
+    }
 
-	public function evaluateChildNodes(RenderingContextInterface $renderingContext) {
-		$identifiers = (array) $this->variableContainer->getAllIdentifiers();
-		$callElement = array();
-		foreach ($identifiers as $identifier) {
-			$callElement[$identifier] = $this->variableContainer->get($identifier);
-		}
-		$this->callProtocol[] = $callElement;
-	}
+    public function evaluateChildNodes(RenderingContextInterface $renderingContext)
+    {
+        $identifiers = (array) $this->variableContainer->getAllIdentifiers();
+        $callElement = [];
+        foreach ($identifiers as $identifier) {
+            $callElement[$identifier] = $this->variableContainer->get($identifier);
+        }
+        $this->callProtocol[] = $callElement;
+    }
 
-	public function evaluate(RenderingContextInterface $renderingContext) {
-	}
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+    }
 }

--- a/tests/Unit/ViewHelpers/Fixtures/ParsedTemplateImplementationFixture.php
+++ b/tests/Unit/ViewHelpers/Fixtures/ParsedTemplateImplementationFixture.php
@@ -5,42 +5,51 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 
-class ParsedTemplateImplementationFixture implements ParsedTemplateInterface {
+class ParsedTemplateImplementationFixture implements ParsedTemplateInterface
+{
 
-	public function setIdentifier($identifier) {
-		// stub
-	}
+    public function setIdentifier($identifier)
+    {
+        // stub
+    }
 
-	public function getIdentifier() {
-		// stub
-	}
+    public function getIdentifier()
+    {
+        // stub
+    }
 
-	public function render(RenderingContextInterface $renderingContext) {
-		return 'rendered by fixture';
-	}
+    public function render(RenderingContextInterface $renderingContext)
+    {
+        return 'rendered by fixture';
+    }
 
-	public function getVariableContainer() {
-		// stub
-	}
+    public function getVariableContainer()
+    {
+        // stub
+    }
 
-	public function getLayoutName(RenderingContextInterface $renderingContext) {
-		// stub
-	}
+    public function getLayoutName(RenderingContextInterface $renderingContext)
+    {
+        // stub
+    }
 
-	public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {
-		// stub
-	}
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext)
+    {
+        // stub
+    }
 
-	public function hasLayout() {
-		// stub
-	}
+    public function hasLayout()
+    {
+        // stub
+    }
 
-	public function isCompilable() {
-		// stub
-	}
+    public function isCompilable()
+    {
+        // stub
+    }
 
-	public function isCompiled() {
-		// stub
-	}
-
+    public function isCompiled()
+    {
+        // stub
+    }
 }

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithToArray.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithToArray.php
@@ -9,12 +9,14 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
 /**
  * Dummy object to test Viewhelper behavior on objects with a toArray() method
  */
-class UserWithToArray extends UserWithToString {
+class UserWithToArray extends UserWithToString
+{
 
-	/**
-	 * @return array
-	 */
-	function toArray() {
-		return array('name' => $this->name);
-	}
+    /**
+     * @return array
+     */
+    function toArray()
+    {
+        return ['name' => $this->name];
+    }
 }

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithToString.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithToString.php
@@ -9,12 +9,14 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
 /**
  * Dummy object to test Viewhelper behavior on objects with a __toString method
  */
-class UserWithToString extends UserWithoutToString {
+class UserWithToString extends UserWithoutToString
+{
 
-	/**
-	 * @return string
-	 */
-	function __toString() {
-		return $this->name;
-	}
+    /**
+     * @return string
+     */
+    function __toString()
+    {
+        return $this->name;
+    }
 }

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithoutToString.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithoutToString.php
@@ -9,31 +9,35 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
 /**
  * Dummy object to test Viewhelper behavior on objects without a __toString method
  */
-class UserWithoutToString {
+class UserWithoutToString
+{
 
-	/**
-	 * @var string
-	 */
-	protected $name;
+    /**
+     * @var string
+     */
+    protected $name;
 
-	/**
-	 * @param string $name
-	 */
-	public function __construct($name) {
-		$this->name = $name;
-	}
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getName() {
-		return $this->name;
-	}
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 
-	/**
-	 * @return boolean
-	 */
-	public function isNamed() {
-		return !empty($this->name);
-	}
+    /**
+     * @return boolean
+     */
+    public function isNamed()
+    {
+        return !empty($this->name);
+    }
 }

--- a/tests/Unit/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ForViewHelperTest.php
@@ -14,420 +14,436 @@ use TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper;
 /**
  * Testcase for ForViewHelper
  */
-class ForViewHelperTest extends ViewHelperBaseTestcase {
-
-	public function setUp() {
-		parent::setUp();
-
-
-		$this->arguments['reverse'] = NULL;
-		$this->arguments['key'] = NULL;
-		$this->arguments['iteration'] = NULL;
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderExecutesTheLoopCorrectly() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-		$this->arguments['each'] = array(0, 1, 2, 3);
-		$this->arguments['as'] = 'innerVariable';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array('innerVariable' => 0),
-			array('innerVariable' => 1),
-			array('innerVariable' => 2),
-			array('innerVariable' => 3)
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderPreservesKeys() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = array('key1' => 'value1', 'key2' => 'value2');
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => 'value1',
-				'someKey' => 'key1'
-			),
-			array(
-				'innerVariable' => 'value2',
-				'someKey' => 'key2'
-			)
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderReturnsEmptyStringIfObjectIsNull() {
-		$viewHelper = new ForViewHelper();
-
-		$this->arguments['each'] = NULL;
-		$this->arguments['as'] = 'foo';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-
-		$this->assertEquals('', $viewHelper->initializeArgumentsAndRender());
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderReturnsEmptyStringIfObjectIsEmptyArray() {
-		$viewHelper = new ForViewHelper();
-
-		$this->arguments['each'] = array();
-		$this->arguments['as'] = 'foo';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-
-		$this->assertEquals('', $viewHelper->initializeArgumentsAndRender());
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderIteratesElementsInReverseOrderIfReverseIsTrue() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = array(0, 1, 2, 3);
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['reverse'] = TRUE;
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array('innerVariable' => 3),
-			array('innerVariable' => 2),
-			array('innerVariable' => 1),
-			array('innerVariable' => 0)
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderIteratesElementsInReverseOrderIfReverseIsTrueAndObjectIsIterator() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = new \ArrayIterator(array(0, 1, 2, 3));
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['reverse'] = TRUE;
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array('innerVariable' => 3),
-			array('innerVariable' => 2),
-			array('innerVariable' => 1),
-			array('innerVariable' => 0)
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderPreservesKeysIfReverseIsTrue() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = array('key1' => 'value1', 'key2' => 'value2');
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-		$this->arguments['reverse'] = TRUE;
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => 'value2',
-				'someKey' => 'key2'
-			),
-			array(
-				'innerVariable' => 'value1',
-				'someKey' => 'key1'
-			)
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function keyContainsNumericalIndexIfTheGivenArrayDoesNotHaveAKey() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = array('foo', 'bar', 'baz');
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => 'foo',
-				'someKey' => 0
-			),
-			array(
-				'innerVariable' => 'bar',
-				'someKey' => 1
-			),
-			array(
-				'innerVariable' => 'baz',
-				'someKey' => 2
-			)
-		);
-		$this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function keyContainsNumericalIndexInAscendingOrderEvenIfReverseIsTrueIfTheGivenArrayDoesNotHaveAKey() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = array('foo', 'bar', 'baz');
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-		$this->arguments['reverse'] = TRUE;
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => 'baz',
-				'someKey' => 0
-			),
-			array(
-				'innerVariable' => 'bar',
-				'someKey' => 1
-			),
-			array(
-				'innerVariable' => 'foo',
-				'someKey' => 2
-			)
-		);
-		$this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 * @expectedException InvalidArgumentException
-	 */
-	public function renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable() {
-		$viewHelper = new ForViewHelper();
-		$object = new \stdClass();
-
-		$this->arguments['each'] = $object;
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-		$this->arguments['reverse'] = TRUE;
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->initializeArgumentsAndRender();
-	}
-
-
-	/**
-	 * @test
-	 */
-	public function renderIteratesThroughElementsOfTraversableObjects() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = new \ArrayObject(array('key1' => 'value1', 'key2' => 'value2'));
-		$this->arguments['as'] = 'innerVariable';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array('innerVariable' => 'value1'),
-			array('innerVariable' => 'value2')
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderPreservesKeyWhenIteratingThroughElementsOfObjectsThatImplementIteratorInterface() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = new \ArrayIterator(array('key1' => 'value1', 'key2' => 'value2'));
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => 'value1',
-				'someKey' => 'key1'
-			),
-			array(
-				'innerVariable' => 'value2',
-				'someKey' => 'key2'
-			)
-		);
-		$this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function keyContainsTheNumericalIndexWhenIteratingThroughElementsOfObjectsOfTyeSplObjectStorage() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$splObjectStorageObject = new \SplObjectStorage();
-		$object1 = new \stdClass();
-		$splObjectStorageObject->attach($object1);
-		$object2 = new \stdClass();
-		$splObjectStorageObject->attach($object2, 'foo');
-		$object3 = new \stdClass();
-		$splObjectStorageObject->offsetSet($object3, 'bar');
-
-		$this->arguments['each'] = $splObjectStorageObject;
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['key'] = 'someKey';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => $object1,
-				'someKey' => 0
-			),
-			array(
-				'innerVariable' => $object2,
-				'someKey' => 1
-			),
-			array(
-				'innerVariable' => $object3,
-				'someKey' => 2
-			)
-		);
-		$this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function iterationDataIsAddedToTemplateVariableContainerIfIterationArgumentIsSet() {
-		$viewHelper = new ForViewHelper();
-
-		$viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
-
-		$this->arguments['each'] = array('foo' => 'bar', 'Flow' => 'Fluid', 'TYPO3' => 'rocks');
-		$this->arguments['as'] = 'innerVariable';
-		$this->arguments['iteration'] = 'iteration';
-
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$viewHelper->setViewHelperNode($viewHelperNode);
-		$viewHelper->initializeArgumentsAndRender();
-
-		$expectedCallProtocol = array(
-			array(
-				'innerVariable' => 'bar',
-				'iteration' => array(
-					'index' => 0,
-					'cycle' => 1,
-					'total' => 3,
-					'isFirst' => TRUE,
-					'isLast' => FALSE,
-					'isEven' => FALSE,
-					'isOdd' => TRUE
-				)
-			),
-			array(
-				'innerVariable' => 'Fluid',
-				'iteration' => array(
-					'index' => 1,
-					'cycle' => 2,
-					'total' => 3,
-					'isFirst' => FALSE,
-					'isLast' => FALSE,
-					'isEven' => TRUE,
-					'isOdd' => FALSE
-				)
-			),
-			array(
-				'innerVariable' => 'rocks',
-				'iteration' => array(
-					'index' => 2,
-					'cycle' => 3,
-					'total' => 3,
-					'isFirst' => FALSE,
-					'isLast' => TRUE,
-					'isEven' => FALSE,
-					'isOdd' => TRUE
-				)
-			)
-		);
-		$this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
-	}
-
-	/**
-	 * @test
-	 */
-	public function renderThrowsExceptionOnInvalidObject() {
-		$viewHelper = new ForViewHelper();
-		$this->arguments['each'] = new \DateTime('now');
-		$this->injectDependenciesIntoViewHelper($viewHelper);
-		$this->setExpectedException(Exception::class);
-		$viewHelper->render();
-	}
-
+class ForViewHelperTest extends ViewHelperBaseTestcase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+
+
+        $this->arguments['reverse'] = null;
+        $this->arguments['key'] = null;
+        $this->arguments['iteration'] = null;
+    }
+
+    /**
+     * @test
+     */
+    public function renderExecutesTheLoopCorrectly()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+        $this->arguments['each'] = [0, 1, 2, 3];
+        $this->arguments['as'] = 'innerVariable';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            ['innerVariable' => 0],
+            ['innerVariable' => 1],
+            ['innerVariable' => 2],
+            ['innerVariable' => 3]
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function renderPreservesKeys()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = ['key1' => 'value1', 'key2' => 'value2'];
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => 'value1',
+                'someKey' => 'key1'
+            ],
+            [
+                'innerVariable' => 'value2',
+                'someKey' => 'key2'
+            ]
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function renderReturnsEmptyStringIfObjectIsNull()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $this->arguments['each'] = null;
+        $this->arguments['as'] = 'foo';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+
+        $this->assertEquals('', $viewHelper->initializeArgumentsAndRender());
+    }
+
+    /**
+     * @test
+     */
+    public function renderReturnsEmptyStringIfObjectIsEmptyArray()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $this->arguments['each'] = [];
+        $this->arguments['as'] = 'foo';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+
+        $this->assertEquals('', $viewHelper->initializeArgumentsAndRender());
+    }
+
+    /**
+     * @test
+     */
+    public function renderIteratesElementsInReverseOrderIfReverseIsTrue()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = [0, 1, 2, 3];
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['reverse'] = true;
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            ['innerVariable' => 3],
+            ['innerVariable' => 2],
+            ['innerVariable' => 1],
+            ['innerVariable' => 0]
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function renderIteratesElementsInReverseOrderIfReverseIsTrueAndObjectIsIterator()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = new \ArrayIterator([0, 1, 2, 3]);
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['reverse'] = true;
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            ['innerVariable' => 3],
+            ['innerVariable' => 2],
+            ['innerVariable' => 1],
+            ['innerVariable' => 0]
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function renderPreservesKeysIfReverseIsTrue()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = ['key1' => 'value1', 'key2' => 'value2'];
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+        $this->arguments['reverse'] = true;
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => 'value2',
+                'someKey' => 'key2'
+            ],
+            [
+                'innerVariable' => 'value1',
+                'someKey' => 'key1'
+            ]
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function keyContainsNumericalIndexIfTheGivenArrayDoesNotHaveAKey()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = ['foo', 'bar', 'baz'];
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => 'foo',
+                'someKey' => 0
+            ],
+            [
+                'innerVariable' => 'bar',
+                'someKey' => 1
+            ],
+            [
+                'innerVariable' => 'baz',
+                'someKey' => 2
+            ]
+        ];
+        $this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function keyContainsNumericalIndexInAscendingOrderEvenIfReverseIsTrueIfTheGivenArrayDoesNotHaveAKey()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = ['foo', 'bar', 'baz'];
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+        $this->arguments['reverse'] = true;
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => 'baz',
+                'someKey' => 0
+            ],
+            [
+                'innerVariable' => 'bar',
+                'someKey' => 1
+            ],
+            [
+                'innerVariable' => 'foo',
+                'someKey' => 2
+            ]
+        ];
+        $this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable()
+    {
+        $viewHelper = new ForViewHelper();
+        $object = new \stdClass();
+
+        $this->arguments['each'] = $object;
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+        $this->arguments['reverse'] = true;
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->initializeArgumentsAndRender();
+    }
+
+
+    /**
+     * @test
+     */
+    public function renderIteratesThroughElementsOfTraversableObjects()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = new \ArrayObject(['key1' => 'value1', 'key2' => 'value2']);
+        $this->arguments['as'] = 'innerVariable';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            ['innerVariable' => 'value1'],
+            ['innerVariable' => 'value2']
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function renderPreservesKeyWhenIteratingThroughElementsOfObjectsThatImplementIteratorInterface()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = new \ArrayIterator(['key1' => 'value1', 'key2' => 'value2']);
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => 'value1',
+                'someKey' => 'key1'
+            ],
+            [
+                'innerVariable' => 'value2',
+                'someKey' => 'key2'
+            ]
+        ];
+        $this->assertEquals($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function keyContainsTheNumericalIndexWhenIteratingThroughElementsOfObjectsOfTyeSplObjectStorage()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $splObjectStorageObject = new \SplObjectStorage();
+        $object1 = new \stdClass();
+        $splObjectStorageObject->attach($object1);
+        $object2 = new \stdClass();
+        $splObjectStorageObject->attach($object2, 'foo');
+        $object3 = new \stdClass();
+        $splObjectStorageObject->offsetSet($object3, 'bar');
+
+        $this->arguments['each'] = $splObjectStorageObject;
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['key'] = 'someKey';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => $object1,
+                'someKey' => 0
+            ],
+            [
+                'innerVariable' => $object2,
+                'someKey' => 1
+            ],
+            [
+                'innerVariable' => $object3,
+                'someKey' => 2
+            ]
+        ];
+        $this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function iterationDataIsAddedToTemplateVariableContainerIfIterationArgumentIsSet()
+    {
+        $viewHelper = new ForViewHelper();
+
+        $viewHelperNode = new ConstraintSyntaxTreeNode($this->templateVariableContainer);
+
+        $this->arguments['each'] = ['foo' => 'bar', 'Flow' => 'Fluid', 'TYPO3' => 'rocks'];
+        $this->arguments['as'] = 'innerVariable';
+        $this->arguments['iteration'] = 'iteration';
+
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->setViewHelperNode($viewHelperNode);
+        $viewHelper->initializeArgumentsAndRender();
+
+        $expectedCallProtocol = [
+            [
+                'innerVariable' => 'bar',
+                'iteration' => [
+                    'index' => 0,
+                    'cycle' => 1,
+                    'total' => 3,
+                    'isFirst' => true,
+                    'isLast' => false,
+                    'isEven' => false,
+                    'isOdd' => true
+                ]
+            ],
+            [
+                'innerVariable' => 'Fluid',
+                'iteration' => [
+                    'index' => 1,
+                    'cycle' => 2,
+                    'total' => 3,
+                    'isFirst' => false,
+                    'isLast' => false,
+                    'isEven' => true,
+                    'isOdd' => false
+                ]
+            ],
+            [
+                'innerVariable' => 'rocks',
+                'iteration' => [
+                    'index' => 2,
+                    'cycle' => 3,
+                    'total' => 3,
+                    'isFirst' => false,
+                    'isLast' => true,
+                    'isEven' => false,
+                    'isOdd' => true
+                ]
+            ]
+        ];
+        $this->assertSame($expectedCallProtocol, $viewHelperNode->callProtocol, 'The call protocol differs -> The for loop does not work as it should!');
+    }
+
+    /**
+     * @test
+     */
+    public function renderThrowsExceptionOnInvalidObject()
+    {
+        $viewHelper = new ForViewHelper();
+        $this->arguments['each'] = new \DateTime('now');
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $this->setExpectedException(Exception::class);
+        $viewHelper->render();
+    }
 }

--- a/tests/Unit/ViewHelpers/Format/CdataViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/CdataViewHelperTest.php
@@ -13,30 +13,34 @@ use TYPO3Fluid\Fluid\ViewHelpers\Format\CdataViewHelper;
 /**
  * Test for \TYPO3Fluid\Fluid\ViewHelpers\Format\CdataViewHelper
  */
-class CdataViewHelperTest extends ViewHelperBaseTestcase {
+class CdataViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @param array $arguments
-	 * @param string|NULL $tagContent
-	 * @param string $expected
-	 * @dataProvider getRenderTestValues
-	 */
-	public function testRender($arguments, $tagContent, $expected) {
-		$instance = new CdataViewHelper();
-		$instance->setArguments($arguments);
-		$instance->setRenderingContext(new RenderingContextFixture());
-		$instance->setRenderChildrenClosure(function() use ($tagContent) { return $tagContent; });
-		$this->assertEquals($expected, $instance->initializeArgumentsAndRender());
-	}
+    /**
+     * @param array $arguments
+     * @param string|NULL $tagContent
+     * @param string $expected
+     * @dataProvider getRenderTestValues
+     */
+    public function testRender($arguments, $tagContent, $expected)
+    {
+        $instance = new CdataViewHelper();
+        $instance->setArguments($arguments);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $instance->setRenderChildrenClosure(function () use ($tagContent) {
+            return $tagContent;
+        });
+        $this->assertEquals($expected, $instance->initializeArgumentsAndRender());
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array(array(), 'test1', '<![CDATA[test1]]>'),
-			array(array('value' => 'test2'), NULL, '<![CDATA[test2]]>'),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getRenderTestValues()
+    {
+        return [
+            [[], 'test1', '<![CDATA[test1]]>'],
+            [['value' => 'test2'], null, '<![CDATA[test2]]>'],
+        ];
+    }
 }

--- a/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
@@ -17,246 +17,260 @@ use TYPO3Fluid\Fluid\ViewHelpers\Format\HtmlspecialcharsViewHelper;
 /**
  * Test for \TYPO3Fluid\Fluid\ViewHelpers\Format\HtmlspecialcharsViewHelper
  */
-class HtmlspecialcharsViewHelperTest extends ViewHelperBaseTestcase {
+class HtmlspecialcharsViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var HtmlspecialcharsViewHelper|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $viewHelper;
+    /**
+     * @var HtmlspecialcharsViewHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getMock(HtmlspecialcharsViewHelper::class, array('renderChildren'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getMock(HtmlspecialcharsViewHelper::class, ['renderChildren']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperDeactivatesEscapingInterceptor() {
-		$this->assertFalse($this->viewHelper->isOutputEscapingEnabled());
-	}
+    /**
+     * @test
+     */
+    public function viewHelperDeactivatesEscapingInterceptor()
+    {
+        $this->assertFalse($this->viewHelper->isOutputEscapingEnabled());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderUsesValueAsSourceIfSpecified() {
-		$this->viewHelper->expects($this->never())->method('renderChildren');
-		$this->viewHelper->setArguments(
-			array('value' => 'Some string', 'keepQuotes' => FALSE, 'encoding' => 'UTF-8', 'doubleEncode' => FALSE)
-		);
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertEquals('Some string', $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderUsesValueAsSourceIfSpecified()
+    {
+        $this->viewHelper->expects($this->never())->method('renderChildren');
+        $this->viewHelper->setArguments(
+            ['value' => 'Some string', 'keepQuotes' => false, 'encoding' => 'UTF-8', 'doubleEncode' => false]
+        );
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('Some string', $actualResult);
+    }
 
-	/**
-	 * test
-	 */
-	public function renderUsesChildNodesAsSourceIfSpecified() {
-		$this->viewHelper->expects($this->atLeastOnce())->method('renderChildren')->will($this->returnValue('Some string'));
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertEquals('Some string', $actualResult);
-	}
+    /**
+     * test
+     */
+    public function renderUsesChildNodesAsSourceIfSpecified()
+    {
+        $this->viewHelper->expects($this->atLeastOnce())->method('renderChildren')->will($this->returnValue('Some string'));
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('Some string', $actualResult);
+    }
 
-	public function dataProvider() {
-		return array(
-			// render does not modify string without special characters
-			array(
-				'value' => 'This is a sample text without special characters.',
-				'options' => array(),
-				'expectedResult' => 'This is a sample text without special characters.'
-			),
-			// render decodes simple string
-			array(
-				'value' => 'Some special characters: &©"\'',
-				'options' => array(),
-				'expectedResult' => 'Some special characters: &amp;©&quot;&#039;'
-			),
-			// render respects "keepQuotes" argument
-			array(
-				'value' => 'Some special characters: &©"',
-				'options' => array(
-					'keepQuotes' => TRUE,
-				),
-				'expectedResult' => 'Some special characters: &amp;©"'
-			),
-			// render respects "encoding" argument
-			array(
-				'value' => utf8_decode('Some special characters: &"\''),
-				'options' => array(
-					'encoding' => 'ISO-8859-1',
-				),
-				'expectedResult' => 'Some special characters: &amp;&quot;&#039;'
-			),
-			// render converts already converted entities by default
-			array(
-				'value' => 'already &quot;encoded&quot;',
-				'options' => array(),
-				'expectedResult' => 'already &amp;quot;encoded&amp;quot;'
-			),
-			// render does not convert already converted entities if "doubleEncode" is FALSE
-			array(
-				'value' => 'already &quot;encoded&quot;',
-				'options' => array(
-					'doubleEncode' => FALSE,
-				),
-				'expectedResult' => 'already &quot;encoded&quot;'
-			),
-			// render returns unmodified source if it is a float
-			array(
-				'value' => 123.45,
-				'options' => array(),
-				'expectedResult' => 123.45
-			),
-			// render returns unmodified source if it is an integer
-			array(
-				'value' => 12345,
-				'options' => array(),
-				'expectedResult' => 12345
-			),
-			// render returns unmodified source if it is a boolean
-			array(
-				'value' => TRUE,
-				'options' => array(),
-				'expectedResult' => TRUE
-			),
-		);
-	}
+    public function dataProvider()
+    {
+        return [
+            // render does not modify string without special characters
+            [
+                'value' => 'This is a sample text without special characters.',
+                'options' => [],
+                'expectedResult' => 'This is a sample text without special characters.'
+            ],
+            // render decodes simple string
+            [
+                'value' => 'Some special characters: &©"\'',
+                'options' => [],
+                'expectedResult' => 'Some special characters: &amp;©&quot;&#039;'
+            ],
+            // render respects "keepQuotes" argument
+            [
+                'value' => 'Some special characters: &©"',
+                'options' => [
+                    'keepQuotes' => true,
+                ],
+                'expectedResult' => 'Some special characters: &amp;©"'
+            ],
+            // render respects "encoding" argument
+            [
+                'value' => utf8_decode('Some special characters: &"\''),
+                'options' => [
+                    'encoding' => 'ISO-8859-1',
+                ],
+                'expectedResult' => 'Some special characters: &amp;&quot;&#039;'
+            ],
+            // render converts already converted entities by default
+            [
+                'value' => 'already &quot;encoded&quot;',
+                'options' => [],
+                'expectedResult' => 'already &amp;quot;encoded&amp;quot;'
+            ],
+            // render does not convert already converted entities if "doubleEncode" is FALSE
+            [
+                'value' => 'already &quot;encoded&quot;',
+                'options' => [
+                    'doubleEncode' => false,
+                ],
+                'expectedResult' => 'already &quot;encoded&quot;'
+            ],
+            // render returns unmodified source if it is a float
+            [
+                'value' => 123.45,
+                'options' => [],
+                'expectedResult' => 123.45
+            ],
+            // render returns unmodified source if it is an integer
+            [
+                'value' => 12345,
+                'options' => [],
+                'expectedResult' => 12345
+            ],
+            // render returns unmodified source if it is a boolean
+            [
+                'value' => true,
+                'options' => [],
+                'expectedResult' => true
+            ],
+        ];
+    }
 
-	/**
-	 * test
-	 *
-	 * @dataProvider dataProvider
-	 */
-	public function renderTests($value, array $options, $expectedResult) {
-		$options['value'] = $value;
-		$this->viewHelper->setArguments($options);
-		$this->assertSame($expectedResult, $this->viewHelper->initializeArgumentsAndRender());
-	}
+    /**
+     * test
+     *
+     * @dataProvider dataProvider
+     */
+    public function renderTests($value, array $options, $expectedResult)
+    {
+        $options['value'] = $value;
+        $this->viewHelper->setArguments($options);
+        $this->assertSame($expectedResult, $this->viewHelper->initializeArgumentsAndRender());
+    }
 
-	/**
-	 * @test
-	 * @dataProvider dataProvider
-	 */
-	public function renderTestsWithRenderChildrenFallback($value, array $options, $expectedResult) {
-		$this->viewHelper->expects($this->any())->method('renderChildren')->will($this->returnValue($value));
-		$options['value'] = NULL;
-		$options['keepQuotes'] = (boolean) (isset($options['keepQuotes']) && $options['keepQuotes'] ? $options['keepQuotes'] : FALSE);
-		$options['encoding'] = 'UTF-8';
-		$options['doubleEncode'] = (boolean) (isset($options['doubleEncode']) ? $options['doubleEncode'] : TRUE);
-		$this->viewHelper->setArguments($options);
-		$this->assertSame($expectedResult, $this->viewHelper->initializeArgumentsAndRender());
-	}
+    /**
+     * @test
+     * @dataProvider dataProvider
+     */
+    public function renderTestsWithRenderChildrenFallback($value, array $options, $expectedResult)
+    {
+        $this->viewHelper->expects($this->any())->method('renderChildren')->will($this->returnValue($value));
+        $options['value'] = null;
+        $options['keepQuotes'] = (boolean) (isset($options['keepQuotes']) && $options['keepQuotes'] ? $options['keepQuotes'] : false);
+        $options['encoding'] = 'UTF-8';
+        $options['doubleEncode'] = (boolean) (isset($options['doubleEncode']) ? $options['doubleEncode'] : true);
+        $this->viewHelper->setArguments($options);
+        $this->assertSame($expectedResult, $this->viewHelper->initializeArgumentsAndRender());
+    }
 
-	/**
-	 * __test
-	 *
-	 * @dataProvider dataProvider
-	 */
-	public function compileTests($value, array $options, $expectedResult) {
-		/** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
-		$mockSyntaxTreeNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
+    /**
+     * __test
+     *
+     * @dataProvider dataProvider
+     */
+    public function compileTests($value, array $options, $expectedResult)
+    {
+        /** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
+        $mockSyntaxTreeNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
 
-		/** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
-		$mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
-		$mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
+        /** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
+        $mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
+        $mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
 
-		$arguments = array(
-			'value' => $value,
-			'keepQuotes' => (boolean) (isset($options['keepQuotes']) && $options['keepQuotes'] ? $options['keepQuotes'] : FALSE),
-			'encoding' => 'UTF-8',
-			'doubleEncode' => (boolean) (isset($options['doubleEncode']) ? $options['doubleEncode'] : TRUE),
-		);
-		$arguments = array_merge($arguments, $options);
-		$initializationPhpCode = '$arguments = ' . var_export($arguments, TRUE) . ';' . chr(10);
-		$compiledPhpCode = $this->viewHelper->compile('$arguments', 'NULL', $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
-		$result = NULL;
-		eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
-		$this->assertSame($expectedResult, $result);
-	}
+        $arguments = [
+            'value' => $value,
+            'keepQuotes' => (boolean) (isset($options['keepQuotes']) && $options['keepQuotes'] ? $options['keepQuotes'] : false),
+            'encoding' => 'UTF-8',
+            'doubleEncode' => (boolean) (isset($options['doubleEncode']) ? $options['doubleEncode'] : true),
+        ];
+        $arguments = array_merge($arguments, $options);
+        $initializationPhpCode = '$arguments = ' . var_export($arguments, true) . ';' . chr(10);
+        $compiledPhpCode = $this->viewHelper->compile('$arguments', 'NULL', $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
+        $result = null;
+        eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
+        $this->assertSame($expectedResult, $result);
+    }
 
-	/**
-	 * __test
-	 *
-	 * @dataProvider dataProvider
-	 */
-	public function compileTestsWithRenderChildrenFallback($value, array $options, $expectedResult) {
-		/** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
-		$mockSyntaxTreeNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
+    /**
+     * __test
+     *
+     * @dataProvider dataProvider
+     */
+    public function compileTestsWithRenderChildrenFallback($value, array $options, $expectedResult)
+    {
+        /** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
+        $mockSyntaxTreeNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
 
-		/** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
-		$mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
-		$mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
+        /** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
+        $mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
+        $mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
 
-		$renderChildrenClosureName = uniqid('renderChildren');
-		$arguments = array(
-			'value' => NULL,
-			'keepQuotes' => (boolean) isset($options['keepQuotes']) && $options['keepQuotes'],
-			'encoding' => isset($options['keepQuotes']) ? $options['keepQuotes'] : 'UTF-8',
-			'doubleEncode' => (boolean) isset($options['doubleEncode']) && $options['doubleEncode'],
-		);
-		$arguments = array_merge($arguments, $options);
-		$initializationPhpCode = 'function ' . $renderChildrenClosureName . '() { return ' . var_export($value, TRUE) . '; }; ' . chr(10) . '$arguments = ' . var_export($arguments, TRUE) . ';' . chr(10);
-		$compiledPhpCode = $this->viewHelper->compile('$arguments', $renderChildrenClosureName, $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
-		$result = NULL;
-		eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
-		$this->assertSame($expectedResult, $result);
-	}
+        $renderChildrenClosureName = uniqid('renderChildren');
+        $arguments = [
+            'value' => null,
+            'keepQuotes' => (boolean) isset($options['keepQuotes']) && $options['keepQuotes'],
+            'encoding' => isset($options['keepQuotes']) ? $options['keepQuotes'] : 'UTF-8',
+            'doubleEncode' => (boolean) isset($options['doubleEncode']) && $options['doubleEncode'],
+        ];
+        $arguments = array_merge($arguments, $options);
+        $initializationPhpCode = 'function ' . $renderChildrenClosureName . '() { return ' . var_export($value, true) . '; }; ' . chr(10) . '$arguments = ' . var_export($arguments, true) . ';' . chr(10);
+        $compiledPhpCode = $this->viewHelper->compile('$arguments', $renderChildrenClosureName, $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
+        $result = null;
+        eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
+        $this->assertSame($expectedResult, $result);
+    }
 
-	/**
-	 * __test
-	 */
-	public function renderConvertsObjectsToStrings() {
-		$user = new UserWithToString('Xaver <b>Cross-Site</b>');
-		$expectedResult = 'Xaver &lt;b&gt;Cross-Site&lt;/b&gt;';
-		$this->viewHelper->setArguments(array('value' => $user));
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertSame($expectedResult, $actualResult);
-	}
+    /**
+     * __test
+     */
+    public function renderConvertsObjectsToStrings()
+    {
+        $user = new UserWithToString('Xaver <b>Cross-Site</b>');
+        $expectedResult = 'Xaver &lt;b&gt;Cross-Site&lt;/b&gt;';
+        $this->viewHelper->setArguments(['value' => $user]);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertSame($expectedResult, $actualResult);
+    }
 
-	/**
-	 * __test
-	 */
-	public function renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString() {
-		$user = new UserWithoutToString('Xaver <b>Cross-Site</b>');
-		$this->viewHelper->setArguments(array('value' => $user));
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertSame($user, $actualResult);
-	}
+    /**
+     * __test
+     */
+    public function renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString()
+    {
+        $user = new UserWithoutToString('Xaver <b>Cross-Site</b>');
+        $this->viewHelper->setArguments(['value' => $user]);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertSame($user, $actualResult);
+    }
 
-	/**
-	 * __test
-	 */
-	public function compileConvertsObjectsToStrings() {
-		/** @var AbstractNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
-		$mockSyntaxTreeNode = $this->getMockBuilder(AbstractNode::class)->disableOriginalConstructor()->getMock();
+    /**
+     * __test
+     */
+    public function compileConvertsObjectsToStrings()
+    {
+        /** @var AbstractNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
+        $mockSyntaxTreeNode = $this->getMockBuilder(AbstractNode::class)->disableOriginalConstructor()->getMock();
 
-		/** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
-		$mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
-		$mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
+        /** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
+        $mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
+        $mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
 
-		$initializationPhpCode = '$arguments = array("value" => new \TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString("Xaver <b>Cross-Site</b>"), "keepQuotes" => FALSE, "encoding" => "UTF-8", "doubleEncode" => TRUE);' . chr(10);
-		$compiledPhpCode = $this->viewHelper->compile('$arguments', 'NULL', $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
-		$result = NULL;
-		eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
-		$this->assertSame('Xaver &lt;b&gt;Cross-Site&lt;/b&gt;', $result);
-	}
+        $initializationPhpCode = '$arguments = array("value" => new \TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString("Xaver <b>Cross-Site</b>"), "keepQuotes" => FALSE, "encoding" => "UTF-8", "doubleEncode" => TRUE);' . chr(10);
+        $compiledPhpCode = $this->viewHelper->compile('$arguments', 'NULL', $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
+        $result = null;
+        eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
+        $this->assertSame('Xaver &lt;b&gt;Cross-Site&lt;/b&gt;', $result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function compileDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString() {
-		/** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
-		$mockSyntaxTreeNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
+    /**
+     * @test
+     */
+    public function compileDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString()
+    {
+        /** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $mockSyntaxTreeNode */
+        $mockSyntaxTreeNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
 
-		/** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
-		$mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
-		$mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
+        /** @var TemplateCompiler|\PHPUnit_Framework_MockObject_MockObject $mockTemplateCompiler */
+        $mockTemplateCompiler = $this->getMockBuilder(TemplateCompiler::class)->disableOriginalConstructor()->getMock();
+        $mockTemplateCompiler->expects($this->once())->method('variableName')->with('value')->will($this->returnValue('$value123'));
 
-		$initializationPhpCode = '$arguments = array("value" => new \TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString("Xaver <b>Cross-Site</b>"), "keepQuotes" => FALSE, "encoding" => "UTF-8", "doubleEncode" => TRUE);' . chr(10);
-		$compiledPhpCode = $this->viewHelper->compile('$arguments', 'NULL', $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
-		$result = NULL;
-		eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
-		$this->assertEquals(new UserWithoutToString("Xaver <b>Cross-Site</b>"), $result);
-	}
+        $initializationPhpCode = '$arguments = array("value" => new \TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString("Xaver <b>Cross-Site</b>"), "keepQuotes" => FALSE, "encoding" => "UTF-8", "doubleEncode" => TRUE);' . chr(10);
+        $compiledPhpCode = $this->viewHelper->compile('$arguments', 'NULL', $initializationPhpCode, $mockSyntaxTreeNode, $mockTemplateCompiler);
+        $result = null;
+        eval($initializationPhpCode . '$result = ' . $compiledPhpCode . ';');
+        $this->assertEquals(new UserWithoutToString("Xaver <b>Cross-Site</b>"), $result);
+    }
 }

--- a/tests/Unit/ViewHelpers/Format/PrintfViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/PrintfViewHelperTest.php
@@ -12,36 +12,40 @@ use TYPO3Fluid\Fluid\ViewHelpers\Format\PrintfViewHelper;
 /**
  * Test for \TYPO3Fluid\Fluid\ViewHelpers\Format\PrintfViewHelper
  */
-class PrintfViewHelperTest extends ViewHelperBaseTestcase {
+class PrintfViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var \TYPO3Fluid\Fluid\ViewHelpers\Format\PrintfViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var \TYPO3Fluid\Fluid\ViewHelpers\Format\PrintfViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getMock(PrintfViewHelper::class, array('renderChildren'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getMock(PrintfViewHelper::class, ['renderChildren']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperCanUseArrayAsArgument() {
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('%04d-%02d-%02d'));
-		$this->viewHelper->setArguments(array('value' => NULL, 'arguments' => array('year' => 2009, 'month' => 4, 'day' => 5)));
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertEquals('2009-04-05', $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function viewHelperCanUseArrayAsArgument()
+    {
+        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('%04d-%02d-%02d'));
+        $this->viewHelper->setArguments(['value' => null, 'arguments' => ['year' => 2009, 'month' => 4, 'day' => 5]]);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('2009-04-05', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperCanSwapMultipleArguments() {
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('%2$s %1$d %3$s %2$s'));
-		$this->viewHelper->setArguments(array('value' => NULL, 'arguments' => array(123, 'foo', 'bar')));
-		$actualResult = $this->viewHelper->initializeArgumentsAndRender();
-		$this->assertEquals('foo 123 bar foo', $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function viewHelperCanSwapMultipleArguments()
+    {
+        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('%2$s %1$d %3$s %2$s'));
+        $this->viewHelper->setArguments(['value' => null, 'arguments' => [123, 'foo', 'bar']]);
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('foo 123 bar foo', $actualResult);
+    }
 }

--- a/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
@@ -13,43 +13,48 @@ use TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper;
 /**
  * Test for \TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper
  */
-class RawViewHelperTest extends UnitTestCase {
+class RawViewHelperTest extends UnitTestCase
+{
 
-	/**
-	 * @var RawViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var RawViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		$this->viewHelper = $this->getMock(RawViewHelper::class, array('renderChildren'));
-		$this->viewHelper->setRenderingContext(new RenderingContextFixture());
-	}
+    public function setUp()
+    {
+        $this->viewHelper = $this->getMock(RawViewHelper::class, ['renderChildren']);
+        $this->viewHelper->setRenderingContext(new RenderingContextFixture());
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperDeactivatesEscapingInterceptor() {
-		$this->assertFalse($this->viewHelper->isOutputEscapingEnabled());
-	}
+    /**
+     * @test
+     */
+    public function viewHelperDeactivatesEscapingInterceptor()
+    {
+        $this->assertFalse($this->viewHelper->isOutputEscapingEnabled());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsUnmodifiedValueIfSpecified() {
-		$value = 'input value " & äöüß@';
-		$this->viewHelper->expects($this->never())->method('renderChildren');
-		$this->viewHelper->setArguments(array('value' => $value));
-		$actualResult = $this->viewHelper->render();
-		$this->assertEquals($value, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsUnmodifiedValueIfSpecified()
+    {
+        $value = 'input value " & äöüß@';
+        $this->viewHelper->expects($this->never())->method('renderChildren');
+        $this->viewHelper->setArguments(['value' => $value]);
+        $actualResult = $this->viewHelper->render();
+        $this->assertEquals($value, $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsUnmodifiedChildNodesIfNoValueIsSpecified() {
-		$childNodes = 'input value " & äöüß@';
-		$this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($childNodes));
-		$actualResult = $this->viewHelper->render();
-		$this->assertEquals($childNodes, $actualResult);
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsUnmodifiedChildNodesIfNoValueIsSpecified()
+    {
+        $childNodes = 'input value " & äöüß@';
+        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($childNodes));
+        $actualResult = $this->viewHelper->render();
+        $this->assertEquals($childNodes, $actualResult);
+    }
 }

--- a/tests/Unit/ViewHelpers/GroupedForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/GroupedForViewHelperTest.php
@@ -10,272 +10,287 @@ use TYPO3Fluid\Fluid\ViewHelpers\GroupedForViewHelper;
 /**
  * Testcase for GroupedForViewHelperTest
  */
-class GroupedForViewHelperTest extends ViewHelperBaseTestcase {
+class GroupedForViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var \TYPO3Fluid\Fluid\ViewHelpers\GroupedForViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var \TYPO3Fluid\Fluid\ViewHelpers\GroupedForViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getMock(GroupedForViewHelper::class, array('renderChildren'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getMock(GroupedForViewHelper::class, ['renderChildren']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsEmptyStringIfObjectIsNull() {
-		$this->viewHelper->setArguments(array('each' => NULL, 'as' => 'foo', 'groupBy' => 'bar', 'groupKey' => NULL));
-		$this->assertEquals('', $this->viewHelper->initializeArgumentsAndRender());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsEmptyStringIfObjectIsNull()
+    {
+        $this->viewHelper->setArguments(['each' => null, 'as' => 'foo', 'groupBy' => 'bar', 'groupKey' => null]);
+        $this->assertEquals('', $this->viewHelper->initializeArgumentsAndRender());
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderReturnsEmptyStringIfObjectIsEmptyArray() {
-		$this->viewHelper->setArguments(array('each' => array(), 'as' => 'foo', 'groupBy' => 'bar', 'groupKey' => NULL));
-		$this->assertEquals('', $this->viewHelper->initializeArgumentsAndRender());
-	}
+    /**
+     * @test
+     */
+    public function renderReturnsEmptyStringIfObjectIsEmptyArray()
+    {
+        $this->viewHelper->setArguments(['each' => [], 'as' => 'foo', 'groupBy' => 'bar', 'groupKey' => null]);
+        $this->assertEquals('', $this->viewHelper->initializeArgumentsAndRender());
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
-	 */
-	public function renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable() {
-		$object = new \stdClass();
-		$this->viewHelper->setArguments(
-			array('each' => $object, 'as' => 'innerVariable', 'groupBy' => 'someKey', 'groupKey' => NULL)
-		);
-		$this->viewHelper->render();
-	}
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     */
+    public function renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable()
+    {
+        $object = new \stdClass();
+        $this->viewHelper->setArguments(
+            ['each' => $object, 'as' => 'innerVariable', 'groupBy' => 'someKey', 'groupKey' => null]
+        );
+        $this->viewHelper->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsMultidimensionalArrayAndPreservesKeys() {
-		$photoshop = array('name' => 'Adobe Photoshop', 'license' => 'commercial');
-		$typo3 = array('name' => 'TYPO3', 'license' => 'GPL');
-		$office = array('name' => 'Microsoft Office', 'license' => 'commercial');
-		$drupal = array('name' => 'Drupal', 'license' => 'GPL');
-		$wordpress = array('name' => 'Wordpress', 'license' => 'GPL');
+    /**
+     * @test
+     */
+    public function renderGroupsMultidimensionalArrayAndPreservesKeys()
+    {
+        $photoshop = ['name' => 'Adobe Photoshop', 'license' => 'commercial'];
+        $typo3 = ['name' => 'TYPO3', 'license' => 'GPL'];
+        $office = ['name' => 'Microsoft Office', 'license' => 'commercial'];
+        $drupal = ['name' => 'Drupal', 'license' => 'GPL'];
+        $wordpress = ['name' => 'Wordpress', 'license' => 'GPL'];
 
-		$products = array('photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress);
+        $products = ['photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress];
 
-		$this->viewHelper->setArguments(
-			array('each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsMultidimensionalArrayObjectAndPreservesKeys() {
-		$photoshop = array('name' => 'Adobe Photoshop', 'license' => 'commercial');
-		$typo3 = array('name' => 'TYPO3', 'license' => 'GPL');
-		$office = array('name' => 'Microsoft Office', 'license' => 'commercial');
-		$drupal = array('name' => 'Drupal', 'license' => 'GPL');
-		$wordpress = array('name' => 'Wordpress', 'license' => 'GPL');
+    /**
+     * @test
+     */
+    public function renderGroupsMultidimensionalArrayObjectAndPreservesKeys()
+    {
+        $photoshop = ['name' => 'Adobe Photoshop', 'license' => 'commercial'];
+        $typo3 = ['name' => 'TYPO3', 'license' => 'GPL'];
+        $office = ['name' => 'Microsoft Office', 'license' => 'commercial'];
+        $drupal = ['name' => 'Drupal', 'license' => 'GPL'];
+        $wordpress = ['name' => 'Wordpress', 'license' => 'GPL'];
 
-		$products = array('photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress);
+        $products = ['photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress];
 
-		$this->viewHelper->setArguments(
-			array('each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsArrayOfObjectsAndPreservesKeys() {
-		$photoshop = new \stdClass();
-		$photoshop->name = 'Adobe Photoshop';
-		$photoshop->license = 'commercial';
-		$typo3 = new \stdClass();
-		$typo3->name = 'TYPO3';
-		$typo3->license = 'GPL';
-		$office = new \stdClass();
-		$office->name = 'Microsoft Office';
-		$office->license = 'commercial';
-		$drupal = new \stdClass();
-		$drupal->name = 'Drupal';
-		$drupal->license = 'GPL';
-		$wordpress = new \stdClass();
-		$wordpress->name = 'Wordpress';
-		$wordpress->license = 'GPL';
+    /**
+     * @test
+     */
+    public function renderGroupsArrayOfObjectsAndPreservesKeys()
+    {
+        $photoshop = new \stdClass();
+        $photoshop->name = 'Adobe Photoshop';
+        $photoshop->license = 'commercial';
+        $typo3 = new \stdClass();
+        $typo3->name = 'TYPO3';
+        $typo3->license = 'GPL';
+        $office = new \stdClass();
+        $office->name = 'Microsoft Office';
+        $office->license = 'commercial';
+        $drupal = new \stdClass();
+        $drupal->name = 'Drupal';
+        $drupal->license = 'GPL';
+        $wordpress = new \stdClass();
+        $wordpress->name = 'Wordpress';
+        $wordpress->license = 'GPL';
 
-		$products = array('photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress);
+        $products = ['photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress];
 
-		$this->viewHelper->setArguments(
-			array('each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsIteratorOfObjectsAndPreservesKeys() {
-		$photoshop = new \stdClass();
-		$photoshop->name = 'Adobe Photoshop';
-		$photoshop->license = 'commercial';
-		$typo3 = new \stdClass();
-		$typo3->name = 'TYPO3';
-		$typo3->license = 'GPL';
-		$office = new \stdClass();
-		$office->name = 'Microsoft Office';
-		$office->license = 'commercial';
-		$drupal = new \stdClass();
-		$drupal->name = 'Drupal';
-		$drupal->license = 'GPL';
-		$wordpress = new \stdClass();
-		$wordpress->name = 'Wordpress';
-		$wordpress->license = 'GPL';
+    /**
+     * @test
+     */
+    public function renderGroupsIteratorOfObjectsAndPreservesKeys()
+    {
+        $photoshop = new \stdClass();
+        $photoshop->name = 'Adobe Photoshop';
+        $photoshop->license = 'commercial';
+        $typo3 = new \stdClass();
+        $typo3->name = 'TYPO3';
+        $typo3->license = 'GPL';
+        $office = new \stdClass();
+        $office->name = 'Microsoft Office';
+        $office->license = 'commercial';
+        $drupal = new \stdClass();
+        $drupal->name = 'Drupal';
+        $drupal->license = 'GPL';
+        $wordpress = new \stdClass();
+        $wordpress->name = 'Wordpress';
+        $wordpress->license = 'GPL';
 
-		$products = new \ArrayIterator(
-			array('photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress)
-		);
+        $products = new \ArrayIterator(
+            ['photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office, 'drupal' => $drupal, 'wordpress' => $wordpress]
+        );
 
-		$this->viewHelper->setArguments(
-			array('each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsMultidimensionalArrayByObjectKey() {
-		$customer1 = new \stdClass();
-		$customer1->name = 'Anton Abel';
+    /**
+     * @test
+     */
+    public function renderGroupsMultidimensionalArrayByObjectKey()
+    {
+        $customer1 = new \stdClass();
+        $customer1->name = 'Anton Abel';
 
-		$customer2 = new \stdClass();
-		$customer2->name = 'Balthasar Bux';
+        $customer2 = new \stdClass();
+        $customer2->name = 'Balthasar Bux';
 
-		$invoice1 = array('date' => new \DateTime('1980-12-13'), 'customer' => $customer1);
-		$invoice2 = array('date' => new \DateTime('2010-07-01'), 'customer' => $customer1);
-		$invoice3 = array('date' => new \DateTime('2010-07-04'), 'customer' => $customer2);
+        $invoice1 = ['date' => new \DateTime('1980-12-13'), 'customer' => $customer1];
+        $invoice2 = ['date' => new \DateTime('2010-07-01'), 'customer' => $customer1];
+        $invoice3 = ['date' => new \DateTime('2010-07-04'), 'customer' => $customer2];
 
-		$invoices = array('invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3);
+        $invoices = ['invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3];
 
-		$this->viewHelper->setArguments(
-			array('each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsMultidimensionalArrayByPropertyPath() {
-		$customer1 = new \stdClass();
-		$customer1->name = 'Anton Abel';
+    /**
+     * @test
+     */
+    public function renderGroupsMultidimensionalArrayByPropertyPath()
+    {
+        $customer1 = new \stdClass();
+        $customer1->name = 'Anton Abel';
 
-		$customer2 = new \stdClass();
-		$customer2->name = 'Balthasar Bux';
+        $customer2 = new \stdClass();
+        $customer2->name = 'Balthasar Bux';
 
-		$invoice1 = new \stdClass();
-		$invoice1->customer = $customer1;
+        $invoice1 = new \stdClass();
+        $invoice1->customer = $customer1;
 
-		$invoice2 = new \stdClass();
-		$invoice2->customer = $customer1;
+        $invoice2 = new \stdClass();
+        $invoice2->customer = $customer1;
 
-		$invoice3 = new \stdClass();
-		$invoice3->customer = $customer2;
+        $invoice3 = new \stdClass();
+        $invoice3->customer = $customer2;
 
-		$invoices = array('invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3);
+        $invoices = ['invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3];
 
-		$this->viewHelper->setArguments(
-			array('each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer.name', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer.name', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsMultidimensionalObjectByObjectKey() {
-		$customer1 = new \stdClass();
-		$customer1->name = 'Anton Abel';
+    /**
+     * @test
+     */
+    public function renderGroupsMultidimensionalObjectByObjectKey()
+    {
+        $customer1 = new \stdClass();
+        $customer1->name = 'Anton Abel';
 
-		$customer2 = new \stdClass();
-		$customer2->name = 'Balthasar Bux';
+        $customer2 = new \stdClass();
+        $customer2->name = 'Balthasar Bux';
 
-		$invoice1 = new \stdClass();
-		$invoice1->date = new \DateTime('1980-12-13');
-		$invoice1->customer = $customer1;
+        $invoice1 = new \stdClass();
+        $invoice1->date = new \DateTime('1980-12-13');
+        $invoice1->customer = $customer1;
 
-		$invoice2 = new \stdClass();
-		$invoice2->date = new \DateTime('2010-07-01');
-		$invoice2->customer = $customer1;
+        $invoice2 = new \stdClass();
+        $invoice2->date = new \DateTime('2010-07-01');
+        $invoice2->customer = $customer1;
 
-		$invoice3 = new \stdClass();
-		$invoice3->date = new \DateTime('2010-07-04');
-		$invoice3->customer = $customer2;
+        $invoice3 = new \stdClass();
+        $invoice3->date = new \DateTime('2010-07-04');
+        $invoice3->customer = $customer2;
 
-		$invoices = array('invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3);
+        $invoices = ['invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3];
 
-		$this->viewHelper->setArguments(
-			array('each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderGroupsMultidimensionalObjectByDateTimeObject() {
-		$date1 = new \DateTime('2010-07-01');
-		$date2 = new \DateTime('2010-07-04');
+    /**
+     * @test
+     */
+    public function renderGroupsMultidimensionalObjectByDateTimeObject()
+    {
+        $date1 = new \DateTime('2010-07-01');
+        $date2 = new \DateTime('2010-07-04');
 
-		$invoice1 = new \stdClass();
-		$invoice1->date = $date1;
-		$invoice1->id = 12340;
+        $invoice1 = new \stdClass();
+        $invoice1->date = $date1;
+        $invoice1->id = 12340;
 
-		$invoice2 = new \stdClass();
-		$invoice2->date = $date1;
-		$invoice2->id = 12341;
+        $invoice2 = new \stdClass();
+        $invoice2->date = $date1;
+        $invoice2->id = 12341;
 
-		$invoice3 = new \stdClass();
-		$invoice3->date = $date2;
-		$invoice3->id = 12342;
+        $invoice3 = new \stdClass();
+        $invoice3->date = $date2;
+        $invoice3->id = 12342;
 
-		$invoices = array('invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3);
-		$this->viewHelper->setArguments(
-			array('each' => $invoices, 'as' => 'invoices', 'groupBy' => 'date', 'groupKey' => 'myGroupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $invoices = ['invoice1' => $invoice1, 'invoice2' => $invoice2, 'invoice3' => $invoice3];
+        $this->viewHelper->setArguments(
+            ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'date', 'groupKey' => 'myGroupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function groupingByAKeyThatDoesNotExistCreatesASingleGroup() {
-		$photoshop = array('name' => 'Adobe Photoshop', 'license' => 'commercial');
-		$typo3 = array('name' => 'TYPO3', 'license' => 'GPL');
-		$office = array('name' => 'Microsoft Office', 'license' => 'commercial');
+    /**
+     * @test
+     */
+    public function groupingByAKeyThatDoesNotExistCreatesASingleGroup()
+    {
+        $photoshop = ['name' => 'Adobe Photoshop', 'license' => 'commercial'];
+        $typo3 = ['name' => 'TYPO3', 'license' => 'GPL'];
+        $office = ['name' => 'Microsoft Office', 'license' => 'commercial'];
 
-		$products = array('photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office);
+        $products = ['photoshop' => $photoshop, 'typo3' => $typo3, 'office' => $office];
 
-		$this->viewHelper->setArguments(
-			array('each' => $products, 'as' => 'innerKey', 'groupBy' => 'NonExistingKey', 'groupKey' => 'groupKey')
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $products, 'as' => 'innerKey', 'groupBy' => 'NonExistingKey', 'groupKey' => 'groupKey']
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
-	 */
-	public function renderThrowsExceptionWhenPassingOneDimensionalArraysToEach() {
-		$values = array('some', 'simple', 'array');
+    /**
+     * @test
+     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     */
+    public function renderThrowsExceptionWhenPassingOneDimensionalArraysToEach()
+    {
+        $values = ['some', 'simple', 'array'];
 
-		$this->viewHelper->setArguments(
-			array('each' => $values, 'as' => 'innerVariable', 'groupBy' => 'someKey', 'groupKey' => NULL)
-		);
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+        $this->viewHelper->setArguments(
+            ['each' => $values, 'as' => 'innerVariable', 'groupBy' => 'someKey', 'groupKey' => null]
+        );
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 }

--- a/tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -10,44 +10,48 @@ use TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper;
 /**
  * Testcase for IfViewHelper
  */
-class IfViewHelperTest extends ViewHelperBaseTestcase {
+class IfViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
+     */
+    protected $viewHelper;
 
-	/**
-	 * @var \TYPO3Fluid\Fluid\Core\ViewHelper\Arguments
-	 */
-	protected $mockArguments;
+    /**
+     * @var \TYPO3Fluid\Fluid\Core\ViewHelper\Arguments
+     */
+    protected $mockArguments;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getAccessibleMock(IfViewHelper::class, array('renderThenChild', 'renderElseChild'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-		$this->viewHelper->initializeArguments();
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getAccessibleMock(IfViewHelper::class, ['renderThenChild', 'renderElseChild']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+        $this->viewHelper->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperRendersThenChildIfConditionIsTrue() {
-		$this->viewHelper->expects($this->at(0))->method('renderThenChild')->will($this->returnValue('foo'));
+    /**
+     * @test
+     */
+    public function viewHelperRendersThenChildIfConditionIsTrue()
+    {
+        $this->viewHelper->expects($this->at(0))->method('renderThenChild')->will($this->returnValue('foo'));
 
-		$this->viewHelper->setArguments(array('condition' => TRUE));
-		$actualResult = $this->viewHelper->render();
-		$this->assertEquals('foo', $actualResult);
-	}
+        $this->viewHelper->setArguments(['condition' => true]);
+        $actualResult = $this->viewHelper->render();
+        $this->assertEquals('foo', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function viewHelperRendersElseChildIfConditionIsFalse() {
-		$this->viewHelper->expects($this->at(0))->method('renderElseChild')->will($this->returnValue('foo'));
+    /**
+     * @test
+     */
+    public function viewHelperRendersElseChildIfConditionIsFalse()
+    {
+        $this->viewHelper->expects($this->at(0))->method('renderElseChild')->will($this->returnValue('foo'));
 
-		$this->viewHelper->setArguments(array('condition' => FALSE));
-		$actualResult = $this->viewHelper->render();
-		$this->assertEquals('foo', $actualResult);
-	}
+        $this->viewHelper->setArguments(['condition' => false]);
+        $actualResult = $this->viewHelper->render();
+        $this->assertEquals('foo', $actualResult);
+    }
 }

--- a/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
@@ -17,49 +17,53 @@ use TYPO3Fluid\Fluid\ViewHelpers\LayoutViewHelper;
 /**
  * Testcase for LayoutViewHelper
  */
-class LayoutViewHelperTest extends ViewHelperBaseTestcase {
+class LayoutViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArgumentsRegistersExpectedArguments() {
-		$instance = $this->getMock(LayoutViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('name', 'string', $this->anything());
-		$instance->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $instance = $this->getMock(LayoutViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with('name', 'string', $this->anything());
+        $instance->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderReturnsNull() {
-		$instance = new LayoutViewHelper();
-		$result = $instance->render();
-		$this->assertNull($result);
-	}
+    /**
+     * @test
+     */
+    public function testRenderReturnsNull()
+    {
+        $instance = new LayoutViewHelper();
+        $result = $instance->render();
+        $this->assertNull($result);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getPostParseEventTestValues
-	 * @param arary $arguments
-	 * @param string $expectedLayoutName
-	 */
-	public function testPostParseEvent(array $arguments, $expectedLayoutName) {
-		$instance = new LayoutViewHelper();
-		$variableContainer = new StandardVariableProvider();
-		$node = new ViewHelperNode(new RenderingContextFixture(), 'f', 'layout', $arguments, new ParsingState());
-		$result = LayoutViewHelper::postParseEvent($node, $arguments, $variableContainer);
-		$this->assertNull($result);
-		$this->assertEquals($expectedLayoutName, $variableContainer->get('layoutName'));
-	}
+    /**
+     * @test
+     * @dataProvider getPostParseEventTestValues
+     * @param arary $arguments
+     * @param string $expectedLayoutName
+     */
+    public function testPostParseEvent(array $arguments, $expectedLayoutName)
+    {
+        $instance = new LayoutViewHelper();
+        $variableContainer = new StandardVariableProvider();
+        $node = new ViewHelperNode(new RenderingContextFixture(), 'f', 'layout', $arguments, new ParsingState());
+        $result = LayoutViewHelper::postParseEvent($node, $arguments, $variableContainer);
+        $this->assertNull($result);
+        $this->assertEquals($expectedLayoutName, $variableContainer->get('layoutName'));
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getPostParseEventTestValues() {
-		return array(
-			array(array('name' => 'test'), 'test'),
-			array(array(), new TextNode('Default')),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getPostParseEventTestValues()
+    {
+        return [
+            [['name' => 'test'], 'test'],
+            [[], new TextNode('Default')],
+        ];
+    }
 }

--- a/tests/Unit/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/OrViewHelperTest.php
@@ -12,69 +12,74 @@ use TYPO3Fluid\Fluid\ViewHelpers\OrViewHelper;
 /**
  * Class OrViewHelperTest
  */
-class OrViewHelperTest extends ViewHelperBaseTestcase {
+class OrViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArguments() {
-		$instance = $this->getMock(OrViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('content', 'mixed', $this->anything(), FALSE, '');
-		$instance->expects($this->at(1))->method('registerArgument')->with('alternative', 'mixed', $this->anything(), FALSE, '');
-		$instance->expects($this->at(2))->method('registerArgument')->with('arguments', 'array', $this->anything());
-		$instance->setRenderingContext(new RenderingContextFixture());
-		$instance->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArguments()
+    {
+        $instance = $this->getMock(OrViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with('content', 'mixed', $this->anything(), false, '');
+        $instance->expects($this->at(1))->method('registerArgument')->with('alternative', 'mixed', $this->anything(), false, '');
+        $instance->expects($this->at(2))->method('registerArgument')->with('arguments', 'array', $this->anything());
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $instance->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getRenderTestValues
-	 * @param array $arguments
-	 * @param mixed $expected
-	 */
-	public function testRender($arguments, $expected) {
-		$instance = $this->getMock(OrViewHelper::class, array('renderChildren'));
-		$instance->expects($this->exactly((integer) empty($arguments['content'])))->method('renderChildren')->willReturn($arguments['content']);
-		$instance->setArguments($arguments);
-		$instance->setRenderingContext(new RenderingContextFixture());
-		$result = $instance->render();
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @test
+     * @dataProvider getRenderTestValues
+     * @param array $arguments
+     * @param mixed $expected
+     */
+    public function testRender($arguments, $expected)
+    {
+        $instance = $this->getMock(OrViewHelper::class, ['renderChildren']);
+        $instance->expects($this->exactly((integer) empty($arguments['content'])))->method('renderChildren')->willReturn($arguments['content']);
+        $instance->setArguments($arguments);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $result = $instance->render();
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array(array('arguments' => NULL, 'content' => 'alt', 'alternative' => 'alternative'), 'alt'),
-			array(array('arguments' => NULL, 'content' => '1', 'alternative' => 'alternative'), '1'),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getRenderTestValues()
+    {
+        return [
+            [['arguments' => null, 'content' => 'alt', 'alternative' => 'alternative'], 'alt'],
+            [['arguments' => null, 'content' => '1', 'alternative' => 'alternative'], '1'],
+        ];
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getRenderAlternativeTestValues
-	 * @param array $arguments
-	 * @param mixed $expected
-	 */
-	public function testRenderAlternative($arguments, $expected) {
-		$instance = $this->getMock(OrViewHelper::class, array('renderChildren'));
-		$instance->expects($this->once())->method('renderChildren')->willReturn(NULL);
-		$arguments['content'] = NULL;
-		$instance->setArguments($arguments);
-		$instance->setRenderingContext(new RenderingContextFixture());
-		$result = $instance->render();
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @test
+     * @dataProvider getRenderAlternativeTestValues
+     * @param array $arguments
+     * @param mixed $expected
+     */
+    public function testRenderAlternative($arguments, $expected)
+    {
+        $instance = $this->getMock(OrViewHelper::class, ['renderChildren']);
+        $instance->expects($this->once())->method('renderChildren')->willReturn(null);
+        $arguments['content'] = null;
+        $instance->setArguments($arguments);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $result = $instance->render();
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderAlternativeTestValues() {
-		return array(
-			array(array('arguments' => NULL, 'alternative' => 'alternative'), 'alternative'),
-			array(array('arguments' => array('abc'), 'alternative' => 'alternative %s alt'), 'alternative abc alt'),
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getRenderAlternativeTestValues()
+    {
+        return [
+            [['arguments' => null, 'alternative' => 'alternative'], 'alternative'],
+            [['arguments' => ['abc'], 'alternative' => 'alternative %s alt'], 'alternative abc alt'],
+        ];
+    }
 }

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -15,183 +15,192 @@ use TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper;
 /**
  * Testcase for RenderViewHelper
  */
-class RenderViewHelperTest extends ViewHelperBaseTestcase {
+class RenderViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var RenderViewHelper
-	 */
-	protected $subject;
+    /**
+     * @var RenderViewHelper
+     */
+    protected $subject;
 
-	/**
-	 * @var TemplateView
-	 */
-	protected $view;
+    /**
+     * @var TemplateView
+     */
+    protected $view;
 
-	/**
-	 * @return void
-	 */
-	public function setUp() {
-		parent::setUp();
-		$this->subject = $this->getMock(RenderViewHelper::class, array('renderChildren'));
-		$this->view = $this->getMock(TemplateView::class, array('renderPartial', 'renderSection'));
-		$this->view->setRenderingContext($this->renderingContext);
-		$container = new ViewHelperVariableContainer();
-		$container->setView($this->view);
-		$this->renderingContext->setViewHelperVariableContainer($container);
-		$this->subject->setRenderingContext($this->renderingContext);
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->subject = $this->getMock(RenderViewHelper::class, ['renderChildren']);
+        $this->view = $this->getMock(TemplateView::class, ['renderPartial', 'renderSection']);
+        $this->view->setRenderingContext($this->renderingContext);
+        $container = new ViewHelperVariableContainer();
+        $container->setView($this->view);
+        $this->renderingContext->setViewHelperVariableContainer($container);
+        $this->subject->setRenderingContext($this->renderingContext);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testInitializeArgumentsRegistersExpectedArguments() {
-		$instance = $this->getMock(RenderViewHelper::class, array('registerArgument'));
-		$instance->expects($this->at(0))->method('registerArgument')->with('section', 'string', $this->anything());
-		$instance->expects($this->at(1))->method('registerArgument')->with('partial', 'string', $this->anything());
-		$instance->expects($this->at(2))->method('registerArgument')->with('delegate', 'string', $this->anything());
-		$instance->expects($this->at(3))->method('registerArgument')->with('arguments', 'array', $this->anything(), FALSE, array());
-		$instance->expects($this->at(4))->method('registerArgument')->with('optional', 'boolean', $this->anything(), FALSE, FALSE);
-		$instance->expects($this->at(5))->method('registerArgument')->with('default', 'mixed', $this->anything());
-		$instance->expects($this->at(6))->method('registerArgument')->with('contentAs', 'string', $this->anything());
-		$instance->initializeArguments();
-	}
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $instance = $this->getMock(RenderViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with('section', 'string', $this->anything());
+        $instance->expects($this->at(1))->method('registerArgument')->with('partial', 'string', $this->anything());
+        $instance->expects($this->at(2))->method('registerArgument')->with('delegate', 'string', $this->anything());
+        $instance->expects($this->at(3))->method('registerArgument')->with('arguments', 'array', $this->anything(), false, []);
+        $instance->expects($this->at(4))->method('registerArgument')->with('optional', 'boolean', $this->anything(), false, false);
+        $instance->expects($this->at(5))->method('registerArgument')->with('default', 'mixed', $this->anything());
+        $instance->expects($this->at(6))->method('registerArgument')->with('contentAs', 'string', $this->anything());
+        $instance->initializeArguments();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testThrowsInvalidArgumentExceptionWhenNoTargetSpecifiedIfOptionalIsFalse() {
-		$this->subject->expects($this->any())->method('renderChildren')->willReturn(NULL);
-		$this->subject->setArguments(array(
-			'partial' => NULL,
-			'section' => NULL,
-			'delegate' => NULL,
-			'arguments' => array(),
-			'optional' => FALSE,
-			'default' => NULL,
-			'contentAs' => NULL
-		));
-		$this->setExpectedException(\InvalidArgumentException::class);
-		$this->subject->render();
-	}
+    /**
+     * @test
+     */
+    public function testThrowsInvalidArgumentExceptionWhenNoTargetSpecifiedIfOptionalIsFalse()
+    {
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
+        $this->subject->setArguments([
+            'partial' => null,
+            'section' => null,
+            'delegate' => null,
+            'arguments' => [],
+            'optional' => false,
+            'default' => null,
+            'contentAs' => null
+        ]);
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->subject->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testThrowsInvalidArgumentExceptionOnInvalidDelegateType() {
-		$this->subject->expects($this->any())->method('renderChildren')->willReturn(NULL);
-		$this->subject->setArguments(array(
-			'partial' => NULL,
-			'section' => NULL,
-			'delegate' => RenderingContextFixture::class,
-			'arguments' => array(),
-			'optional' => FALSE,
-			'default' => NULL,
-			'contentAs' => NULL
-		));
-		$this->setExpectedException(\InvalidArgumentException::class);
-		$this->subject->render();
-	}
+    /**
+     * @test
+     */
+    public function testThrowsInvalidArgumentExceptionOnInvalidDelegateType()
+    {
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
+        $this->subject->setArguments([
+            'partial' => null,
+            'section' => null,
+            'delegate' => RenderingContextFixture::class,
+            'arguments' => [],
+            'optional' => false,
+            'default' => null,
+            'contentAs' => null
+        ]);
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->subject->render();
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderWithDelegate() {
-		$this->subject->expects($this->any())->method('renderChildren')->willReturn(NULL);
-		$this->subject->setArguments(array(
-			'partial' => NULL,
-			'section' => NULL,
-			'delegate' => ParsedTemplateImplementationFixture::class,
-			'arguments' => array(),
-			'optional' => FALSE,
-			'default' => NULL,
-			'contentAs' => NULL
-		));
-		$result = $this->subject->render();
-		$this->assertEquals('rendered by fixture', $result);
-	}
+    /**
+     * @test
+     */
+    public function testRenderWithDelegate()
+    {
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
+        $this->subject->setArguments([
+            'partial' => null,
+            'section' => null,
+            'delegate' => ParsedTemplateImplementationFixture::class,
+            'arguments' => [],
+            'optional' => false,
+            'default' => null,
+            'contentAs' => null
+        ]);
+        $result = $this->subject->render();
+        $this->assertEquals('rendered by fixture', $result);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider getRenderTestValues
-	 * @param array $arguments
-	 * @param string|NULL $expectedViewMethod
-	 */
-	public function testRender(array $arguments, $expectedViewMethod) {
-		if ($expectedViewMethod !== NULL) {
-			$this->view->expects($this->once())->method($expectedViewMethod)->willReturn('');
-		}
-		$this->subject->expects($this->any())->method('renderChildren')->willReturn(NULL);
-		$this->subject->setArguments($arguments);
-		$this->subject->render();
-	}
+    /**
+     * @test
+     * @dataProvider getRenderTestValues
+     * @param array $arguments
+     * @param string|NULL $expectedViewMethod
+     */
+    public function testRender(array $arguments, $expectedViewMethod)
+    {
+        if ($expectedViewMethod !== null) {
+            $this->view->expects($this->once())->method($expectedViewMethod)->willReturn('');
+        }
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
+        $this->subject->setArguments($arguments);
+        $this->subject->render();
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array(
-				array('partial' => NULL, 'section' => 'foo-section', 'delegate' => NULL, 'arguments' => array(), 'optional' => FALSE, 'default' => NULL, 'contentAs' => NULL),
-				NULL
-			),
-			array(
-				array('partial' => 'foo-partial', 'section' => NULL, 'delegate' => NULL, 'arguments' => array(), 'optional' => FALSE, 'default' => NULL, 'contentAs' => NULL),
-				'renderPartial'
-			),
-			array(
-				array('partial' => 'foo-partial', 'section' => 'foo-section', 'delegate' => NULL, 'arguments' => array(), 'optional' => FALSE, 'default' => NULL, 'contentAs' => NULL),
-				'renderPartial'
-			),
-			array(
-				array('partial' => NULL, 'section' => 'foo-section', 'delegate' => NULL, 'arguments' => array(), 'optional' => FALSE, 'default' => NULL, 'contentAs' => NULL),
-				'renderSection'
-			),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getRenderTestValues()
+    {
+        return [
+            [
+                ['partial' => null, 'section' => 'foo-section', 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                null
+            ],
+            [
+                ['partial' => 'foo-partial', 'section' => null, 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                'renderPartial'
+            ],
+            [
+                ['partial' => 'foo-partial', 'section' => 'foo-section', 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                'renderPartial'
+            ],
+            [
+                ['partial' => null, 'section' => 'foo-section', 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                'renderSection'
+            ],
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderWithDefautReturnsDefaultIfContentEmpty() {
-		$this->view->expects($this->once())->method('renderPartial')->willReturn('');
-		$this->subject->expects($this->any())->method('renderChildren')->willReturn(NULL);
-		$this->subject->setArguments(
-			array(
-				'partial' => 'test',
-				'section' => NULL,
-				'delegate' => NULL,
-				'arguments' => array(),
-				'optional' => TRUE,
-				'default' => 'default-foobar',
-				'contentAs' => NULL
-			)
-		);
-		$output = $this->subject->render();
-		$this->assertEquals('default-foobar', $output);
-	}
+    /**
+     * @test
+     */
+    public function testRenderWithDefautReturnsDefaultIfContentEmpty()
+    {
+        $this->view->expects($this->once())->method('renderPartial')->willReturn('');
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
+        $this->subject->setArguments(
+            [
+                'partial' => 'test',
+                'section' => null,
+                'delegate' => null,
+                'arguments' => [],
+                'optional' => true,
+                'default' => 'default-foobar',
+                'contentAs' => null
+            ]
+        );
+        $output = $this->subject->render();
+        $this->assertEquals('default-foobar', $output);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testRenderSupportsContentAs() {
-		$variables = array('foo' => 'bar', 'foobar' => 'tagcontent-foobar');
-		$this->view->expects($this->once())->method('renderPartial')->with('test1', 'test2', $variables, TRUE)->willReturn('baz');
-		$this->subject->expects($this->any())->method('renderChildren')->willReturn('tagcontent-foobar');
-		$this->subject->setArguments(
-			array(
-				'partial' => 'test1',
-				'section' => 'test2',
-				'delegate' => NULL,
-				'arguments' => array(
-					'foo' => 'bar'
-				),
-				'optional' => TRUE,
-				'default' => NULL,
-				'contentAs' => 'foobar'
-			)
-		);
-		$output = $this->subject->render();
-		$this->assertEquals('baz', $output);
-	}
-
+    /**
+     * @test
+     */
+    public function testRenderSupportsContentAs()
+    {
+        $variables = ['foo' => 'bar', 'foobar' => 'tagcontent-foobar'];
+        $this->view->expects($this->once())->method('renderPartial')->with('test1', 'test2', $variables, true)->willReturn('baz');
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn('tagcontent-foobar');
+        $this->subject->setArguments(
+            [
+                'partial' => 'test1',
+                'section' => 'test2',
+                'delegate' => null,
+                'arguments' => [
+                    'foo' => 'bar'
+                ],
+                'optional' => true,
+                'default' => null,
+                'contentAs' => 'foobar'
+            ]
+        );
+        $output = $this->subject->render();
+        $this->assertEquals('baz', $output);
+    }
 }

--- a/tests/Unit/ViewHelpers/SectionViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SectionViewHelperTest.php
@@ -18,37 +18,39 @@ use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
  * Testcase for SectionViewHelper
  *
  */
-class SectionViewHelperTest extends UnitTestCase {
+class SectionViewHelperTest extends UnitTestCase
+{
 
-	/**
-	 * @test
-	 */
-	public function sectionIsAddedToParseVariableContainer() {
-		$section = new SectionViewHelper();
+    /**
+     * @test
+     */
+    public function sectionIsAddedToParseVariableContainer()
+    {
+        $section = new SectionViewHelper();
 
-		$viewHelperNodeMock = $this->getMock(ViewHelperNode::class, array(), array(), '', FALSE);
-		$viewHelperArguments = array(
-			'name' => new TextNode('sectionName')
-		);
+        $viewHelperNodeMock = $this->getMock(ViewHelperNode::class, [], [], '', false);
+        $viewHelperArguments = [
+            'name' => new TextNode('sectionName')
+        ];
 
-		$variableContainer = new StandardVariableProvider();
+        $variableContainer = new StandardVariableProvider();
 
-		$section->postParseEvent($viewHelperNodeMock, $viewHelperArguments, $variableContainer);
+        $section->postParseEvent($viewHelperNodeMock, $viewHelperArguments, $variableContainer);
 
-		$this->assertTrue($variableContainer->exists('1457379500_sections'), 'Sections array was not created, albeit it should.');
-		$sections = $variableContainer->get('1457379500_sections');
-		$this->assertEquals($sections['sectionName'], $viewHelperNodeMock, 'ViewHelperNode for section was not stored.');
-	}
+        $this->assertTrue($variableContainer->exists('1457379500_sections'), 'Sections array was not created, albeit it should.');
+        $sections = $variableContainer->get('1457379500_sections');
+        $this->assertEquals($sections['sectionName'], $viewHelperNodeMock, 'ViewHelperNode for section was not stored.');
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCompileReturnsEmptyString() {
-		$section = new SectionViewHelper();
-		$init = '';
-		$viewHelperNodeMock = $this->getMock(ViewHelperNode::class, array(), array(), '', FALSE);
-		$result = $section->compile('fake', 'fake', $init, $viewHelperNodeMock, new TemplateCompiler());
-		$this->assertEquals('\'\'', $result);
-	}
-
+    /**
+     * @test
+     */
+    public function testCompileReturnsEmptyString()
+    {
+        $section = new SectionViewHelper();
+        $init = '';
+        $viewHelperNodeMock = $this->getMock(ViewHelperNode::class, [], [], '', false);
+        $result = $section->compile('fake', 'fake', $init, $viewHelperNodeMock, new TemplateCompiler());
+        $this->assertEquals('\'\'', $result);
+    }
 }

--- a/tests/Unit/ViewHelpers/SpacelessViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SpacelessViewHelperTest.php
@@ -12,42 +12,49 @@ use TYPO3Fluid\Fluid\ViewHelpers\SpacelessViewHelper;
 /**
  * Testcase for SpacelessViewHelper
  */
-class SpacelessViewHelperTest extends ViewHelperBaseTestcase {
+class SpacelessViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @param string $input
-	 * @param string $expected
-	 * @dataProvider getRenderStaticData
-	 * @test
-	 */
-	public function testRender($input, $expected) {
-		$instance = new SpacelessViewHelper();
-		$instance->setRenderChildrenClosure(function() use ($input) { return $input; });
-		$instance->setRenderingContext($this->getMock(RenderingContextInterface::class));
-		$instance->setArguments(array());
-		$this->assertEquals($expected, $instance->render());
-	}
+    /**
+     * @param string $input
+     * @param string $expected
+     * @dataProvider getRenderStaticData
+     * @test
+     */
+    public function testRender($input, $expected)
+    {
+        $instance = new SpacelessViewHelper();
+        $instance->setRenderChildrenClosure(function () use ($input) {
+            return $input;
+        });
+        $instance->setRenderingContext($this->getMock(RenderingContextInterface::class));
+        $instance->setArguments([]);
+        $this->assertEquals($expected, $instance->render());
+    }
 
-	/**
-	 * @param string $input
-	 * @param string $expected
-	 * @dataProvider getRenderStaticData
-	 * @test
-	 */
-	public function testRenderStatic($input, $expected) {
-		$context = $this->getMock(RenderingContextInterface::class);
-		$this->assertEquals($expected, SpacelessViewHelper::renderStatic(array(), function() use ($input) { return $input; }, $context));
-	}
+    /**
+     * @param string $input
+     * @param string $expected
+     * @dataProvider getRenderStaticData
+     * @test
+     */
+    public function testRenderStatic($input, $expected)
+    {
+        $context = $this->getMock(RenderingContextInterface::class);
+        $this->assertEquals($expected, SpacelessViewHelper::renderStatic([], function () use ($input) {
+            return $input;
+        }, $context));
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRenderStaticData() {
-		return array(
-			'extra whitespace between tags' => array('<div>foo</div>  <div>bar</div>', '<div>foo</div><div>bar</div>'),
-			'whitespace preserved in text node' => array(PHP_EOL . '<div>' . PHP_EOL . 'foo</div>', '<div>' . PHP_EOL . 'foo</div>'),
-			'whitespace removed from non-text node' => array(PHP_EOL . '<div>' . PHP_EOL . '<div>foo</div></div>', '<div><div>foo</div></div>')
-		);
-	}
-
+    /**
+     * @return array
+     */
+    public function getRenderStaticData()
+    {
+        return [
+            'extra whitespace between tags' => ['<div>foo</div>  <div>bar</div>', '<div>foo</div><div>bar</div>'],
+            'whitespace preserved in text node' => [PHP_EOL . '<div>' . PHP_EOL . 'foo</div>', '<div>' . PHP_EOL . 'foo</div>'],
+            'whitespace removed from non-text node' => [PHP_EOL . '<div>' . PHP_EOL . '<div>foo</div></div>', '<div><div>foo</div></div>']
+        ];
+    }
 }

--- a/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
@@ -21,172 +21,183 @@ use TYPO3Fluid\Fluid\ViewHelpers\SwitchViewHelper;
 /**
  * Testcase for SwitchViewHelper
  */
-class SwitchViewHelperTest extends ViewHelperBaseTestcase {
+class SwitchViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @var SwitchViewHelper
-	 */
-	protected $viewHelper;
+    /**
+     * @var SwitchViewHelper
+     */
+    protected $viewHelper;
 
-	public function setUp() {
-		parent::setUp();
-		$this->viewHelper = $this->getMock(SwitchViewHelper::class, array('renderChildren'));
-		$this->injectDependenciesIntoViewHelper($this->viewHelper);
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        $this->viewHelper = $this->getMock(SwitchViewHelper::class, ['renderChildren']);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderSetsSwitchExpressionInViewHelperVariableContainer() {
-		$switchExpression = new \stdClass();
-		$this->viewHelper->setArguments(array('expression' => $switchExpression));
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+    /**
+     * @test
+     */
+    public function renderSetsSwitchExpressionInViewHelperVariableContainer()
+    {
+        $switchExpression = new \stdClass();
+        $this->viewHelper->setArguments(['expression' => $switchExpression]);
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @test
-	 */
-	public function renderRemovesSwitchExpressionFromViewHelperVariableContainerAfterInvocation() {
-		$this->viewHelper->setArguments(array('expression' => 'switchExpression'));
-		$this->viewHelper->initializeArgumentsAndRender();
-	}
+    /**
+     * @test
+     */
+    public function renderRemovesSwitchExpressionFromViewHelperVariableContainerAfterInvocation()
+    {
+        $this->viewHelper->setArguments(['expression' => 'switchExpression']);
+        $this->viewHelper->initializeArgumentsAndRender();
+    }
 
-	/**
-	 * @param NodeInterface[] $childNodes
-	 * @param array $variables
-	 * @param mixed $expected
-	 * @test
-	 * @dataProvider getRetrieveContentFromChildNodesTestValues
-	 */
-	public function retrieveContentFromChildNodesProcessesChildNodesCorrectly(array $childNodes, array $variables, $expected) {
-		$instance = $this->getAccessibleMock(SwitchViewHelper::class, array('dummy'));
-		$context = new RenderingContextFixture();
-		$context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', FALSE);
-		foreach ($variables as $name => $value) {
-			$context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, $name, $value);
-		}
-		$instance->_set('viewHelperVariableContainer', $context->getViewHelperVariableContainer());
-		$instance->_set('renderingContext', $context);
-		$method = new \ReflectionMethod(SwitchViewHelper::class, 'retrieveContentFromChildNodes');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($instance, array($childNodes));
-		$this->assertEquals($expected, $result);
-	}
+    /**
+     * @param NodeInterface[] $childNodes
+     * @param array $variables
+     * @param mixed $expected
+     * @test
+     * @dataProvider getRetrieveContentFromChildNodesTestValues
+     */
+    public function retrieveContentFromChildNodesProcessesChildNodesCorrectly(array $childNodes, array $variables, $expected)
+    {
+        $instance = $this->getAccessibleMock(SwitchViewHelper::class, ['dummy']);
+        $context = new RenderingContextFixture();
+        $context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', false);
+        foreach ($variables as $name => $value) {
+            $context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, $name, $value);
+        }
+        $instance->_set('viewHelperVariableContainer', $context->getViewHelperVariableContainer());
+        $instance->_set('renderingContext', $context);
+        $method = new \ReflectionMethod(SwitchViewHelper::class, 'retrieveContentFromChildNodes');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($instance, [$childNodes]);
+        $this->assertEquals($expected, $result);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRetrieveContentFromChildNodesTestValues() {
-		$matchingNode = $this->getMock(ViewHelperNode::class, array('evaluate', 'getViewHelperClassName'), array(), '', FALSE);
-		$matchingNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
-		$matchingNode->method('evaluate')->willReturn('foo');
-		$notMatchingNode = $this->getMock(ViewHelperNode::class, array('evaluate', 'getViewHelperClassName'), array(), '', FALSE);
-		$notMatchingNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
-		$notMatchingNode->method('evaluate')->willReturn('');
-		$notMatchingNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
-		$defaultCaseNode = $this->getMock(ViewHelperNode::class, array('evaluate', 'getViewHelperClassName'), array(), '', FALSE);
-		$defaultCaseNode->method('evaluate')->willReturn('default');
-		$defaultCaseNode->method('getViewHelperClassName')->willReturn(DefaultCaseViewHelper::class);
-		$textNode = $this->getMock(TextNode::class, array(), array(), '', FALSE);
-		$objectAccessorNode = $this->getMock(ObjectAccessorNode::class, array(), array(), '', FALSE);
-		return array(
-			'empty switch' => array(array(), array('switchExpression' => FALSE), NULL),
-			'single case matching' => array(array(clone $matchingNode), array('switchExpression' => 'foo'), 'foo'),
-			'two case without break' => array(array(clone $matchingNode, clone $notMatchingNode), array('switchExpression' => 'foo'), ''),
-			'single case not matching with default last' => array(array(clone $matchingNode, clone $defaultCaseNode), array('switchExpression' => 'bar'), 'default'),
-			'skips non-ViewHelper nodes' => array(array($textNode, $objectAccessorNode, clone $matchingNode), array('switchExpression' => 'foo'), 'foo')
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getRetrieveContentFromChildNodesTestValues()
+    {
+        $matchingNode = $this->getMock(ViewHelperNode::class, ['evaluate', 'getViewHelperClassName'], [], '', false);
+        $matchingNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
+        $matchingNode->method('evaluate')->willReturn('foo');
+        $notMatchingNode = $this->getMock(ViewHelperNode::class, ['evaluate', 'getViewHelperClassName'], [], '', false);
+        $notMatchingNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
+        $notMatchingNode->method('evaluate')->willReturn('');
+        $notMatchingNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
+        $defaultCaseNode = $this->getMock(ViewHelperNode::class, ['evaluate', 'getViewHelperClassName'], [], '', false);
+        $defaultCaseNode->method('evaluate')->willReturn('default');
+        $defaultCaseNode->method('getViewHelperClassName')->willReturn(DefaultCaseViewHelper::class);
+        $textNode = $this->getMock(TextNode::class, [], [], '', false);
+        $objectAccessorNode = $this->getMock(ObjectAccessorNode::class, [], [], '', false);
+        return [
+            'empty switch' => [[], ['switchExpression' => false], null],
+            'single case matching' => [[clone $matchingNode], ['switchExpression' => 'foo'], 'foo'],
+            'two case without break' => [[clone $matchingNode, clone $notMatchingNode], ['switchExpression' => 'foo'], ''],
+            'single case not matching with default last' => [[clone $matchingNode, clone $defaultCaseNode], ['switchExpression' => 'bar'], 'default'],
+            'skips non-ViewHelper nodes' => [[$textNode, $objectAccessorNode, clone $matchingNode], ['switchExpression' => 'foo'], 'foo']
+        ];
+    }
 
-	/**
-	 * @test
-	 */
-	public function retrieveContentFromChildNodesReturnsBreaksOnBreak() {
-		$instance = $this->getAccessibleMock(SwitchViewHelper::class, array('dummy'));
-		$context = new RenderingContextFixture();
-		$context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'switchExpression', 'foo');
-		$context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', FALSE);
-		$instance->_set('viewHelperVariableContainer', $context->getViewHelperVariableContainer());
-		$instance->_set('renderingContext', $context);
-		$matchingCaseViewHelper = new CaseViewHelper();
-		$matchingCaseViewHelper->setRenderChildrenClosure(function() { return 'foo-childcontent'; });
-		$breakingMatchingCaseNode = $this->getAccessibleMock(ViewHelperNode::class, array('getViewHelperClassName', 'getUninitializedViewHelper'), array(), '', FALSE);
-		$breakingMatchingCaseNode->_set('arguments', array('value' => 'foo'));
-		$breakingMatchingCaseNode->_set('uninitializedViewHelper', $matchingCaseViewHelper);
-		$breakingMatchingCaseNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
-		$defaultCaseNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', FALSE);
-		$defaultCaseNode->method('getViewHelperClassName')->willReturn(DefaultCaseViewHelper::class);
-		$defaultCaseNode->expects($this->never())->method('evaluate');
+    /**
+     * @test
+     */
+    public function retrieveContentFromChildNodesReturnsBreaksOnBreak()
+    {
+        $instance = $this->getAccessibleMock(SwitchViewHelper::class, ['dummy']);
+        $context = new RenderingContextFixture();
+        $context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'switchExpression', 'foo');
+        $context->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'break', false);
+        $instance->_set('viewHelperVariableContainer', $context->getViewHelperVariableContainer());
+        $instance->_set('renderingContext', $context);
+        $matchingCaseViewHelper = new CaseViewHelper();
+        $matchingCaseViewHelper->setRenderChildrenClosure(function () {
+            return 'foo-childcontent';
+        });
+        $breakingMatchingCaseNode = $this->getAccessibleMock(ViewHelperNode::class, ['getViewHelperClassName', 'getUninitializedViewHelper'], [], '', false);
+        $breakingMatchingCaseNode->_set('arguments', ['value' => 'foo']);
+        $breakingMatchingCaseNode->_set('uninitializedViewHelper', $matchingCaseViewHelper);
+        $breakingMatchingCaseNode->method('getViewHelperClassName')->willReturn(CaseViewHelper::class);
+        $defaultCaseNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate'], [], '', false);
+        $defaultCaseNode->method('getViewHelperClassName')->willReturn(DefaultCaseViewHelper::class);
+        $defaultCaseNode->expects($this->never())->method('evaluate');
 
-		$method = new \ReflectionMethod(SwitchViewHelper::class, 'retrieveContentFromChildNodes');
-		$method->setAccessible(TRUE);
-		$result = $method->invokeArgs($instance, array(array($breakingMatchingCaseNode, $defaultCaseNode)));
-		$this->assertEquals('foo-childcontent', $result);
-	}
+        $method = new \ReflectionMethod(SwitchViewHelper::class, 'retrieveContentFromChildNodes');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($instance, [[$breakingMatchingCaseNode, $defaultCaseNode]]);
+        $this->assertEquals('foo-childcontent', $result);
+    }
 
-	/**
-	 * @param ViewHelperNode $node
-	 * @param string $expectedCode
-	 * @param string $expectedInitialization
-	 * @test
-	 * @dataProvider getCompileTestValues
-	 */
-	public function compileGeneratesExpectedPhpCode(ViewHelperNode $node, $expectedCode, $expectedInitialization) {
-		$viewHelper = new SwitchViewHelper();
-		$compiler = new TemplateCompiler();
-		$code = $viewHelper->compile('$arguments', 'closure', $initializationCode, $node, $compiler);
-		$this->assertEquals($expectedCode, $code);
-		$this->assertEquals($expectedInitialization, $initializationCode);
-	}
+    /**
+     * @param ViewHelperNode $node
+     * @param string $expectedCode
+     * @param string $expectedInitialization
+     * @test
+     * @dataProvider getCompileTestValues
+     */
+    public function compileGeneratesExpectedPhpCode(ViewHelperNode $node, $expectedCode, $expectedInitialization)
+    {
+        $viewHelper = new SwitchViewHelper();
+        $compiler = new TemplateCompiler();
+        $code = $viewHelper->compile('$arguments', 'closure', $initializationCode, $node, $compiler);
+        $this->assertEquals($expectedCode, $code);
+        $this->assertEquals($expectedInitialization, $initializationCode);
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getCompileTestValues() {
-		$renderingContext = new RenderingContext($this->getMock(TemplateView::class), array('dummy'), array(), '', FALSE);
-		$parsingState = new ParsingState();
-		$emptySwitchNode = new ViewHelperNode(
-			$renderingContext,
-			'f',
-			'switch',
-			array('expression' => new TextNode('test-expression')),
-			$parsingState
-		);
-		$withDefaultCaseOnly = clone $emptySwitchNode;
-		$withDefaultCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'defaultCase', array(), $parsingState));
-		$withSingleCaseOnly = clone $emptySwitchNode;
-		$withSingleCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'case', array('value' => 'foo'), $parsingState));
-		return array(
-			'Empty switch statement' => array(
-				$emptySwitchNode,
-				'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
-				'switch ($arguments[\'expression\']) {' .
-				PHP_EOL . '}' . PHP_EOL .
-				'}, array($arguments))',
-				''
-			),
-			'With default case only' => array(
-				$withDefaultCaseOnly,
-				'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
-				'switch ($arguments[\'expression\']) {' . PHP_EOL .
-				'default: return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
-				'return NULL;' . PHP_EOL .
-				'});' . PHP_EOL .
-				'}' . PHP_EOL . '}, array($arguments))',
-				''
-			),
-			'With single case only' => array(
-				$withSingleCaseOnly,
-				'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
-				'switch ($arguments[\'expression\']) {' . PHP_EOL .
-				'case call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
-				'$argument = unserialize(\'s:3:"foo";\'); return $argument->evaluate($renderingContext);' . PHP_EOL .
-				'}): return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
-				'return NULL;' . PHP_EOL .
-				'});' . PHP_EOL .
-				'}' . PHP_EOL . '}, array($arguments))',
-				''
-			),
-		);
-	}
+    /**
+     * @return array
+     */
+    public function getCompileTestValues()
+    {
+        $renderingContext = new RenderingContext($this->getMock(TemplateView::class), ['dummy'], [], '', false);
+        $parsingState = new ParsingState();
+        $emptySwitchNode = new ViewHelperNode(
+            $renderingContext,
+            'f',
+            'switch',
+            ['expression' => new TextNode('test-expression')],
+            $parsingState
+        );
+        $withDefaultCaseOnly = clone $emptySwitchNode;
+        $withDefaultCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'defaultCase', [], $parsingState));
+        $withSingleCaseOnly = clone $emptySwitchNode;
+        $withSingleCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'case', ['value' => 'foo'], $parsingState));
+        return [
+            'Empty switch statement' => [
+                $emptySwitchNode,
+                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+                'switch ($arguments[\'expression\']) {' .
+                PHP_EOL . '}' . PHP_EOL .
+                '}, array($arguments))',
+                ''
+            ],
+            'With default case only' => [
+                $withDefaultCaseOnly,
+                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+                'switch ($arguments[\'expression\']) {' . PHP_EOL .
+                'default: return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
+                'return NULL;' . PHP_EOL .
+                '});' . PHP_EOL .
+                '}' . PHP_EOL . '}, array($arguments))',
+                ''
+            ],
+            'With single case only' => [
+                $withSingleCaseOnly,
+                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+                'switch ($arguments[\'expression\']) {' . PHP_EOL .
+                'case call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
+                '$argument = unserialize(\'s:3:"foo";\'); return $argument->evaluate($renderingContext);' . PHP_EOL .
+                '}): return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
+                'return NULL;' . PHP_EOL .
+                '});' . PHP_EOL .
+                '}' . PHP_EOL . '}, array($arguments))',
+                ''
+            ],
+        ];
+    }
 }

--- a/tests/Unit/ViewHelpers/ThenViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ThenViewHelperTest.php
@@ -12,28 +12,30 @@ use TYPO3Fluid\Fluid\ViewHelpers\ThenViewHelper;
 /**
  * Testcase for ElseViewHelper
  */
-class ThenViewHelperTest extends ViewHelperBaseTestcase {
+class ThenViewHelperTest extends ViewHelperBaseTestcase
+{
 
-	/**
-	 * @test
-	 */
-	public function renderRendersChildren() {
-		$viewHelper = $this->getMock(ThenViewHelper::class, array('renderChildren'));
+    /**
+     * @test
+     */
+    public function renderRendersChildren()
+    {
+        $viewHelper = $this->getMock(ThenViewHelper::class, ['renderChildren']);
 
-		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
-		$actualResult = $viewHelper->render();
-		$this->assertEquals('foo', $actualResult);
-	}
+        $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
+        $actualResult = $viewHelper->render();
+        $this->assertEquals('foo', $actualResult);
+    }
 
-	/**
-	 * @test
-	 */
-	public function testCompileReturnsEmptyString() {
-		$section = new ThenViewHelper();
-		$init = '';
-		$viewHelperNodeMock = $this->getMock(ViewHelperNode::class, array(), array(), '', FALSE);
-		$result = $section->compile('fake', 'fake', $init, $viewHelperNodeMock, new TemplateCompiler());
-		$this->assertEquals('\'\'', $result);
-	}
-
+    /**
+     * @test
+     */
+    public function testCompileReturnsEmptyString()
+    {
+        $section = new ThenViewHelper();
+        $init = '';
+        $viewHelperNodeMock = $this->getMock(ViewHelperNode::class, [], [], '', false);
+        $result = $section->compile('fake', 'fake', $init, $viewHelperNodeMock, new TemplateCompiler());
+        $this->assertEquals('\'\'', $result);
+    }
 }

--- a/tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -19,81 +19,86 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * Base test class for testing view helpers
  */
-abstract class ViewHelperBaseTestcase extends UnitTestCase {
+abstract class ViewHelperBaseTestcase extends UnitTestCase
+{
 
-	/**
-	 * @var ViewHelperVariableContainer
-	 */
-	protected $viewHelperVariableContainer;
+    /**
+     * @var ViewHelperVariableContainer
+     */
+    protected $viewHelperVariableContainer;
 
-	/**
-	 * Mock contents of the $viewHelperVariableContainer in the format:
-	 * array(
-	 *  'Some\ViewHelper\Class' => array('key1' => 'value1', 'key2' => 'value2')
-	 * )
-	 *
-	 * @var array
-	 */
-	protected $viewHelperVariableContainerData = array();
+    /**
+     * Mock contents of the $viewHelperVariableContainer in the format:
+     * array(
+     *  'Some\ViewHelper\Class' => array('key1' => 'value1', 'key2' => 'value2')
+     * )
+     *
+     * @var array
+     */
+    protected $viewHelperVariableContainerData = [];
 
-	/**
-	 * @var TemplateVariableContainer
-	 */
-	protected $templateVariableContainer;
+    /**
+     * @var TemplateVariableContainer
+     */
+    protected $templateVariableContainer;
 
-	/**
-	 * @var TagBuilder
-	 */
-	protected $tagBuilder;
+    /**
+     * @var TagBuilder
+     */
+    protected $tagBuilder;
 
-	/**
-	 * @var array
-	 */
-	protected $arguments = array();
+    /**
+     * @var array
+     */
+    protected $arguments = [];
 
-	/**
-	 * @var RenderingContext
-	 */
-	protected $renderingContext;
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
 
-	/**
-	 * @return void
-	 */
-	public function setUp() {
-		$this->viewHelperVariableContainer = new ViewHelperVariableContainer();
-		$this->templateVariableContainer = new StandardVariableProvider();
-		$this->renderingContext = new RenderingContextFixture();
-		$this->renderingContext->setVariableProvider($this->templateVariableContainer);
-		$this->renderingContext->setViewHelperVariableContainer($this->viewHelperVariableContainer);
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->viewHelperVariableContainer = new ViewHelperVariableContainer();
+        $this->templateVariableContainer = new StandardVariableProvider();
+        $this->renderingContext = new RenderingContextFixture();
+        $this->renderingContext->setVariableProvider($this->templateVariableContainer);
+        $this->renderingContext->setViewHelperVariableContainer($this->viewHelperVariableContainer);
+    }
 
-	/**
-	 * @param string $viewHelperName
-	 * @param string $key
-	 * @return boolean
-	 */
-	public function viewHelperVariableContainerExistsCallback($viewHelperName, $key) {
-		return isset($this->viewHelperVariableContainerData[$viewHelperName][$key]);
-	}
+    /**
+     * @param string $viewHelperName
+     * @param string $key
+     * @return boolean
+     */
+    public function viewHelperVariableContainerExistsCallback($viewHelperName, $key)
+    {
+        return isset($this->viewHelperVariableContainerData[$viewHelperName][$key]);
+    }
 
-	/**
-	 * @param string $viewHelperName
-	 * @param string $key
-	 * @return boolean
-	 */
-	public function viewHelperVariableContainerGetCallback($viewHelperName, $key) {
-		return $this->viewHelperVariableContainerData[$viewHelperName][$key];
-	}
+    /**
+     * @param string $viewHelperName
+     * @param string $key
+     * @return boolean
+     */
+    public function viewHelperVariableContainerGetCallback($viewHelperName, $key)
+    {
+        return $this->viewHelperVariableContainerData[$viewHelperName][$key];
+    }
 
-	/**
-	 * @param AbstractViewHelper $viewHelper
-	 * @return void
-	 */
-	protected function injectDependenciesIntoViewHelper(AbstractViewHelper $viewHelper) {
-		$viewHelper->setRenderingContext($this->renderingContext);
-		$viewHelper->setArguments($this->arguments);
-		if ($viewHelper instanceof AbstractTagBasedViewHelper) {
-			$viewHelper->injectTagBuilder($this->tagBuilder);
-		}
-	}
+    /**
+     * @param AbstractViewHelper $viewHelper
+     * @return void
+     */
+    protected function injectDependenciesIntoViewHelper(AbstractViewHelper $viewHelper)
+    {
+        $viewHelper->setRenderingContext($this->renderingContext);
+        $viewHelper->setArguments($this->arguments);
+        if ($viewHelper instanceof AbstractTagBasedViewHelper) {
+            $viewHelper->injectTagBuilder($this->tagBuilder);
+        }
+    }
 }

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -16,6 +16,7 @@ namespace TYPO3Fluid\Fluid\Tests;
  *
  * @api
  */
-abstract class UnitTestCase extends BaseTestCase {
+abstract class UnitTestCase extends BaseTestCase
+{
 
 }


### PR DESCRIPTION
This converts the code formatting to PSR-2 and
switches to shorthand array syntax. The phpcs and
phpcbf tools are included as dev dependencies and
validation/fixing can be run with `--standard=PSR2`.